### PR TITLE
fix(accounts): changed account sorting by name and type

### DIFF
--- a/apps/app-frontend/src/components/ui/AccountsCard.vue
+++ b/apps/app-frontend/src/components/ui/AccountsCard.vue
@@ -387,6 +387,7 @@ function createSkinHeadDataUrl(textureUrl: string) {
 const defaultSteveHeadUrl = createSkinHeadDataUrl(steveSkinTexture)
 
 async function refreshValues() {
+	const targetUser = defaultUser.value
 	defaultUser.value = await get_default_user(offline.value).catch(handleError)
 	if (offline.value && defaultUser.value) {
 		await set_default_user(defaultUser.value).catch(handleError)
@@ -405,6 +406,7 @@ async function refreshValues() {
 	await renderYggdrasilAccountHeads(accounts.value)
 	try {
 		const skins = await get_available_skins()
+		if (defaultUser.value !== targetUser) return
 		equippedSkin.value = skins.find((skin) => skin.is_equipped) ?? null
 
 		if (equippedSkin.value) {

--- a/apps/app-frontend/src/components/ui/AccountsCard.vue
+++ b/apps/app-frontend/src/components/ui/AccountsCard.vue
@@ -393,15 +393,22 @@ async function refreshValues() {
 		await set_default_user(defaultUser.value).catch(handleError)
 	}
 	const userList = await users(offline.value).catch(handleError)
-	accounts.value = Array.isArray(userList) ? (userList as unknown as MinecraftCredential[]) : []
-	const typeOrder = { microsoft: 0, yggdrasil: 1, offline: 2 }
+	accounts.value = Array.isArray(userList)
+		? [...(userList as unknown as MinecraftCredential[])]
+		: []
+	const typeOrder = {
+		microsoft: 0,
+		yggdrasil: 1,
+		offline: 2,
+	} as const
 	accounts.value.sort((a, b) => {
 		const nameCmp = (a.profile?.name ?? '').localeCompare(b.profile?.name ?? '')
 		if (nameCmp !== 0) return nameCmp
-		const typeCmp =
+
+		return (
 			(typeOrder[a.account_type as keyof typeof typeOrder] ?? 3) -
 			(typeOrder[b.account_type as keyof typeof typeOrder] ?? 3)
-		return typeCmp
+		)
 	})
 	await renderYggdrasilAccountHeads(accounts.value)
 	try {

--- a/apps/app-frontend/src/components/ui/AccountsCard.vue
+++ b/apps/app-frontend/src/components/ui/AccountsCard.vue
@@ -392,8 +392,16 @@ async function refreshValues() {
 		await set_default_user(defaultUser.value).catch(handleError)
 	}
 	const userList = await users(offline.value).catch(handleError)
-	accounts.value = Array.isArray(userList) ? [...userList] : []
-	accounts.value.sort((a, b) => (a.profile?.name ?? '').localeCompare(b.profile?.name ?? ''))
+	accounts.value = Array.isArray(userList) ? (userList as unknown as MinecraftCredential[]) : []
+	const typeOrder = { microsoft: 0, yggdrasil: 1, offline: 2 }
+	accounts.value.sort((a, b) => {
+		const nameCmp = (a.profile?.name ?? '').localeCompare(b.profile?.name ?? '')
+		if (nameCmp !== 0) return nameCmp
+		const typeCmp =
+			(typeOrder[a.account_type as keyof typeof typeOrder] ?? 3) -
+			(typeOrder[b.account_type as keyof typeof typeOrder] ?? 3)
+		return typeCmp
+	})
 	await renderYggdrasilAccountHeads(accounts.value)
 	try {
 		const skins = await get_available_skins()
@@ -535,6 +543,7 @@ function getAccountAvatarUrl(account: MinecraftCredential) {
 
 async function setAccount(account: MinecraftCredential) {
 	defaultUser.value = account.profile.id
+	equippedSkin.value = null
 	await set_default_user(account.profile.id).catch(handleError)
 	await refreshValues()
 	emit('change')


### PR DESCRIPTION
尝试修复#36 和#12

对于#36，现在，当同名账号出现时，它们根据账号类型排序，就像这样
`const typeOrder = { microsoft: 0, yggdrasil: 1, offline: 2 }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account list handling when account/user data is missing or not in the expected format.
  * Updated account ordering to sort by profile name first, then apply an explicit account-type priority (with other types shown last).
  * Switching accounts now clears the previously equipped skin to avoid stale visuals.
  * Prevents outdated skin/head updates when the default user changes during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->