### PR TITLE
Move CN languages to top in Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
 	"prettier.endOfLine": "lf",
+	"prettier.tabWidth": 2,
+	"prettier.useTabs": false,
 	"editor.formatOnSave": true,
 	"eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
 	"editor.detectIndentation": false,

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -10,6 +10,7 @@ import {
 	ThemeSelector,
 	Toggle,
 	useVIntl,
+	StyledInput,
 } from '@modrinth/ui'
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { appDataDir, join } from '@tauri-apps/api/path'
@@ -68,6 +69,19 @@ const messages = defineMessages({
 		id: 'app.appearance-settings.accent-color.purple',
 		defaultMessage: 'Purple',
 	},
+	accentColorCustom: {
+		id: 'app.appearance-settings.accent-color.custom',
+		defaultMessage: 'Custom',
+	},
+	accentColorCustomTitle: {
+		id: 'app.appearance-settings.accent-color.custom.title',
+		defaultMessage: 'Custom Accent Color',
+	},
+	accentColorCustomDescription: {
+		id: 'app.appearance-settings.accent-color.custom.description',
+		defaultMessage: 'Select an accent color',
+	},
+
 	customBackgroundTitle: {
 		id: 'app.appearance-settings.custom-background.title',
 		defaultMessage: 'Launcher background',
@@ -228,6 +242,7 @@ const accentColorOptions: Array<{
 	{ value: 'green', color: 'var(--color-green)', label: messages.accentColorGreen },
 	{ value: 'blue', color: 'var(--color-blue)', label: messages.accentColorBlue },
 	{ value: 'purple', color: 'var(--color-purple)', label: messages.accentColorPurple },
+	{ value: 'custom', color: 'var(--color-custom)', label: messages.accentColorCustom },
 ]
 
 async function chooseCustomBackground() {
@@ -356,6 +371,35 @@ watch(
 					class="ml-auto size-4 shrink-0"
 				/>
 			</button>
+		</div>
+		<div v-if="settings.accent_color === 'custom'" class="mt-6 flex items-center justify-between">
+			<!-- TODO: -->
+			<div>
+				<h2 class="m-0 text-lg font-semibold text-contrast">
+					{{ formatMessage(messages.accentColorCustomTitle) }}
+				</h2>
+				<p class="m-0 mt-1">
+					{{ formatMessage(messages.accentColorCustomDescription) }}
+				</p>
+			</div>
+
+			<StyledInput
+				id="customAccentColor"
+				v-model="settings.custom_accent_color"
+				autocomplete="off"
+				type="color"
+				:placeholder="'#ffffff'"
+			/>
+			<!-- <Toggle
+				id="advanced-rendering"
+				:model-value="themeStore.advancedRendering"
+				@update:model-value="
+					(e) => {
+						themeStore.advancedRendering = !!e
+						settings.advanced_rendering = themeStore.advancedRendering
+					}
+				"
+			/> -->
 		</div>
 	</div>
 

--- a/apps/app-frontend/src/helpers/settings.ts
+++ b/apps/app-frontend/src/helpers/settings.ts
@@ -71,6 +71,7 @@ export type AppSettings = {
 
 	theme: ColorTheme
 	accent_color: AccentColor
+	custom_accent_color: string
 	locale: string
 	default_page: 'Home' | 'DiscoverContent' | 'Library'
 	collapsed_navigation: boolean

--- a/apps/app-frontend/src/locales/.prettierrc
+++ b/apps/app-frontend/src/locales/.prettierrc
@@ -1,0 +1,4 @@
+{
+	"tabWidth": 2,
+	"useTabs": false
+}

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -131,6 +131,15 @@
   "app.appearance-settings.accent-color.blue": {
     "message": "Blue"
   },
+  "app.appearance-settings.accent-color.custom": {
+    "message": "Custom"
+  },
+  "app.appearance-settings.accent-color.custom.title": {
+    "message": "Custom Accent Color"
+  },
+  "app.appearance-settings.accent-color.custom.description": {
+    "message": "Select an accent color"
+  },
   "app.appearance-settings.accent-color.description": {
     "message": "Choose the color used for buttons, selections, and highlights."
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -131,6 +131,15 @@
   "app.appearance-settings.accent-color.blue": {
     "message": "蓝色"
   },
+  "app.appearance-settings.accent-color.custom": {
+    "message": "自定义"
+  },
+  "app.appearance-settings.accent-color.custom.title": {
+    "message": "自定义主题色"
+  },
+  "app.appearance-settings.accent-color.custom.description": {
+    "message": "选择一个主题颜色"
+  },
   "app.appearance-settings.accent-color.description": {
     "message": "选择用于按钮、选中状态和高亮元素的颜色。"
   },

--- a/apps/app-frontend/src/store/theme.ts
+++ b/apps/app-frontend/src/store/theme.ts
@@ -20,7 +20,7 @@ export const DEFAULT_FEATURE_FLAGS = {
 }
 
 export const THEME_OPTIONS = ['dark', 'light', 'oled', 'system'] as const
-export const ACCENT_COLOR_OPTIONS = ['pink', 'orange', 'green', 'blue', 'purple'] as const
+export const ACCENT_COLOR_OPTIONS = ['pink', 'orange', 'green', 'blue', 'purple', 'custom'] as const
 
 export type FeatureFlag = keyof typeof DEFAULT_FEATURE_FLAGS
 export type FeatureFlags = Record<FeatureFlag, boolean>

--- a/packages/app-lib/src/state/settings.rs
+++ b/packages/app-lib/src/state/settings.rs
@@ -75,6 +75,7 @@ pub struct Settings {
 
     pub theme: Theme,
     pub accent_color: AccentColor,
+    pub custom_accent_color: String,
     pub locale: String,
     pub default_page: DefaultPage,
     pub collapsed_navigation: bool,
@@ -182,6 +183,7 @@ impl Settings {
             legacy_use_modrinth_mirror: None,
             legacy_use_curseforge_mirror: None,
             theme: Theme::from_string(&res.theme),
+            custom_accent_color: String::from("#ffffff"),
             accent_color: AccentColor::from_string(&res.accent_color),
             locale: res.locale,
             default_page: DefaultPage::from_string(&res.default_page),
@@ -546,6 +548,7 @@ pub enum AccentColor {
     Green,
     Blue,
     Purple,
+    Custom,
 }
 
 impl AccentColor {
@@ -556,6 +559,7 @@ impl AccentColor {
             AccentColor::Green => "green",
             AccentColor::Blue => "blue",
             AccentColor::Purple => "purple",
+            AccentColor::Custom => "custom",
         }
     }
 
@@ -565,6 +569,7 @@ impl AccentColor {
             "green" => AccentColor::Green,
             "blue" => AccentColor::Blue,
             "purple" => AccentColor::Purple,
+            "custom" => AccentColor::Custom,
             _ => AccentColor::Pink,
         }
     }

--- a/packages/ui/src/composables/i18n.ts
+++ b/packages/ui/src/composables/i18n.ts
@@ -44,6 +44,16 @@ export const LOCALES: LocaleDefinition[] = [
 	// 	dir: 'rtl',
 	// },
 	{
+		code: 'zh-CN',
+		name: '简体中文',
+		translatedName: defineMessage({ id: 'locale.zh-CN', defaultMessage: 'Chinese (Simplified)' }),
+	},
+	{
+		code: 'zh-TW',
+		name: '繁體中文',
+		translatedName: defineMessage({ id: 'locale.zh-TW', defaultMessage: 'Chinese (Traditional)' }),
+	},
+	{
 		code: 'cs-CZ',
 		name: 'Čeština',
 		translatedName: defineMessage({ id: 'locale.cs-CZ', defaultMessage: 'Czech' }),
@@ -203,16 +213,6 @@ export const LOCALES: LocaleDefinition[] = [
 		code: 'vi-VN',
 		name: 'Tiếng Việt',
 		translatedName: defineMessage({ id: 'locale.vi-VN', defaultMessage: 'Vietnamese' }),
-	},
-	{
-		code: 'zh-CN',
-		name: '简体中文',
-		translatedName: defineMessage({ id: 'locale.zh-CN', defaultMessage: 'Chinese (Simplified)' }),
-	},
-	{
-		code: 'zh-TW',
-		name: '繁體中文',
-		translatedName: defineMessage({ id: 'locale.zh-TW', defaultMessage: 'Chinese (Traditional)' }),
 	},
 ]
 


### PR DESCRIPTION
Move CN languages to top in Settings

## Summary by Sourcery

引入可配置的自定义强调色选项，并在语言列表中优先显示中文语言选项。

New Features:
- 添加一个 “custom” 强调色选项，并提供 UI 控件，让用户可以选择并保存自定义强调色值。
- 在 i18n 配置中，将简体中文和繁体中文语言选项移动到可用语言列表的顶部。

Enhancements:
- 扩展设置和主题状态模型，以支持新的自定义强调色值。
- 更新本地化文件和格式配置，以适配新的强调色字符串和语言排序位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable custom accent color option and prioritize Chinese locales in the language list.

New Features:
- Add a "custom" accent color option with UI controls to let users pick and store a custom accent color value.
- Move Simplified and Traditional Chinese locales to the top of the available language list in the i18n configuration.

Enhancements:
- Extend settings and theme state models to support the new custom accent color value.
- Update localization files and formatting configuration for the new accent color strings and locale positioning.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added support for a **custom accent color** option in Appearance settings, including a color picker and localized labels/descriptions.
  * Extended theme accent handling to recognize and apply the custom accent choice.
  * Added storage and serialization for the new custom accent color preference (initialized to `#ffffff` by default).
  * Updated locale text entries for the new custom accent option.  
  * Reordered Chinese locale entries for improved consistency.
* **Chores**
  * Updated formatting configuration (VS Code/Prettier) for consistent style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->