### PR TITLE
fix: disable WebKitGTK DMA-BUF renderer on NVIDIA to prevent segfault

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -113,6 +113,15 @@ async fn set_restart_after_pending_update(
 // if Tauri app is called with arguments, then those arguments will be treated as commands
 // ie: deep links or filepaths for .mrpacks
 fn main() {
+    // Workaround: NVIDIA's proprietary EGL driver crashes WebKitGTK's DMA-BUF renderer
+    #[cfg(target_os = "linux")]
+    if env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err()
+        && std::path::Path::new("/proc/driver/nvidia/version").exists()
+    {
+        // SAFETY: This is called before any threads are spawned in main()
+        unsafe { env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1") }
+    }
+
     /*
         tracing is set basd on the environment variable RUST_LOG=xxx, depending on the amount of logs to show
             ERROR > WARN > INFO > DEBUG > TRACE

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -115,7 +115,7 @@ async fn set_restart_after_pending_update(
 fn main() {
     // Workaround: NVIDIA's proprietary EGL driver crashes WebKitGTK's DMA-BUF renderer
     #[cfg(target_os = "linux")]
-    if env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err()
+    if env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
         && std::path::Path::new("/proc/driver/nvidia/version").exists()
     {
         // SAFETY: This is called before any threads are spawned in main()


### PR DESCRIPTION
WebKitGTK's DMA-BUF renderer crashes with NVIDIA's proprietary EGL driver (libnvidia-eglcore.so), causing SIGSEGV in WebKitWebProcess. This detects NVIDIA drivers via /proc/driver/nvidia/version and sets WEBKIT_DISABLE_DMABUF_RENDERER=1 to use a compatible rendering path. Non-NVIDIA users are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup compatibility on Linux systems using NVIDIA’s proprietary graphics driver.
  * Helps prevent display and rendering issues related to WebKit’s DMA-BUF renderer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->