### PR TITLE
feat(app): 整合包导入支持更多格式（CurseForge/MCBBS/HMCL/MultiMC 等）并新增 OptiFine 支持

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -820,8 +820,9 @@ async function handleCommand(e) {
 	}
 
 	if (e.event === 'RunMRPack') {
-		// RunMRPack should directly install a local mrpack given a path
-		if (e.path.endsWith('.mrpack')) {
+		// RunMRPack should directly install a local modpack file given a path;
+		// non-mrpack archives (CurseForge/MCBBS/HMCL/MultiMC zips) are format-sniffed by the backend
+		if (e.path.endsWith('.mrpack') || e.path.endsWith('.zip')) {
 			const location = { type: 'fromFile', path: e.path }
 			const preview = await install_get_modpack_preview(location).catch(handleError)
 			if (preview?.unknownFile) {

--- a/apps/app-frontend/src/announcements/catalog.ts
+++ b/apps/app-frontend/src/announcements/catalog.ts
@@ -44,6 +44,18 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 			added: [
 				{
 					'en-US':
+						'Modpack imports now detect the archive format by content: CurseForge, MCBBS, HMCL, and MultiMC/Prism export packs, launcher-bundled archives, and zipped game folders can be imported alongside .mrpack files.',
+					'zh-CN':
+						'整合包导入现在按压缩包内容识别格式：除 .mrpack 外，还支持 CurseForge、MCBBS、HMCL、MultiMC/Prism 导出包、附带启动器的整合包以及打包的游戏目录。',
+				},
+				{
+					'en-US':
+						'Added OptiFine support: modpacks declaring OptiFine install it automatically, standalone as the loader or as a mod alongside Forge/NeoForge.',
+					'zh-CN':
+						'新增 OptiFine 支持：声明了 OptiFine 的整合包会自动安装——单独存在时作为加载器，与 Forge/NeoForge 共存时作为模组安装。',
+				},
+				{
+					'en-US':
 						'Added an appearance setting to limit the number of recent instances shown in the sidebar, with 0 showing all instances.',
 					'zh-CN': '新增外观设置，可限制侧边栏显示的最近实例数量，设为 0 时显示全部实例。',
 				},
@@ -72,6 +84,16 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 						'Fixed local modpack installs appearing stuck at 100% and hanging when a Minecraft file download stops receiving data.',
 					'zh-CN':
 						'修复本地整合包安装在 100% 后看似卡住，以及 Minecraft 文件下载停止接收数据时任务无法结束的问题。',
+				},
+				{
+					'en-US':
+						'Fixed the Minecraft download progress overshooting and pegging at 100% early after a download attempt was retried.',
+					'zh-CN': '修复下载重试后 Minecraft 资源下载进度虚高、提前钳制在 100% 的问题。',
+				},
+				{
+					'en-US':
+						'Modpack archives with GB18030 (GBK) encoded Chinese file names now extract correctly.',
+					'zh-CN': '使用 GB18030（GBK）编码中文文件名的整合包压缩包现在可以正确解压。',
 				},
 			],
 		},

--- a/apps/app-frontend/src/helpers/types.d.ts
+++ b/apps/app-frontend/src/helpers/types.d.ts
@@ -99,7 +99,7 @@ export type Instance = GameInstance
 
 type ReleaseChannel = 'release' | 'beta' | 'alpha'
 
-export type InstanceLoader = 'vanilla' | 'forge' | 'fabric' | 'quilt' | 'neoforge'
+export type InstanceLoader = 'vanilla' | 'forge' | 'fabric' | 'quilt' | 'neoforge' | 'optifine'
 
 type ContentFile = {
 	enabled: boolean

--- a/apps/app-frontend/src/providers/setup/file-picker.ts
+++ b/apps/app-frontend/src/providers/setup/file-picker.ts
@@ -68,7 +68,7 @@ export function setupFilePickerProvider() {
 		async pickModpackFile(options) {
 			const result = await open({
 				multiple: false,
-				filters: [{ name: 'Modpack', extensions: ['mrpack'] }],
+				filters: [{ name: 'Modpack', extensions: ['mrpack', 'zip'] }],
 			})
 			if (!result) return null
 			const path = getDialogPath(result)

--- a/packages/app-lib/src/api/curseforge.rs
+++ b/packages/app-lib/src/api/curseforge.rs
@@ -3587,6 +3587,8 @@ mod tests {
             },
             files: Vec::new(),
             overrides: "overrides".to_string(),
+            name: None,
+            version: None,
         };
 
         assert_eq!(
@@ -3608,6 +3610,8 @@ mod tests {
             },
             files: Vec::new(),
             overrides: "overrides".to_string(),
+            name: None,
+            version: None,
         };
 
         assert_eq!(

--- a/packages/app-lib/src/api/curseforge.rs
+++ b/packages/app-lib/src/api/curseforge.rs
@@ -464,8 +464,18 @@ pub struct CurseForgeModpackTarget {
 #[serde(rename_all = "camelCase")]
 struct CurseForgeModpackManifest {
     minecraft: CurseForgeManifestMinecraft,
+    #[serde(default)]
     files: Vec<CurseForgeManifestFile>,
+    #[serde(default = "default_overrides")]
     overrides: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+fn default_overrides() -> String {
+    "overrides".to_string()
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -483,14 +493,14 @@ struct CurseForgeManifestLoader {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct CurseForgeManifestFile {
+pub(crate) struct CurseForgeManifestFile {
     // CurseForge modpack manifests use projectID/fileID (capital ID), not projectId.
     #[serde(alias = "projectID", alias = "projectId")]
-    project_id: u32,
+    pub(crate) project_id: u32,
     #[serde(alias = "fileID", alias = "fileId")]
-    file_id: u32,
+    pub(crate) file_id: u32,
     #[serde(default = "default_true")]
-    required: bool,
+    pub(crate) required: bool,
 }
 
 fn default_true() -> bool {
@@ -997,7 +1007,7 @@ pub async fn get_modpack_target(
         let file = std::fs::File::open(&pack_path)?;
         let mut archive =
             zip::ZipArchive::new(file).map_err(modpack_zip_error)?;
-        let manifest = read_modpack_manifest(&mut archive)?;
+        let manifest = read_modpack_manifest(&mut archive, "")?;
         modpack_target(&manifest)
     })
     .await??;
@@ -1195,7 +1205,7 @@ pub async fn install_modpack_with_reporter(
         let file = std::fs::File::open(&pack_path_for_manifest)?;
         let mut archive =
             zip::ZipArchive::new(file).map_err(modpack_zip_error)?;
-        read_modpack_manifest(&mut archive)
+        read_modpack_manifest(&mut archive, "")
     })
     .await??;
 
@@ -1597,7 +1607,7 @@ pub async fn install_modpack_with_reporter(
             .await?;
     }
     let overrides_written = tokio::task::spawn_blocking(move || {
-        extract_modpack_overrides(&pack_path, &instance_path)
+        extract_modpack_overrides(&pack_path, &instance_path, "")
     })
     .await??;
     Ok(CurseForgeModpackInstallResult {
@@ -1606,6 +1616,438 @@ pub async fn install_modpack_with_reporter(
         minecraft_version: manifest.minecraft.version,
         loader,
     })
+}
+
+/// Installs a CurseForge modpack from a local archive on disk (a zip with a
+/// `manifest.json`), downloading the listed files through the CurseForge API
+/// and extracting the overrides folder. Unlike [`install_modpack_with_reporter`]
+/// this needs no project/file id — undownloadable files land on the manual
+/// download list exactly like API-driven installs.
+pub async fn install_modpack_from_local_archive_with_reporter(
+    instance_id: String,
+    archive_path: std::path::PathBuf,
+    base_folder: String,
+    source_filename: Option<String>,
+    install_optional: bool,
+    reporter: InstallProgressReporter,
+) -> crate::Result<CurseForgeModpackInstallResult> {
+    let manifest_archive_path = archive_path.clone();
+    let manifest_base = base_folder.clone();
+    let manifest = tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&manifest_archive_path)?;
+        let mut archive =
+            zip::ZipArchive::new(file).map_err(modpack_zip_error)?;
+        read_modpack_manifest(&mut archive, &manifest_base)
+    })
+    .await??;
+
+    let target = modpack_target(&manifest)?;
+    let loader = (target.loader != ModLoader::Vanilla)
+        .then(|| target.loader.as_str().to_string());
+    let pack_name = manifest
+        .name
+        .clone()
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| {
+            source_filename.as_ref().map(|name| {
+                std::path::Path::new(name)
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+        })
+        .unwrap_or_else(|| "CurseForge Modpack".to_string());
+    let pack_details = InstallPhaseDetails::Modpack {
+        project_id: None,
+        version_id: None,
+        title: Some(pack_name.clone()),
+    };
+    reporter
+        .update(InstallPhaseId::ResolvingPack, None, pack_details.clone())
+        .await?;
+
+    let loader_version = if target.loader != ModLoader::Vanilla {
+        crate::launcher::get_loader_version_from_profile(
+            &manifest.minecraft.version,
+            target.loader,
+            target.loader_version.as_deref(),
+        )
+        .await?
+    } else {
+        None
+    };
+
+    crate::api::instance::edit(
+        &instance_id,
+        EditInstance {
+            install_stage: Some(crate::state::InstanceInstallStage::PackInstalling),
+            name: Some(pack_name.clone()),
+            link: Some(InstanceLink::ImportedModpack {
+                project_id: None,
+                version_id: None,
+                name: Some(pack_name.clone()),
+                version_number: manifest.version.clone(),
+                filename: source_filename,
+            }),
+            content_set_patch: Some(crate::state::AppliedContentSetPatch {
+                source_kind: Some(ContentSourceKind::CurseForge),
+                game_version: Some(manifest.minecraft.version.clone()),
+                protocol_version: Some(None),
+                loader: Some(target.loader),
+                loader_version: Some(loader_version.map(|version| version.id)),
+            }),
+            ..EditInstance::default()
+        },
+    )
+    .await?;
+
+    let content = install_local_manifest_files(
+        &instance_id,
+        manifest.files.clone(),
+        install_optional,
+        &manifest.minecraft.version,
+        loader.as_deref(),
+        pack_details.clone(),
+        &reporter,
+    )
+    .await?;
+
+    reporter
+        .update(
+            InstallPhaseId::ExtractingOverrides,
+            None,
+            pack_details.clone(),
+        )
+        .await?;
+    let instance_path =
+        crate::api::instance::get_full_path(&instance_id).await?;
+    let overrides_archive_path = archive_path.clone();
+    let overrides_base = base_folder.clone();
+    let overrides_written = tokio::task::spawn_blocking(move || {
+        extract_modpack_overrides(
+            &overrides_archive_path,
+            &instance_path,
+            &overrides_base,
+        )
+    })
+    .await??;
+
+    crate::launcher::install_minecraft_for_instance_id_with_reporter(
+        &instance_id,
+        false,
+        Some(reporter.clone()),
+    )
+    .await?;
+    reporter.clear_context().await?;
+
+    Ok(CurseForgeModpackInstallResult {
+        content,
+        overrides_written,
+        minecraft_version: manifest.minecraft.version,
+        loader,
+    })
+}
+
+/// Downloads and installs the files listed in a local CurseForge manifest.
+/// Mirrors the file loop of [`install_modpack_with_reporter`], simplified to
+/// the job-reporter path used by local imports. Also used by the MCBBS
+/// installer for its CurseForge-style `files` array.
+pub(crate) async fn install_local_manifest_files(
+    instance_id: &str,
+    manifest_files: Vec<CurseForgeManifestFile>,
+    install_optional: bool,
+    minecraft_version: &str,
+    loader: Option<&str>,
+    pack_details: InstallPhaseDetails,
+    reporter: &InstallProgressReporter,
+) -> crate::Result<CurseForgeInstallResult> {
+    let state = State::get().await?;
+    let selected_files = manifest_files
+        .into_iter()
+        .filter(|file| file.required || install_optional)
+        .collect::<Vec<_>>();
+    let loader_type_value = loader.and_then(loader_type);
+    let project_ids = selected_files
+        .iter()
+        .map(|file| file.project_id)
+        .collect::<Vec<_>>();
+    let mut projects = HashMap::new();
+    for project_ids in project_ids.chunks(50) {
+        for project in get_projects(project_ids.to_vec()).await? {
+            projects.insert(project.id, project);
+        }
+    }
+    for project_id in &project_ids {
+        if !projects.contains_key(project_id) {
+            let project = get_project(*project_id).await?;
+            projects.insert(project.id, project);
+        }
+    }
+
+    let total_files = selected_files.len().max(1);
+    let mut file_ids = selected_files
+        .iter()
+        .map(|file| file.file_id)
+        .collect::<Vec<_>>();
+    file_ids.sort_unstable();
+    file_ids.dedup();
+    let mut file_meta = HashMap::<u32, CurseForgeFile>::new();
+    for chunk in file_ids.chunks(50) {
+        for file in get_files_many(chunk.to_vec()).await? {
+            file_meta.insert(file.id, file);
+        }
+    }
+    let content_total_bytes = selected_files
+        .iter()
+        .map(|file| {
+            file_meta
+                .get(&file.file_id)
+                .map(|meta| meta.file_length)
+                .unwrap_or(0)
+        })
+        .sum::<u64>();
+    reporter
+        .update_with_events(
+            InstallPhaseId::DownloadingContent,
+            Some(InstallProgress {
+                current: 0,
+                total: total_files as u64,
+                secondary: Some(InstallProgressSecondary {
+                    current: 0,
+                    total: content_total_bytes,
+                }),
+            }),
+            pack_details.clone(),
+            vec![InstallJobEventKind::ContentDownloadStarted {
+                files: total_files as u64,
+                bytes: Some(content_total_bytes),
+            }],
+        )
+        .await?;
+
+    tracing::info!(
+        selected_manifest_files = selected_files.len(),
+        "Resolved local CurseForge modpack manifest files"
+    );
+    let content = Arc::new(Mutex::new(CurseForgeInstallResult::default()));
+    let download_metrics = Arc::new(CurseForgeDownloadMetrics::default());
+    let projects = Arc::new(projects);
+    let file_meta = Arc::new(file_meta);
+    let files_done = Arc::new(AtomicU64::new(0));
+    let bytes_done = Arc::new(AtomicU64::new(0));
+    let active_downloads = Arc::new(AtomicU64::new(0));
+
+    loading_try_for_each_concurrent(
+        stream::iter(selected_files.into_iter().map(Ok::<_, crate::Error>)),
+        Some(state.download_concurrency()),
+        None,
+        1.0,
+        total_files,
+        None,
+        |manifest_file| {
+            let content = content.clone();
+            let projects = projects.clone();
+            let file_meta = file_meta.clone();
+            let files_done = files_done.clone();
+            let bytes_done = bytes_done.clone();
+            let active_downloads = active_downloads.clone();
+            let reporter = reporter.clone();
+            let download_metrics = download_metrics.clone();
+            let pack_details = pack_details.clone();
+            let instance_id = instance_id.to_string();
+            let minecraft_version = minecraft_version.to_string();
+            async move {
+                let expected_bytes = file_meta
+                    .get(&manifest_file.file_id)
+                    .map(|file| file.file_length)
+                    .unwrap_or(0);
+                let project = projects
+                    .get(&manifest_file.project_id)
+                    .ok_or_else(|| {
+                        ErrorKind::OtherError(format!(
+                            "CurseForge project metadata is missing for {}",
+                            manifest_file.project_id
+                        ))
+                    })?;
+                let project_type = project_type_for_class(project.class_id);
+                managed_project_type(project_type)?;
+
+                active_downloads.fetch_add(1, Ordering::Relaxed);
+                let mut installed_result = None;
+                let mut failed_result = None;
+                let mut failure_reason = "no file was installed".to_string();
+                for attempt in 1..=MODPACK_FILE_INSTALL_ATTEMPTS {
+                    match install_file_with_metrics(
+                        CurseForgeInstallRequest {
+                            instance_id: instance_id.clone(),
+                            project_id: manifest_file.project_id,
+                            file_id: manifest_file.file_id,
+                            project_type: project_type.to_string(),
+                            game_version: Some(minecraft_version.clone()),
+                            mod_loader_type: loader_type_value,
+                            world_name: None,
+                            install_dependencies: false,
+                        },
+                        Some(&download_metrics),
+                    )
+                    .await
+                    {
+                        Ok(item_result)
+                            if !item_result.installed.is_empty() =>
+                        {
+                            installed_result = Some(item_result);
+                            break;
+                        }
+                        Ok(item_result) => {
+                            failure_reason = item_result
+                                .manual_downloads
+                                .first()
+                                .map(|file| {
+                                    format!(
+                                        "{} requires manual download",
+                                        file.file_name
+                                    )
+                                })
+                                .unwrap_or_else(|| {
+                                    "no file was installed".to_string()
+                                });
+                            failed_result = Some(item_result);
+                        }
+                        Err(err) => {
+                            failure_reason = err.to_string();
+                        }
+                    }
+                    tracing::warn!(
+                        project_id = manifest_file.project_id,
+                        file_id = manifest_file.file_id,
+                        attempt,
+                        max_attempts = MODPACK_FILE_INSTALL_ATTEMPTS,
+                        reason = %failure_reason,
+                        "Failed to install required CurseForge file"
+                    );
+                    if attempt < MODPACK_FILE_INSTALL_ATTEMPTS {
+                        tokio::time::sleep(Duration::from_millis(
+                            250 * attempt as u64,
+                        ))
+                        .await;
+                    }
+                }
+
+                let Some(item_result) = installed_result else {
+                    active_downloads.fetch_sub(1, Ordering::Relaxed);
+                    let mut failed_result = failed_result.unwrap_or_default();
+                    if failed_result.manual_downloads.is_empty() {
+                        let file_name = file_meta
+                            .get(&manifest_file.file_id)
+                            .map(|file| file.file_name.clone())
+                            .unwrap_or_else(|| {
+                                format!(
+                                    "project-{}-file-{}",
+                                    manifest_file.project_id,
+                                    manifest_file.file_id
+                                )
+                            });
+                        failed_result.manual_downloads.push(
+                            CurseForgeManualDownload {
+                                project_id: manifest_file.project_id,
+                                file_id: manifest_file.file_id,
+                                file_name: file_name.clone(),
+                                website_url: curseforge_file_page_url(
+                                    project.links.website_url.as_deref(),
+                                    manifest_file.file_id,
+                                ),
+                            },
+                        );
+                    }
+                    let manual_download =
+                        failed_result.manual_downloads.first().cloned();
+                    let skipped_path = manual_download
+                        .as_ref()
+                        .map(|file| file.file_name.clone())
+                        .unwrap_or_else(|| {
+                            format!(
+                                "project-{}-file-{}",
+                                manifest_file.project_id, manifest_file.file_id
+                            )
+                        });
+                    {
+                        let mut content =
+                            content.lock().expect("content mutex");
+                        merge_install_result(&mut content, failed_result);
+                    }
+                    report_modpack_progress(
+                        None,
+                        Some(&reporter),
+                        pack_details,
+                        &files_done,
+                        &bytes_done,
+                        &active_downloads,
+                        total_files as u64,
+                        content_total_bytes,
+                        0,
+                        InstallJobEventKind::ContentFileSkipped {
+                            path: skipped_path,
+                            reason: format!(
+                                "Failed after {} attempts: {}",
+                                MODPACK_FILE_INSTALL_ATTEMPTS, failure_reason
+                            ),
+                            project_id: Some(
+                                manifest_file.project_id.to_string(),
+                            ),
+                            version_id: Some(manifest_file.file_id.to_string()),
+                            manual_url: manual_download
+                                .and_then(|file| file.website_url),
+                        },
+                    )
+                    .await?;
+                    return Ok(());
+                };
+                let completed_path =
+                    item_result.installed[0].relative_path.clone();
+                {
+                    let mut content = content.lock().expect("content mutex");
+                    merge_install_result(&mut content, item_result);
+                }
+                active_downloads.fetch_sub(1, Ordering::Relaxed);
+                report_modpack_progress(
+                    None,
+                    Some(&reporter),
+                    pack_details,
+                    &files_done,
+                    &bytes_done,
+                    &active_downloads,
+                    total_files as u64,
+                    content_total_bytes,
+                    expected_bytes,
+                    InstallJobEventKind::ContentFileCompleted {
+                        path: completed_path,
+                        bytes: expected_bytes,
+                    },
+                )
+                .await?;
+                Ok(())
+            }
+        },
+    )
+    .await?;
+
+    download_metrics.finish(reporter).await?;
+
+    Arc::try_unwrap(content)
+        .map_err(|_| {
+            ErrorKind::OtherError(
+                "CurseForge install state was still shared after completion"
+                    .to_string(),
+            )
+        })?
+        .into_inner()
+        .map_err(|_| {
+            ErrorKind::OtherError(
+                "CurseForge install state mutex was poisoned".to_string(),
+            )
+        })
+        .map_err(Into::into)
 }
 
 pub async fn update_managed_modpack(
@@ -1767,19 +2209,23 @@ async fn remove_existing_curseforge_pack_content(
 fn extract_modpack_overrides(
     archive_path: &Path,
     instance_path: &Path,
+    base_folder: &str,
 ) -> crate::Result<u32> {
     let file = std::fs::File::open(archive_path)?;
     let mut archive = zip::ZipArchive::new(file).map_err(modpack_zip_error)?;
-    let manifest = read_modpack_manifest(&mut archive)?;
-    let prefix = format!("{}/", manifest.overrides.trim_matches('/'));
+    let manifest = read_modpack_manifest(&mut archive, base_folder)?;
+    let prefix =
+        format!("{base_folder}{}/", manifest.overrides.trim_matches('/'));
     let mut files_written = 0_u32;
     let mut total_size = 0_u64;
     for index in 0..archive.len() {
         let mut entry = archive.by_index(index).map_err(modpack_zip_error)?;
-        if entry.is_dir() || !entry.name().starts_with(&prefix) {
+        let entry_name =
+            crate::pack::detect::decode_zip_entry_name(entry.name_raw());
+        if entry.is_dir() || !entry_name.starts_with(&prefix) {
             continue;
         }
-        let relative = &entry.name()[prefix.len()..];
+        let relative = &entry_name[prefix.len()..];
         let safe_path = safe_archive_relative_path(relative)?;
         total_size = total_size.saturating_add(entry.size());
         if total_size > 2 * 1024 * 1024 * 1024 {
@@ -1814,12 +2260,16 @@ fn extract_modpack_overrides(
 
 fn read_modpack_manifest<R: Read + Seek>(
     archive: &mut zip::ZipArchive<R>,
+    base_folder: &str,
 ) -> crate::Result<CurseForgeModpackManifest> {
-    let mut entry = archive.by_name("manifest.json").map_err(|_| {
-        ErrorKind::InputError(
-            "CurseForge modpack is missing manifest.json".to_string(),
-        )
-    })?;
+    let entry_name = format!("{base_folder}manifest.json");
+    let index = crate::pack::detect::find_entry_index(archive, &entry_name)?
+        .ok_or_else(|| {
+            ErrorKind::InputError(
+                "CurseForge modpack is missing manifest.json".to_string(),
+            )
+        })?;
+    let mut entry = archive.by_index(index).map_err(modpack_zip_error)?;
     let mut json = String::new();
     entry.read_to_string(&mut json)?;
     Ok(serde_json::from_str::<CurseForgeModpackManifest>(&json)?)

--- a/packages/app-lib/src/api/curseforge.rs
+++ b/packages/app-lib/src/api/curseforge.rs
@@ -1681,7 +1681,9 @@ pub async fn install_modpack_from_local_archive_with_reporter(
     crate::api::instance::edit(
         &instance_id,
         EditInstance {
-            install_stage: Some(crate::state::InstanceInstallStage::PackInstalling),
+            install_stage: Some(
+                crate::state::InstanceInstallStage::PackInstalling,
+            ),
             name: Some(pack_name.clone()),
             link: Some(InstanceLink::ImportedModpack {
                 project_id: None,

--- a/packages/app-lib/src/api/handler.rs
+++ b/packages/app-lib/src/api/handler.rs
@@ -100,11 +100,12 @@ pub async fn parse_command(
     if let Some(sublink) = command_string.strip_prefix("axolotl://") {
         Ok(handle_url(sublink).await?)
     } else {
-        // We assume anything else is a filepath to an .mrpack file
+        // We assume anything else is a filepath to a modpack file; zip
+        // archives are format-sniffed by the pack installer.
         let path = PathBuf::from(command_string);
         let path = io::canonicalize(path)?;
         if let Some(ext) = path.extension()
-            && ext == "mrpack"
+            && (ext == "mrpack" || ext == "zip")
         {
             return Ok(CommandPayload::RunMRPack { path });
         }

--- a/packages/app-lib/src/api/instance/export_mrpack.rs
+++ b/packages/app-lib/src/api/instance/export_mrpack.rs
@@ -198,6 +198,12 @@ pub async fn create_mrpack_json(
             dependencies.insert(PackDependency::QuiltLoader, v)
         }
         (ModLoader::Vanilla, _) => None,
+        (ModLoader::OptiFine, _) => {
+            return Err(crate::ErrorKind::OtherError(
+                "OptiFine instances cannot be exported to mrpack, as the format has no OptiFine dependency type".to_string(),
+            )
+            .into());
+        }
         _ => {
             return Err(crate::ErrorKind::OtherError(
                 "Loader version mismatch".to_string(),

--- a/packages/app-lib/src/api/pack/archive_util.rs
+++ b/packages/app-lib/src/api/pack/archive_util.rs
@@ -8,10 +8,8 @@ use crate::util::io;
 const EXTRACTION_SIZE_LIMIT: u64 = 8 * 1024 * 1024 * 1024;
 
 fn archive_error(error: zip::result::ZipError) -> crate::Error {
-    crate::ErrorKind::InputError(format!(
-        "Modpack archive is invalid: {error}"
-    ))
-    .into()
+    crate::ErrorKind::InputError(format!("Modpack archive is invalid: {error}"))
+        .into()
 }
 
 pub(crate) fn safe_relative_path(value: &str) -> crate::Result<String> {
@@ -134,13 +132,12 @@ pub(crate) async fn read_archive_entry_to_string(
         let file = std::fs::File::open(&archive_path)
             .map_err(|error| io::IOError::with_path(error, &archive_path))?;
         let mut archive = zip::ZipArchive::new(file).map_err(archive_error)?;
-        let index =
-            super::detect::find_entry_index(&mut archive, &entry_name)?
-                .ok_or_else(|| {
-                    crate::ErrorKind::InputError(format!(
-                        "Modpack archive is missing {entry_name}"
-                    ))
-                })?;
+        let index = super::detect::find_entry_index(&mut archive, &entry_name)?
+            .ok_or_else(|| {
+                crate::ErrorKind::InputError(format!(
+                    "Modpack archive is missing {entry_name}"
+                ))
+            })?;
         let mut entry = archive.by_index(index).map_err(archive_error)?;
         let mut contents = Vec::new();
         std::io::Read::read_to_end(&mut entry, &mut contents)?;

--- a/packages/app-lib/src/api/pack/archive_util.rs
+++ b/packages/app-lib/src/api/pack/archive_util.rs
@@ -1,0 +1,170 @@
+//! Shared helpers for extracting content from local modpack archives.
+
+use std::path::{Component, Path, PathBuf};
+
+use super::detect::decode_zip_entry_name;
+use crate::util::io;
+
+const EXTRACTION_SIZE_LIMIT: u64 = 8 * 1024 * 1024 * 1024;
+
+fn archive_error(error: zip::result::ZipError) -> crate::Error {
+    crate::ErrorKind::InputError(format!(
+        "Modpack archive is invalid: {error}"
+    ))
+    .into()
+}
+
+pub(crate) fn safe_relative_path(value: &str) -> crate::Result<String> {
+    let path = Path::new(value);
+    if value.is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(crate::ErrorKind::InputError(
+            "Modpack archive contains an invalid file path".to_string(),
+        )
+        .into());
+    }
+    Ok(path.to_string_lossy().replace('\\', "/"))
+}
+
+/// Extracts every file under `prefix` in the archive into `target_dir`,
+/// preserving the directory structure below the prefix. Returns the number of
+/// files written.
+pub(crate) async fn extract_archive_subdir(
+    archive_path: PathBuf,
+    prefix: String,
+    target_dir: PathBuf,
+) -> crate::Result<u32> {
+    tokio::task::spawn_blocking(move || {
+        extract_archive_subdir_sync(&archive_path, &prefix, &target_dir)
+    })
+    .await?
+}
+
+fn extract_archive_subdir_sync(
+    archive_path: &Path,
+    prefix: &str,
+    target_dir: &Path,
+) -> crate::Result<u32> {
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| io::IOError::with_path(error, archive_path))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(archive_error)?;
+    let mut files_written = 0_u32;
+    let mut total_size = 0_u64;
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(archive_error)?;
+        let entry_name = decode_zip_entry_name(entry.name_raw());
+        if entry.is_dir() || !entry_name.starts_with(prefix) {
+            continue;
+        }
+        let relative = &entry_name[prefix.len()..];
+        if relative.is_empty() {
+            continue;
+        }
+        total_size = total_size.saturating_add(entry.size());
+        if total_size > EXTRACTION_SIZE_LIMIT {
+            return Err(crate::ErrorKind::InputError(
+                "Modpack archive contents exceed the extraction limit"
+                    .to_string(),
+            )
+            .into());
+        }
+        let target = target_dir.join(safe_relative_path(relative)?);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| io::IOError::with_path(error, parent))?;
+        }
+        let mut output = std::fs::File::create(&target)
+            .map_err(|error| io::IOError::with_path(error, &target))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| io::IOError::with_path(error, &target))?;
+        files_written = files_written.saturating_add(1);
+    }
+    Ok(files_written)
+}
+
+/// Extracts a single archive entry to the given target file path.
+pub(crate) async fn extract_archive_entry_to_file(
+    archive_path: PathBuf,
+    entry_name: String,
+    target: PathBuf,
+) -> crate::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&archive_path)
+            .map_err(|error| io::IOError::with_path(error, &archive_path))?;
+        let mut archive = zip::ZipArchive::new(file).map_err(archive_error)?;
+        let index = (0..archive.len())
+            .find(|&index| {
+                archive
+                    .by_index_raw(index)
+                    .map(|entry| {
+                        decode_zip_entry_name(entry.name_raw()) == entry_name
+                    })
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| {
+                crate::ErrorKind::InputError(format!(
+                    "Modpack archive is missing {entry_name}"
+                ))
+            })?;
+        let mut entry = archive.by_index(index).map_err(archive_error)?;
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| io::IOError::with_path(error, parent))?;
+        }
+        let mut output = std::fs::File::create(&target)
+            .map_err(|error| io::IOError::with_path(error, &target))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| io::IOError::with_path(error, &target))?;
+        Ok(())
+    })
+    .await?
+}
+
+/// Reads a single archive entry into a string, tolerating GB18030-encoded
+/// file contents produced by Chinese packaging tools.
+pub(crate) async fn read_archive_entry_to_string(
+    archive_path: PathBuf,
+    entry_name: String,
+) -> crate::Result<String> {
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&archive_path)
+            .map_err(|error| io::IOError::with_path(error, &archive_path))?;
+        let mut archive = zip::ZipArchive::new(file).map_err(archive_error)?;
+        let index =
+            super::detect::find_entry_index(&mut archive, &entry_name)?
+                .ok_or_else(|| {
+                    crate::ErrorKind::InputError(format!(
+                        "Modpack archive is missing {entry_name}"
+                    ))
+                })?;
+        let mut entry = archive.by_index(index).map_err(archive_error)?;
+        let mut contents = Vec::new();
+        std::io::Read::read_to_end(&mut entry, &mut contents)?;
+        Ok(match String::from_utf8(contents) {
+            Ok(value) => value,
+            Err(error) => {
+                let (decoded, _, _) =
+                    encoding_rs::GB18030.decode(error.as_bytes());
+                decoded.into_owned()
+            }
+        })
+    })
+    .await?
+}
+
+/// Allocates a unique scratch directory for extracting nested pack content.
+pub(crate) async fn create_import_scratch_dir(
+    state: &crate::State,
+) -> crate::Result<PathBuf> {
+    let dir = state
+        .directories
+        .caches_dir()
+        .join("modpack-import")
+        .join(uuid::Uuid::new_v4().to_string());
+    io::create_dir_all(&dir).await?;
+    Ok(dir)
+}

--- a/packages/app-lib/src/api/pack/detect.rs
+++ b/packages/app-lib/src/api/pack/detect.rs
@@ -1,0 +1,287 @@
+//! Local modpack file format detection.
+//!
+//! Detects the modpack format of a local archive by inspecting its contents
+//! rather than its file extension, checking both the archive root and a single
+//! wrapping folder, mirroring the detection behavior of PCL.
+
+use std::io::Read;
+use std::path::Path;
+
+pub const MRPACK_MANIFEST: &str = "modrinth.index.json";
+pub const CURSEFORGE_MANIFEST: &str = "manifest.json";
+pub const MCBBS_MANIFEST: &str = "mcbbs.packmeta";
+pub const HMCL_MANIFEST: &str = "modpack.json";
+pub const MMC_MANIFEST: &str = "mmc-pack.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalPackFormat {
+    Mrpack,
+    CurseForge,
+    Mcbbs,
+    Hmcl,
+    MmcExport,
+    LauncherBundled,
+    PlainArchive,
+}
+
+impl LocalPackFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mrpack => "Modrinth",
+            Self::CurseForge => "CurseForge",
+            Self::Mcbbs => "MCBBS",
+            Self::Hmcl => "HMCL",
+            Self::MmcExport => "MultiMC",
+            Self::LauncherBundled => "launcher bundle",
+            Self::PlainArchive => "game folder archive",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DetectedLocalPack {
+    pub format: LocalPackFormat,
+    /// Prefix of the folder containing the pack's key files, either empty or
+    /// a single path segment ending in `/`.
+    pub base_folder: String,
+    /// For [`LocalPackFormat::LauncherBundled`], the archive entry of the
+    /// nested modpack file.
+    pub inner_pack_entry: Option<String>,
+    /// For [`LocalPackFormat::PlainArchive`], the version id matched under
+    /// `versions/<id>/<id>.json`.
+    pub plain_version_id: Option<String>,
+}
+
+/// Decodes a zip entry name, tolerating archives produced by Chinese tools
+/// that store GB18030-encoded names without the UTF-8 flag.
+pub fn decode_zip_entry_name(raw: &[u8]) -> String {
+    match std::str::from_utf8(raw) {
+        Ok(name) => name.to_string(),
+        Err(_) => {
+            let (decoded, _, _) = encoding_rs::GB18030.decode(raw);
+            decoded.into_owned()
+        }
+    }
+}
+
+pub async fn detect_local_pack(
+    path: &Path,
+) -> crate::Result<DetectedLocalPack> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || detect_local_pack_sync(&path)).await?
+}
+
+fn open_error(path: &Path, error: impl std::fmt::Display) -> crate::Error {
+    if path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("rar"))
+    {
+        crate::ErrorKind::InputError(
+            "RAR modpack archives are not supported; please repackage the modpack as a zip file".to_string(),
+        )
+        .into()
+    } else {
+        crate::ErrorKind::InputError(format!(
+            "Failed to open modpack archive: {error}"
+        ))
+        .into()
+    }
+}
+
+fn detect_local_pack_sync(path: &Path) -> crate::Result<DetectedLocalPack> {
+    let file = std::fs::File::open(path)
+        .map_err(|error| open_error(path, error))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|error| open_error(path, error))?;
+
+    let mut names = Vec::with_capacity(archive.len());
+    for index in 0..archive.len() {
+        let entry = archive.by_index_raw(index).map_err(|error| {
+            crate::ErrorKind::InputError(format!(
+                "Failed to read modpack archive entry: {error}"
+            ))
+        })?;
+        if entry.encrypted() {
+            return Err(crate::ErrorKind::InputError(
+                "Encrypted modpack archives are not supported".to_string(),
+            )
+            .into());
+        }
+        names.push(decode_zip_entry_name(entry.name_raw()));
+    }
+
+    let bases = candidate_bases(&names);
+    for base in &bases {
+        if let Some(detected) = detect_at_base(&mut archive, &names, base)? {
+            return Ok(detected);
+        }
+    }
+
+    if let Some(detected) = detect_plain_archive(&names) {
+        return Ok(detected);
+    }
+
+    Err(crate::ErrorKind::InputError(
+        "Unrecognized modpack format: no known pack manifest was found in the archive"
+            .to_string(),
+    )
+    .into())
+}
+
+/// The archive root, followed by each distinct single wrapping folder.
+fn candidate_bases(names: &[String]) -> Vec<String> {
+    let mut bases = vec![String::new()];
+    for name in names {
+        if let Some((first, rest)) = name.split_once('/')
+            && !rest.is_empty()
+            && !rest.contains('/')
+        {
+            let base = format!("{first}/");
+            if !bases.contains(&base) {
+                bases.push(base);
+            }
+        }
+    }
+    bases
+}
+
+fn detect_at_base<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    names: &[String],
+    base: &str,
+) -> crate::Result<Option<DetectedLocalPack>> {
+    let has = |file: &str| -> bool {
+        let target = format!("{base}{file}");
+        names.iter().any(|name| name == &target)
+    };
+    let detected = |format: LocalPackFormat| DetectedLocalPack {
+        format,
+        base_folder: base.to_string(),
+        inner_pack_entry: None,
+        plain_version_id: None,
+    };
+
+    // MCBBS and MultiMC packs may also contain a manifest.json, so both must
+    // be checked before the CurseForge manifest.
+    if has(MCBBS_MANIFEST) {
+        return Ok(Some(detected(LocalPackFormat::Mcbbs)));
+    }
+    if has(MMC_MANIFEST) {
+        return Ok(Some(detected(LocalPackFormat::MmcExport)));
+    }
+    if has(MRPACK_MANIFEST) {
+        return Ok(Some(detected(LocalPackFormat::Mrpack)));
+    }
+    if has(CURSEFORGE_MANIFEST) {
+        // A manifest.json with an `addons` array is the MCBBS variant. An
+        // unreadable manifest.json (e.g. an unrelated mod config inside a
+        // zipped game folder) does not abort detection of other formats.
+        match read_entry_json(archive, &format!("{base}{CURSEFORGE_MANIFEST}"))
+        {
+            Ok(manifest) => {
+                return Ok(Some(detected(
+                    if manifest
+                        .get("addons")
+                        .is_some_and(|value| !value.is_null())
+                    {
+                        LocalPackFormat::Mcbbs
+                    } else {
+                        LocalPackFormat::CurseForge
+                    },
+                )));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Ignoring unparsable manifest.json at {base:?} during modpack detection: {error}"
+                );
+            }
+        }
+    }
+    if has(HMCL_MANIFEST) {
+        return Ok(Some(detected(LocalPackFormat::Hmcl)));
+    }
+    for inner in ["modpack.zip", "modpack.mrpack"] {
+        if has(inner) {
+            return Ok(Some(DetectedLocalPack {
+                format: LocalPackFormat::LauncherBundled,
+                base_folder: base.to_string(),
+                inner_pack_entry: Some(format!("{base}{inner}")),
+                plain_version_id: None,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Finds an entry index by its decoded name, so lookups stay consistent with
+/// [`decode_zip_entry_name`] even for archives with GB18030-encoded names.
+pub(crate) fn find_entry_index<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    entry_name: &str,
+) -> crate::Result<Option<usize>> {
+    for index in 0..archive.len() {
+        let entry = archive.by_index_raw(index).map_err(|error| {
+            crate::ErrorKind::InputError(format!(
+                "Failed to read modpack archive entry: {error}"
+            ))
+        })?;
+        if decode_zip_entry_name(entry.name_raw()) == entry_name {
+            return Ok(Some(index));
+        }
+    }
+    Ok(None)
+}
+
+fn read_entry_json<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    entry_name: &str,
+) -> crate::Result<serde_json::Value> {
+    let index = find_entry_index(archive, entry_name)?.ok_or_else(|| {
+        crate::ErrorKind::InputError(format!(
+            "Modpack archive is missing {entry_name}"
+        ))
+    })?;
+    let mut entry = archive.by_index(index).map_err(|error| {
+        crate::ErrorKind::InputError(format!(
+            "Failed to read {entry_name} from modpack archive: {error}"
+        ))
+    })?;
+    let mut contents = Vec::new();
+    entry.read_to_end(&mut contents)?;
+    Ok(serde_json::from_slice(&contents)?)
+}
+
+/// Looks for a `versions/<id>/<id>.json` structure marking a zipped-up game
+/// folder, returning the prefix of the folder containing `versions`.
+fn detect_plain_archive(names: &[String]) -> Option<DetectedLocalPack> {
+    for name in names {
+        let segments: Vec<&str> = name.split('/').collect();
+        if segments.len() < 3 {
+            continue;
+        }
+        let json = segments[segments.len() - 1];
+        let version = segments[segments.len() - 2];
+        let marker = segments[segments.len() - 3];
+        if marker == "versions"
+            && !version.is_empty()
+            && json
+                .strip_suffix(".json")
+                .is_some_and(|stem| stem == version)
+        {
+            let base = segments[..segments.len() - 3].join("/");
+            let base = if base.is_empty() {
+                base
+            } else {
+                format!("{base}/")
+            };
+            return Some(DetectedLocalPack {
+                format: LocalPackFormat::PlainArchive,
+                base_folder: base,
+                inner_pack_entry: None,
+                plain_version_id: Some(version.to_string()),
+            });
+        }
+    }
+    None
+}

--- a/packages/app-lib/src/api/pack/detect.rs
+++ b/packages/app-lib/src/api/pack/detect.rs
@@ -89,10 +89,10 @@ fn open_error(path: &Path, error: impl std::fmt::Display) -> crate::Error {
 }
 
 fn detect_local_pack_sync(path: &Path) -> crate::Result<DetectedLocalPack> {
-    let file = std::fs::File::open(path)
-        .map_err(|error| open_error(path, error))?;
-    let mut archive = zip::ZipArchive::new(file)
-        .map_err(|error| open_error(path, error))?;
+    let file =
+        std::fs::File::open(path).map_err(|error| open_error(path, error))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|error| open_error(path, error))?;
 
     let mut names = Vec::with_capacity(archive.len());
     for index in 0..archive.len() {

--- a/packages/app-lib/src/api/pack/import/mmc.rs
+++ b/packages/app-lib/src/api/pack/import/mmc.rs
@@ -185,7 +185,25 @@ pub async fn import_mmc(
 ) -> crate::Result<()> {
     let mmc_instance_path =
         mmc_base_path.join("instances").join(instance_folder);
+    import_mmc_instance_dir(
+        mmc_instance_path,
+        Some(mmc_base_path.join("icons")),
+        instance_id,
+        reporter,
+        details,
+    )
+    .await
+}
 
+/// Imports an MMC/Prism instance directly from its instance directory, used
+/// both for launcher-folder imports and extracted MultiMC export zips.
+pub(crate) async fn import_mmc_instance_dir(
+    mmc_instance_path: PathBuf,
+    icons_dir: Option<PathBuf>,
+    instance_id: &str,
+    reporter: InstallProgressReporter,
+    details: InstallPhaseDetails,
+) -> crate::Result<()> {
     let mmc_pack = serde_json::from_str::<MMCPack>(
         &io::read_any_encoding_to_string(
             &mmc_instance_path.join("mmc-pack.json"),
@@ -199,8 +217,21 @@ pub async fn import_mmc(
 
     // Re-cache icon
     let icon = if let Some(icon_key) = instance_cfg.icon_key {
-        let icon_path = mmc_base_path.join("icons").join(icon_key);
-        import::recache_icon(icon_path).await?
+        let mut icon = None;
+        for icon_dir in
+            icons_dir.iter().chain(std::iter::once(&mmc_instance_path))
+        {
+            let icon_path = icon_dir.join(&icon_key);
+            icon = import::recache_icon(icon_path).await?;
+            if icon.is_none() {
+                let icon_path = icon_dir.join(format!("{icon_key}.png"));
+                icon = import::recache_icon(icon_path).await?;
+            }
+            if icon.is_some() {
+                break;
+            }
+        }
+        icon
     } else {
         None
     };

--- a/packages/app-lib/src/api/pack/install_hmcl.rs
+++ b/packages/app-lib/src/api/pack/install_hmcl.rs
@@ -1,0 +1,242 @@
+//! Installer for HMCL modpacks.
+//!
+//! HMCL packs are zips carrying a `modpack.json` with the pack name and game
+//! version, optionally with an MCBBS-style `addons` array declaring loaders;
+//! bundled content ships in a `minecraft/` folder that maps onto the
+//! instance's game directory.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::archive_util;
+use crate::State;
+use crate::data::ModLoader;
+use crate::install::{
+    InstallJobEventKind, InstallPhaseDetails, InstallPhaseId,
+    InstallProgressReporter,
+};
+use crate::pack::detect::HMCL_MANIFEST;
+use crate::state::{
+    AppliedContentSetPatch, ContentSourceKind, EditInstance,
+    InstanceInstallStage, InstanceLink,
+};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct HmclManifest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    game_version: Option<String>,
+    #[serde(default)]
+    addons: Vec<HmclAddon>,
+}
+
+#[derive(Deserialize, Debug)]
+struct HmclAddon {
+    id: String,
+    version: String,
+}
+
+pub(crate) async fn install_hmcl_pack_with_reporter(
+    instance_id: String,
+    archive_path: PathBuf,
+    base_folder: String,
+    source_filename: Option<String>,
+    reporter: InstallProgressReporter,
+) -> crate::Result<()> {
+    let state = State::get().await?;
+    let manifest_json = archive_util::read_archive_entry_to_string(
+        archive_path.clone(),
+        format!("{base_folder}{HMCL_MANIFEST}"),
+    )
+    .await?;
+    let manifest: HmclManifest = serde_json::from_str(&manifest_json)?;
+
+    let mut game_version = manifest
+        .game_version
+        .clone()
+        .filter(|version| !version.trim().is_empty());
+    let mut loader = ModLoader::Vanilla;
+    let mut loader_version = None;
+    let mut optifine_version = None;
+    for addon in &manifest.addons {
+        match addon.id.to_ascii_lowercase().as_str() {
+            "game" => {
+                if game_version.is_none() {
+                    game_version = Some(addon.version.clone());
+                }
+            }
+            "forge" => {
+                loader = ModLoader::Forge;
+                loader_version = Some(addon.version.clone());
+            }
+            "neoforge" => {
+                loader = ModLoader::NeoForge;
+                loader_version = Some(addon.version.clone());
+            }
+            "fabric" => {
+                loader = ModLoader::Fabric;
+                loader_version = Some(addon.version.clone());
+            }
+            "quilt" => {
+                loader = ModLoader::Quilt;
+                loader_version = Some(addon.version.clone());
+            }
+            "optifine" => optifine_version = Some(addon.version.clone()),
+            other => {
+                tracing::warn!(
+                    "Ignoring unsupported HMCL addon {other} {}",
+                    addon.version
+                );
+            }
+        }
+    }
+    let Some(game_version) = game_version else {
+        return Err(crate::ErrorKind::InputError(
+            "HMCL modpack did not specify a Minecraft version".to_string(),
+        )
+        .into());
+    };
+
+    let mut optifine_as_mod = None;
+    if let Some(optifine_version) = optifine_version {
+        match loader {
+            ModLoader::Vanilla => {
+                loader = ModLoader::OptiFine;
+                loader_version = Some(optifine_version);
+            }
+            ModLoader::Forge | ModLoader::NeoForge => {
+                optifine_as_mod = Some(optifine_version);
+            }
+            _ => {
+                tracing::warn!(
+                    "Skipping OptiFine {optifine_version}: not compatible with {}",
+                    loader.as_str()
+                );
+            }
+        }
+    }
+
+    let pack_name = manifest
+        .name
+        .clone()
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| {
+            source_filename.as_ref().map(|name| {
+                std::path::Path::new(name)
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+        })
+        .unwrap_or_else(|| "HMCL Modpack".to_string());
+    let pack_details = InstallPhaseDetails::Modpack {
+        project_id: None,
+        version_id: None,
+        title: Some(pack_name.clone()),
+    };
+    reporter
+        .update(InstallPhaseId::ResolvingPack, None, pack_details.clone())
+        .await?;
+
+    let resolved_loader_version = if loader != ModLoader::Vanilla {
+        crate::launcher::get_loader_version_from_profile(
+            &game_version,
+            loader,
+            loader_version.as_deref(),
+        )
+        .await?
+    } else {
+        None
+    };
+
+    crate::api::instance::edit(
+        &instance_id,
+        EditInstance {
+            install_stage: Some(InstanceInstallStage::PackInstalling),
+            name: Some(pack_name.clone()),
+            link: Some(InstanceLink::ImportedModpack {
+                project_id: None,
+                version_id: None,
+                name: Some(pack_name.clone()),
+                version_number: manifest.version.clone(),
+                filename: source_filename,
+            }),
+            content_set_patch: Some(AppliedContentSetPatch {
+                source_kind: Some(ContentSourceKind::ImportedModpack),
+                game_version: Some(game_version.clone()),
+                protocol_version: Some(None),
+                loader: Some(loader),
+                loader_version: Some(
+                    resolved_loader_version.map(|version| version.id),
+                ),
+            }),
+            ..EditInstance::default()
+        },
+    )
+    .await?;
+
+    reporter
+        .update(
+            InstallPhaseId::ExtractingOverrides,
+            None,
+            pack_details.clone(),
+        )
+        .await?;
+    let instance_path =
+        crate::api::instance::get_full_path(&instance_id).await?;
+    archive_util::extract_archive_subdir(
+        archive_path,
+        format!("{base_folder}minecraft/"),
+        instance_path.clone(),
+    )
+    .await?;
+
+    crate::launcher::install_minecraft_for_instance_id_with_reporter(
+        &instance_id,
+        false,
+        Some(reporter.clone()),
+    )
+    .await?;
+
+    if let Some(optifine_version) = optifine_as_mod
+        && let Err(error) = super::install_mcbbs::install_optifine_mod(
+            &state,
+            &instance_id,
+            &game_version,
+            &optifine_version,
+            &instance_path,
+        )
+        .await
+    {
+        tracing::warn!(
+            "Failed to install OptiFine {optifine_version} as a mod: {error}"
+        );
+        reporter
+            .update_with_events(
+                InstallPhaseId::DownloadingContent,
+                None,
+                pack_details.clone(),
+                vec![InstallJobEventKind::ContentFileSkipped {
+                    path: format!("OptiFine {optifine_version}"),
+                    reason: format!(
+                        "OptiFine could not be installed automatically: {error}"
+                    ),
+                    project_id: None,
+                    version_id: None,
+                    manual_url: Some(
+                        "https://optifine.net/downloads".to_string(),
+                    ),
+                }],
+            )
+            .await?;
+    }
+
+    reporter.clear_context().await?;
+    Ok(())
+}

--- a/packages/app-lib/src/api/pack/install_mcbbs.rs
+++ b/packages/app-lib/src/api/pack/install_mcbbs.rs
@@ -1,0 +1,389 @@
+//! Installer for MCBBS modpacks.
+//!
+//! MCBBS packs are zips carrying either an `mcbbs.packmeta` file or a
+//! `manifest.json` with an `addons` array. Game and loader versions come from
+//! the addons list, bundled content ships in `overrides/`, and optional
+//! launch settings come from `launchInfo`.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::archive_util;
+use crate::State;
+use crate::data::ModLoader;
+use crate::install::{
+    InstallJobEventKind, InstallPhaseDetails, InstallPhaseId,
+    InstallProgressReporter,
+};
+use crate::pack::detect::{CURSEFORGE_MANIFEST, MCBBS_MANIFEST};
+use crate::state::{
+    AppliedContentSetPatch, ContentSourceKind, EditInstance,
+    InstanceInstallStage, InstanceLaunchOverridesPatch, InstanceLink,
+};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct McbbsManifest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    addons: Vec<McbbsAddon>,
+    #[serde(default)]
+    files: Vec<McbbsFile>,
+    #[serde(default)]
+    launch_info: Option<McbbsLaunchInfo>,
+}
+
+#[derive(Deserialize, Debug)]
+struct McbbsAddon {
+    id: String,
+    version: String,
+}
+
+/// A `files` entry; `curse` entries carry CurseForge project/file ids while
+/// `addition` entries ship inside the overrides folder and need no download.
+#[derive(Deserialize, Debug)]
+struct McbbsFile {
+    #[serde(default, rename = "type")]
+    type_: Option<String>,
+    #[serde(default, alias = "projectID", alias = "projectId")]
+    project_id: Option<u32>,
+    #[serde(default, alias = "fileID", alias = "fileId")]
+    file_id: Option<u32>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct McbbsLaunchInfo {
+    #[serde(default)]
+    java_argument: Option<serde_json::Value>,
+}
+
+fn join_arguments(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::String(value) => vec![value.clone()],
+        serde_json::Value::Array(values) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub(crate) async fn install_mcbbs_pack_with_reporter(
+    instance_id: String,
+    archive_path: PathBuf,
+    base_folder: String,
+    source_filename: Option<String>,
+    reporter: InstallProgressReporter,
+) -> crate::Result<()> {
+    let state = State::get().await?;
+
+    let manifest_json = match archive_util::read_archive_entry_to_string(
+        archive_path.clone(),
+        format!("{base_folder}{MCBBS_MANIFEST}"),
+    )
+    .await
+    {
+        Ok(contents) => contents,
+        Err(_) => {
+            archive_util::read_archive_entry_to_string(
+                archive_path.clone(),
+                format!("{base_folder}{CURSEFORGE_MANIFEST}"),
+            )
+            .await?
+        }
+    };
+    let manifest: McbbsManifest = serde_json::from_str(&manifest_json)?;
+
+    let mut game_version = None;
+    let mut loader = ModLoader::Vanilla;
+    let mut loader_version = None;
+    let mut optifine_version = None;
+    for addon in &manifest.addons {
+        match addon.id.to_ascii_lowercase().as_str() {
+            "game" => game_version = Some(addon.version.clone()),
+            "forge" => {
+                loader = ModLoader::Forge;
+                loader_version = Some(addon.version.clone());
+            }
+            "neoforge" => {
+                loader = ModLoader::NeoForge;
+                loader_version = Some(addon.version.clone());
+            }
+            "fabric" => {
+                loader = ModLoader::Fabric;
+                loader_version = Some(addon.version.clone());
+            }
+            "quilt" => {
+                loader = ModLoader::Quilt;
+                loader_version = Some(addon.version.clone());
+            }
+            "optifine" => optifine_version = Some(addon.version.clone()),
+            other => {
+                tracing::warn!(
+                    "Ignoring unsupported MCBBS addon {other} {}",
+                    addon.version
+                );
+            }
+        }
+    }
+    let Some(game_version) = game_version else {
+        return Err(crate::ErrorKind::InputError(
+            "MCBBS modpack did not specify a Minecraft version".to_string(),
+        )
+        .into());
+    };
+
+    // Standalone OptiFine packs install OptiFine as the loader; packs that
+    // also declare Forge/NeoForge get OptiFine dropped into mods/ instead.
+    let mut optifine_as_mod = None;
+    if let Some(optifine_version) = optifine_version {
+        match loader {
+            ModLoader::Vanilla => {
+                loader = ModLoader::OptiFine;
+                loader_version = Some(optifine_version);
+            }
+            ModLoader::Forge | ModLoader::NeoForge => {
+                optifine_as_mod = Some(optifine_version);
+            }
+            _ => {
+                tracing::warn!(
+                    "Skipping OptiFine {optifine_version}: not compatible with {}",
+                    loader.as_str()
+                );
+            }
+        }
+    }
+
+    let pack_name = manifest
+        .name
+        .clone()
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| {
+            source_filename.as_ref().map(|name| {
+                std::path::Path::new(name)
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+        })
+        .unwrap_or_else(|| "MCBBS Modpack".to_string());
+    let pack_details = InstallPhaseDetails::Modpack {
+        project_id: None,
+        version_id: None,
+        title: Some(pack_name.clone()),
+    };
+    reporter
+        .update(InstallPhaseId::ResolvingPack, None, pack_details.clone())
+        .await?;
+
+    let resolved_loader_version = if loader != ModLoader::Vanilla {
+        crate::launcher::get_loader_version_from_profile(
+            &game_version,
+            loader,
+            loader_version.as_deref(),
+        )
+        .await?
+    } else {
+        None
+    };
+
+    let launch_overrides =
+        manifest.launch_info.as_ref().and_then(|launch_info| {
+            let jvm_args = launch_info
+                .java_argument
+                .as_ref()
+                .map(|value| join_arguments(value))
+                .filter(|args| !args.is_empty())?;
+            Some(InstanceLaunchOverridesPatch {
+                extra_launch_args: Some(Some(jvm_args)),
+                ..InstanceLaunchOverridesPatch::default()
+            })
+        });
+
+    crate::api::instance::edit(
+        &instance_id,
+        EditInstance {
+            install_stage: Some(InstanceInstallStage::PackInstalling),
+            name: Some(pack_name.clone()),
+            link: Some(InstanceLink::ImportedModpack {
+                project_id: None,
+                version_id: None,
+                name: Some(pack_name.clone()),
+                version_number: manifest.version.clone(),
+                filename: source_filename,
+            }),
+            launch_overrides,
+            content_set_patch: Some(AppliedContentSetPatch {
+                source_kind: Some(ContentSourceKind::ImportedModpack),
+                game_version: Some(game_version.clone()),
+                protocol_version: Some(None),
+                loader: Some(loader),
+                loader_version: Some(
+                    resolved_loader_version.map(|version| version.id),
+                ),
+            }),
+            ..EditInstance::default()
+        },
+    )
+    .await?;
+
+    let curse_files = manifest
+        .files
+        .iter()
+        .filter(|file| {
+            file.type_
+                .as_deref()
+                .is_none_or(|kind| kind.eq_ignore_ascii_case("curse"))
+        })
+        .filter_map(|file| {
+            Some(crate::api::curseforge::CurseForgeManifestFile {
+                project_id: file.project_id?,
+                file_id: file.file_id?,
+                required: true,
+            })
+        })
+        .collect::<Vec<_>>();
+    if !curse_files.is_empty() {
+        let content_loader = (loader != ModLoader::Vanilla
+            && loader != ModLoader::OptiFine)
+            .then(|| loader.as_str().to_string());
+        crate::api::curseforge::install_local_manifest_files(
+            &instance_id,
+            curse_files,
+            false,
+            &game_version,
+            content_loader.as_deref(),
+            pack_details.clone(),
+            &reporter,
+        )
+        .await?;
+    }
+
+    reporter
+        .update(
+            InstallPhaseId::ExtractingOverrides,
+            None,
+            pack_details.clone(),
+        )
+        .await?;
+    let instance_path =
+        crate::api::instance::get_full_path(&instance_id).await?;
+    archive_util::extract_archive_subdir(
+        archive_path,
+        format!("{base_folder}overrides/"),
+        instance_path.clone(),
+    )
+    .await?;
+
+    crate::launcher::install_minecraft_for_instance_id_with_reporter(
+        &instance_id,
+        false,
+        Some(reporter.clone()),
+    )
+    .await?;
+
+    if let Some(optifine_version) = optifine_as_mod
+        && let Err(error) = install_optifine_mod(
+            &state,
+            &instance_id,
+            &game_version,
+            &optifine_version,
+            &instance_path,
+        )
+        .await
+    {
+        tracing::warn!(
+            "Failed to install OptiFine {optifine_version} as a mod: {error}"
+        );
+        reporter
+            .update_with_events(
+                InstallPhaseId::DownloadingContent,
+                None,
+                pack_details.clone(),
+                vec![InstallJobEventKind::ContentFileSkipped {
+                    path: format!("OptiFine {optifine_version}"),
+                    reason: format!(
+                        "OptiFine could not be installed automatically: {error}"
+                    ),
+                    project_id: None,
+                    version_id: None,
+                    manual_url: Some(
+                        "https://optifine.net/downloads".to_string(),
+                    ),
+                }],
+            )
+            .await?;
+    }
+
+    reporter.clear_context().await?;
+    Ok(())
+}
+
+/// Installs OptiFine into the instance's mods folder for packs that pair it
+/// with Forge or NeoForge. Requires the instance's Minecraft install to have
+/// completed so the client jar and a Java runtime are available.
+pub(crate) async fn install_optifine_mod(
+    state: &State,
+    instance_id: &str,
+    game_version: &str,
+    optifine_version: &str,
+    instance_path: &std::path::Path,
+) -> crate::Result<()> {
+    let metadata = crate::api::instance::get(instance_id)
+        .await?
+        .ok_or_else(|| {
+            crate::ErrorKind::InputError(format!(
+                "Unknown instance {instance_id}"
+            ))
+        })?;
+    let version_jar = match &metadata.applied_content_set.loader_version {
+        Some(loader_version) => format!("{game_version}-{loader_version}"),
+        None => game_version.to_string(),
+    };
+    let client_jar = state
+        .directories
+        .version_dir(&version_jar)
+        .join(format!("{version_jar}.jar"));
+
+    let (manifest, version_index) =
+        crate::launcher::resolve_minecraft_manifest(game_version, state)
+            .await?;
+    let version_info = crate::launcher::download::download_version_info(
+        state,
+        &manifest.versions[version_index],
+        ModLoader::Vanilla,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await?;
+    let java_key = version_info
+        .java_version
+        .as_ref()
+        .map_or(8, |java| java.major_version);
+    let java = crate::state::JavaVersion::get(java_key, &state.pool)
+        .await?
+        .ok_or_else(|| {
+            crate::ErrorKind::LauncherError(format!(
+                "No Java {java_key} runtime is available for the OptiFine installer"
+            ))
+        })?;
+
+    crate::launcher::optifine::install_optifine_as_mod(
+        state,
+        std::path::Path::new(&java.path),
+        game_version,
+        optifine_version,
+        &client_jar,
+        &instance_path.join("mods"),
+    )
+    .await?;
+    Ok(())
+}

--- a/packages/app-lib/src/api/pack/install_mcbbs.rs
+++ b/packages/app-lib/src/api/pack/install_mcbbs.rs
@@ -335,13 +335,14 @@ pub(crate) async fn install_optifine_mod(
     optifine_version: &str,
     instance_path: &std::path::Path,
 ) -> crate::Result<()> {
-    let metadata = crate::api::instance::get(instance_id)
-        .await?
-        .ok_or_else(|| {
-            crate::ErrorKind::InputError(format!(
-                "Unknown instance {instance_id}"
-            ))
-        })?;
+    let metadata =
+        crate::api::instance::get(instance_id)
+            .await?
+            .ok_or_else(|| {
+                crate::ErrorKind::InputError(format!(
+                    "Unknown instance {instance_id}"
+                ))
+            })?;
     let version_jar = match &metadata.applied_content_set.loader_version {
         Some(loader_version) => format!("{game_version}-{loader_version}"),
         None => game_version.to_string(),

--- a/packages/app-lib/src/api/pack/install_mmc_zip.rs
+++ b/packages/app-lib/src/api/pack/install_mmc_zip.rs
@@ -1,0 +1,62 @@
+//! Installer for MultiMC/Prism export zips.
+//!
+//! Export zips carry the same `mmc-pack.json` + `instance.cfg` layout as an
+//! installed MMC instance, so the archive is extracted to a scratch directory
+//! and imported through the existing MMC instance importer.
+
+use std::path::PathBuf;
+
+use super::archive_util;
+use crate::State;
+use crate::install::{
+    InstallPhaseDetails, InstallPhaseId, InstallProgressReporter,
+};
+use crate::pack::import::ImportLauncherType;
+
+pub(crate) async fn install_mmc_zip_with_reporter(
+    instance_id: String,
+    archive_path: PathBuf,
+    base_folder: String,
+    source_filename: Option<String>,
+    reporter: InstallProgressReporter,
+) -> crate::Result<()> {
+    let state = State::get().await?;
+    let details = InstallPhaseDetails::Import {
+        launcher_type: ImportLauncherType::MultiMC,
+        instance_folder: source_filename.unwrap_or_else(|| {
+            archive_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| "MultiMC pack".to_string())
+        }),
+    };
+    reporter
+        .update(InstallPhaseId::ExtractingOverrides, None, details.clone())
+        .await?;
+
+    let scratch = archive_util::create_import_scratch_dir(&state).await?;
+    let result = async {
+        archive_util::extract_archive_subdir(
+            archive_path,
+            base_folder,
+            scratch.clone(),
+        )
+        .await?;
+        crate::pack::import::mmc::import_mmc_instance_dir(
+            scratch.clone(),
+            Some(scratch.clone()),
+            &instance_id,
+            reporter.clone(),
+            details,
+        )
+        .await
+    }
+    .await;
+    if let Err(error) = tokio::fs::remove_dir_all(&scratch).await {
+        tracing::warn!(
+            "Failed to clean up modpack import scratch directory {}: {error}",
+            scratch.display()
+        );
+    }
+    result
+}

--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -457,8 +457,7 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
                     };
                     (name == format!("{archive_base}icon.png")
                         || name == format!("{overrides_prefix}icon.png")
-                        || name
-                            == format!("{client_overrides_prefix}icon.png"))
+                        || name == format!("{client_overrides_prefix}icon.png"))
                     .then_some(index)
                 },
             );

--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -419,14 +419,19 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
         )
         .await?;
 
-    // Extract index of modrinth.index.json
-    let Some(manifest_idx) = zip_reader.file().entries().iter().position(|f| {
-        matches!(f.filename().as_str(), Ok("modrinth.index.json"))
-    }) else {
+    // Extract index of modrinth.index.json, tolerating packs zipped inside a
+    // single wrapping folder. A root-level manifest always wins so override
+    // files that happen to share the name cannot hijack the base folder.
+    let Some((manifest_idx, archive_base)) =
+        locate_mrpack_manifest(zip_reader.file())
+    else {
         return Err(crate::Error::from(crate::ErrorKind::InputError(
             "No pack manifest found in mrpack".to_string(),
         )));
     };
+    let overrides_prefix = format!("{archive_base}overrides/");
+    let client_overrides_prefix = format!("{archive_base}client-overrides/");
+    let server_overrides_prefix = format!("{archive_base}server-overrides/");
 
     let mut manifest = String::new();
     manifest.push_str(&zip_reader.read_entry_to_string(manifest_idx).await?);
@@ -447,12 +452,13 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
         let icon_entry =
             zip_reader.file().entries().iter().enumerate().find_map(
                 |(index, entry)| {
-                    matches!(
-                        entry.filename().as_str(),
-                        Ok("icon.png"
-                            | "overrides/icon.png"
-                            | "client-overrides/icon.png")
-                    )
+                    let Ok(name) = entry.filename().as_str() else {
+                        return None;
+                    };
+                    (name == format!("{archive_base}icon.png")
+                        || name == format!("{overrides_prefix}icon.png")
+                        || name
+                            == format!("{client_overrides_prefix}icon.png"))
                     .then_some(index)
                 },
             );
@@ -490,9 +496,9 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
             .enumerate()
             .filter_map(|(index, entry)| {
                 let filename = entry.filename().as_str().ok()?;
-                let is_override = (filename.starts_with("overrides/")
-                    || filename.starts_with("client-overrides/")
-                    || filename.starts_with("server-overrides/"))
+                let is_override = (filename.starts_with(&overrides_prefix)
+                    || filename.starts_with(&client_overrides_prefix)
+                    || filename.starts_with(&server_overrides_prefix))
                     && !filename.ends_with('/');
                 is_override.then_some(index)
             })
@@ -879,8 +885,8 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
         .enumerate()
         .filter_map(|(index, file)| {
             let filename = file.filename().as_str().unwrap_or_default();
-            ((filename.starts_with("overrides/")
-                || filename.starts_with("client-overrides/"))
+            ((filename.starts_with(&overrides_prefix)
+                || filename.starts_with(&client_overrides_prefix))
                 && !filename.ends_with('/'))
             .then(|| (index, file.clone()))
         })
@@ -939,10 +945,11 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
     };
 
     for (index, file) in override_file_entries {
+        let entry_name = file.filename().as_str().unwrap();
+        let entry_name =
+            entry_name.strip_prefix(&archive_base).unwrap_or(entry_name);
         let relative_override_file_path =
-            SafeRelativeUtf8UnixPathBuf::try_from(
-                file.filename().as_str().unwrap().to_string(),
-            )?;
+            SafeRelativeUtf8UnixPathBuf::try_from(entry_name.to_string())?;
         let relative_override_file_path = relative_override_file_path
             .strip_prefix("overrides")
             .or_else(|_| relative_override_file_path.strip_prefix("client-overrides"))
@@ -1063,6 +1070,29 @@ fn pack_source_path(file: &CreatePackFile) -> String {
     }
 }
 
+/// Finds the `modrinth.index.json` entry and the archive base folder it lives
+/// in. The exact root entry is preferred; a manifest one wrapping folder deep
+/// is accepted as a fallback.
+fn locate_mrpack_manifest(
+    zip_file: &async_zip::ZipFile,
+) -> Option<(usize, String)> {
+    let entries = zip_file.entries();
+    entries
+        .iter()
+        .position(|f| {
+            matches!(f.filename().as_str(), Ok("modrinth.index.json"))
+        })
+        .map(|index| (index, String::new()))
+        .or_else(|| {
+            entries.iter().enumerate().find_map(|(index, f)| {
+                let name = f.filename().as_str().ok()?;
+                let (base, rest) = name.split_once('/')?;
+                (rest == "modrinth.index.json")
+                    .then(|| (index, format!("{base}/")))
+            })
+        })
+}
+
 fn modpack_source_kind(version_id: Option<&str>) -> ContentSourceKind {
     if version_id.is_some() {
         ContentSourceKind::ModrinthModpack
@@ -1081,13 +1111,15 @@ pub async fn remove_all_related_files(
     let mut zip_reader = MrpackZipReader::new(&mrpack_file).await?;
 
     // Extract index of modrinth.index.json
-    let Some(manifest_idx) = zip_reader.file().entries().iter().position(|f| {
-        matches!(f.filename().as_str(), Ok("modrinth.index.json"))
-    }) else {
+    let Some((manifest_idx, archive_base)) =
+        locate_mrpack_manifest(zip_reader.file())
+    else {
         return Err(crate::Error::from(crate::ErrorKind::InputError(
             "No pack manifest found in mrpack".to_string(),
         )));
     };
+    let overrides_prefix = format!("{archive_base}overrides/");
+    let client_overrides_prefix = format!("{archive_base}client-overrides/");
 
     let manifest = zip_reader.read_entry_to_string(manifest_idx).await?;
 
@@ -1176,16 +1208,17 @@ pub async fn remove_all_related_files(
     let override_file_entries =
         zip_reader.file().entries().iter().filter(|file| {
             let filename = file.filename().as_str().unwrap_or_default();
-            (filename.starts_with("overrides/")
-                || filename.starts_with("client-overrides/"))
+            (filename.starts_with(&overrides_prefix)
+                || filename.starts_with(&client_overrides_prefix))
                 && !filename.ends_with('/')
         });
 
     for file in override_file_entries {
+        let entry_name = file.filename().as_str().unwrap();
+        let entry_name =
+            entry_name.strip_prefix(&archive_base).unwrap_or(entry_name);
         let relative_override_file_path =
-            SafeRelativeUtf8UnixPathBuf::try_from(
-                file.filename().as_str().unwrap().to_string(),
-            )?;
+            SafeRelativeUtf8UnixPathBuf::try_from(entry_name.to_string())?;
         let relative_override_file_path = relative_override_file_path
             .strip_prefix("overrides")
             .or_else(|_| relative_override_file_path.strip_prefix("client-overrides"))

--- a/packages/app-lib/src/api/pack/install_plain_archive.rs
+++ b/packages/app-lib/src/api/pack/install_plain_archive.rs
@@ -89,8 +89,7 @@ fn detect_target(version_json: &PlainVersionJson) -> Option<DetectedTarget> {
                 let forge_version = version
                     .split_once('-')
                     .map(|(mc, forge)| {
-                        if game_version.is_none()
-                            && looks_like_game_version(mc)
+                        if game_version.is_none() && looks_like_game_version(mc)
                         {
                             game_version = Some(mc.to_string());
                         }
@@ -149,12 +148,11 @@ async fn read_version_candidates(
         let mut candidates = Vec::new();
         for index in 0..archive.len() {
             let name = {
-                let entry =
-                    archive.by_index_raw(index).map_err(|error| {
-                        crate::ErrorKind::InputError(format!(
-                            "Failed to read modpack archive entry: {error}"
-                        ))
-                    })?;
+                let entry = archive.by_index_raw(index).map_err(|error| {
+                    crate::ErrorKind::InputError(format!(
+                        "Failed to read modpack archive entry: {error}"
+                    ))
+                })?;
                 crate::pack::detect::decode_zip_entry_name(entry.name_raw())
             };
             let Some(rest) = name.strip_prefix(&versions_prefix) else {

--- a/packages/app-lib/src/api/pack/install_plain_archive.rs
+++ b/packages/app-lib/src/api/pack/install_plain_archive.rs
@@ -1,0 +1,310 @@
+//! Installer for plain zipped-up game folders.
+//!
+//! These archives have no pack manifest at all — they are a `.minecraft`
+//! folder (optionally wrapped in extra directories) identified by a
+//! `versions/<id>/<id>.json` structure. The version JSON is inspected to
+//! guess the game version and loader, and the folder contents become the
+//! instance's game directory.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::archive_util;
+use crate::data::ModLoader;
+use crate::install::{
+    InstallPhaseDetails, InstallPhaseId, InstallProgressReporter,
+};
+use crate::state::{
+    AppliedContentSetPatch, ContentSourceKind, EditInstance,
+    InstanceInstallStage, InstanceLink,
+};
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct PlainVersionJson {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    inherits_from: Option<String>,
+    #[serde(default)]
+    libraries: Vec<PlainLibrary>,
+}
+
+#[derive(Deserialize, Debug)]
+struct PlainLibrary {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+fn looks_like_game_version(value: &str) -> bool {
+    let mut parts = value.split('.');
+    parts.next().is_some_and(|part| part.parse::<u32>().is_ok())
+        && value.split('.').skip(1).all(|part| {
+            part.split('-')
+                .next()
+                .is_some_and(|part| part.parse::<u32>().is_ok())
+        })
+}
+
+struct DetectedTarget {
+    game_version: String,
+    loader: ModLoader,
+    loader_version: Option<String>,
+}
+
+fn detect_target(version_json: &PlainVersionJson) -> Option<DetectedTarget> {
+    let mut game_version = version_json
+        .inherits_from
+        .clone()
+        .filter(|value| looks_like_game_version(value));
+    let mut loader = ModLoader::Vanilla;
+    let mut loader_version = None;
+
+    for library in &version_json.libraries {
+        let Some(name) = &library.name else {
+            continue;
+        };
+        let parts: Vec<&str> = name.split(':').collect();
+        if parts.len() < 3 {
+            continue;
+        }
+        let (group, artifact, version) = (parts[0], parts[1], parts[2]);
+        match (group, artifact) {
+            ("net.fabricmc", "fabric-loader") => {
+                loader = ModLoader::Fabric;
+                loader_version = Some(version.to_string());
+            }
+            ("org.quiltmc", "quilt-loader") => {
+                loader = ModLoader::Quilt;
+                loader_version = Some(version.to_string());
+            }
+            ("net.neoforged", "neoforge" | "forge") => {
+                loader = ModLoader::NeoForge;
+                loader_version = Some(version.to_string());
+            }
+            ("net.minecraftforge", "forge" | "fmlloader") => {
+                loader = ModLoader::Forge;
+                // Forge versions are usually stored as `<mc>-<forge>`.
+                let forge_version = version
+                    .split_once('-')
+                    .map(|(mc, forge)| {
+                        if game_version.is_none()
+                            && looks_like_game_version(mc)
+                        {
+                            game_version = Some(mc.to_string());
+                        }
+                        forge.to_string()
+                    })
+                    .unwrap_or_else(|| version.to_string());
+                loader_version = Some(forge_version);
+            }
+            ("optifine", "OptiFine") => {
+                if loader == ModLoader::Vanilla {
+                    loader = ModLoader::OptiFine;
+                    // OptiFine library versions look like `<mc>_HD_U_I6`.
+                    loader_version = Some(
+                        version
+                            .split_once('_')
+                            .map(|(_, of)| of.to_string())
+                            .unwrap_or_else(|| version.to_string()),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if game_version.is_none()
+        && let Some(id) = &version_json.id
+        && looks_like_game_version(id)
+    {
+        game_version = Some(id.clone());
+    }
+
+    game_version.map(|game_version| DetectedTarget {
+        game_version,
+        loader,
+        loader_version,
+    })
+}
+
+/// Reads every `versions/<id>/<id>.json` under the base folder. Archives of
+/// modded installs usually contain both the vanilla and the modded version
+/// folder, so all candidates are needed to pick the right one.
+async fn read_version_candidates(
+    archive_path: PathBuf,
+    base_folder: String,
+) -> crate::Result<Vec<(String, PlainVersionJson)>> {
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&archive_path).map_err(|error| {
+            crate::util::io::IOError::with_path(error, &archive_path)
+        })?;
+        let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+            crate::ErrorKind::InputError(format!(
+                "Modpack archive is invalid: {error}"
+            ))
+        })?;
+        let versions_prefix = format!("{base_folder}versions/");
+        let mut candidates = Vec::new();
+        for index in 0..archive.len() {
+            let name = {
+                let entry =
+                    archive.by_index_raw(index).map_err(|error| {
+                        crate::ErrorKind::InputError(format!(
+                            "Failed to read modpack archive entry: {error}"
+                        ))
+                    })?;
+                crate::pack::detect::decode_zip_entry_name(entry.name_raw())
+            };
+            let Some(rest) = name.strip_prefix(&versions_prefix) else {
+                continue;
+            };
+            let mut segments = rest.split('/');
+            let (Some(id), Some(json), None) =
+                (segments.next(), segments.next(), segments.next())
+            else {
+                continue;
+            };
+            if json.strip_suffix(".json") != Some(id) {
+                continue;
+            }
+            let id = id.to_string();
+            let mut entry = archive.by_index(index).map_err(|error| {
+                crate::ErrorKind::InputError(format!(
+                    "Failed to read modpack archive entry: {error}"
+                ))
+            })?;
+            let mut contents = Vec::new();
+            std::io::Read::read_to_end(&mut entry, &mut contents)?;
+            if let Ok(parsed) =
+                serde_json::from_slice::<PlainVersionJson>(&contents)
+            {
+                candidates.push((id, parsed));
+            }
+        }
+        Ok(candidates)
+    })
+    .await?
+}
+
+pub(crate) async fn install_plain_archive_with_reporter(
+    instance_id: String,
+    archive_path: PathBuf,
+    base_folder: String,
+    version_id: String,
+    source_filename: Option<String>,
+    reporter: InstallProgressReporter,
+) -> crate::Result<()> {
+    let candidates =
+        read_version_candidates(archive_path.clone(), base_folder.clone())
+            .await?;
+    let mut targets: Vec<(String, DetectedTarget)> = candidates
+        .iter()
+        .filter_map(|(id, json)| {
+            detect_target(json).map(|target| (id.clone(), target))
+        })
+        .collect();
+    let selected = targets
+        .iter()
+        .position(|(_, target)| target.loader != ModLoader::Vanilla)
+        .map(|index| targets.remove(index))
+        .or_else(|| {
+            if targets.is_empty() {
+                None
+            } else {
+                Some(targets.remove(0))
+            }
+        });
+    let Some((selected_id, target)) = selected else {
+        return Err(crate::ErrorKind::InputError(format!(
+            "Could not determine the Minecraft version of archived instance {version_id}"
+        ))
+        .into());
+    };
+
+    let pack_name = if selected_id.trim().is_empty() {
+        source_filename
+            .as_ref()
+            .map(|name| {
+                std::path::Path::new(name)
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .unwrap_or_else(|| "Imported Instance".to_string())
+    } else {
+        selected_id.clone()
+    };
+    let pack_details = InstallPhaseDetails::Modpack {
+        project_id: None,
+        version_id: None,
+        title: Some(pack_name.clone()),
+    };
+    reporter
+        .update(InstallPhaseId::ResolvingPack, None, pack_details.clone())
+        .await?;
+
+    let resolved_loader_version = if target.loader != ModLoader::Vanilla {
+        crate::launcher::get_loader_version_from_profile(
+            &target.game_version,
+            target.loader,
+            target.loader_version.as_deref(),
+        )
+        .await?
+    } else {
+        None
+    };
+
+    crate::api::instance::edit(
+        &instance_id,
+        EditInstance {
+            install_stage: Some(InstanceInstallStage::PackInstalling),
+            name: Some(pack_name.clone()),
+            link: Some(InstanceLink::ImportedModpack {
+                project_id: None,
+                version_id: None,
+                name: Some(pack_name),
+                version_number: None,
+                filename: source_filename,
+            }),
+            content_set_patch: Some(AppliedContentSetPatch {
+                source_kind: Some(ContentSourceKind::ImportedModpack),
+                game_version: Some(target.game_version.clone()),
+                protocol_version: Some(None),
+                loader: Some(target.loader),
+                loader_version: Some(
+                    resolved_loader_version.map(|version| version.id),
+                ),
+            }),
+            ..EditInstance::default()
+        },
+    )
+    .await?;
+
+    reporter
+        .update(
+            InstallPhaseId::ExtractingOverrides,
+            None,
+            pack_details.clone(),
+        )
+        .await?;
+    let instance_path =
+        crate::api::instance::get_full_path(&instance_id).await?;
+    archive_util::extract_archive_subdir(
+        archive_path,
+        base_folder,
+        instance_path,
+    )
+    .await?;
+
+    crate::launcher::install_minecraft_for_instance_id_with_reporter(
+        &instance_id,
+        false,
+        Some(reporter.clone()),
+    )
+    .await?;
+    reporter.clear_context().await?;
+    Ok(())
+}

--- a/packages/app-lib/src/api/pack/mod.rs
+++ b/packages/app-lib/src/api/pack/mod.rs
@@ -1,3 +1,9 @@
+pub(crate) mod archive_util;
+pub mod detect;
 pub mod import;
 pub mod install_from;
+pub(crate) mod install_hmcl;
+pub(crate) mod install_mcbbs;
+pub(crate) mod install_mmc_zip;
 pub mod install_mrpack;
+pub(crate) mod install_plain_archive;

--- a/packages/app-lib/src/install/runner.rs
+++ b/packages/app-lib/src/install/runner.rs
@@ -1198,22 +1198,21 @@ async fn install_local_pack_file(
             let inner_detected =
                 crate::api::pack::detect::detect_local_pack(&inner_path)
                     .await?;
-            let result = if inner_detected.format
-                == LocalPackFormat::LauncherBundled
-            {
-                Err(ErrorKind::InputError(
-                    "Nested launcher bundles are not supported".to_string(),
-                )
-                .into())
-            } else {
-                Box::pin(install_local_pack_file(
-                    inner_detected,
-                    inner_path,
-                    instance_id,
-                    reporter,
-                ))
-                .await
-            };
+            let result =
+                if inner_detected.format == LocalPackFormat::LauncherBundled {
+                    Err(ErrorKind::InputError(
+                        "Nested launcher bundles are not supported".to_string(),
+                    )
+                    .into())
+                } else {
+                    Box::pin(install_local_pack_file(
+                        inner_detected,
+                        inner_path,
+                        instance_id,
+                        reporter,
+                    ))
+                    .await
+                };
             if let Err(error) = tokio::fs::remove_dir_all(&scratch).await {
                 tracing::warn!(
                     "Failed to clean up modpack import scratch directory {}: {error}",

--- a/packages/app-lib/src/install/runner.rs
+++ b/packages/app-lib/src/install/runner.rs
@@ -961,6 +961,7 @@ async fn remove_existing_imported_pack_content(
             entry.source_kind,
             ContentSourceKind::ImportedModpack
                 | ContentSourceKind::ModrinthModpack
+                | ContentSourceKind::CurseForge
         ) {
             continue;
         }
@@ -1075,6 +1076,19 @@ async fn install_pack(
                         .build(),
                 )
                 .await?;
+            let detected =
+                crate::api::pack::detect::detect_local_pack(&path).await?;
+            if detected.format
+                != crate::api::pack::detect::LocalPackFormat::Mrpack
+            {
+                return install_local_pack_file(
+                    detected,
+                    path,
+                    instance_id,
+                    reporter,
+                )
+                .await;
+            }
             generate_pack_from_file(path, instance_id.clone()).await?
         }
     };
@@ -1087,6 +1101,145 @@ async fn install_pack(
     )
     .await?;
 
+    Ok(())
+}
+
+/// Dispatches a local non-mrpack modpack file to its format-specific
+/// installer, based on the detected pack format.
+async fn install_local_pack_file(
+    detected: crate::api::pack::detect::DetectedLocalPack,
+    path: PathBuf,
+    instance_id: String,
+    reporter: InstallProgressReporter,
+) -> crate::Result<()> {
+    use crate::api::pack::detect::LocalPackFormat;
+
+    let source_filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string());
+    match detected.format {
+        LocalPackFormat::Mrpack => {
+            let create_pack =
+                generate_pack_from_file(path, instance_id.clone()).await?;
+            install_zipped_mrpack_files_with_reporter(
+                create_pack,
+                false,
+                DownloadReason::Modpack,
+                reporter,
+            )
+            .await?;
+        }
+        LocalPackFormat::CurseForge => {
+            crate::api::curseforge::install_modpack_from_local_archive_with_reporter(
+                instance_id,
+                path,
+                detected.base_folder,
+                source_filename,
+                false,
+                reporter,
+            )
+            .await?;
+        }
+        LocalPackFormat::Mcbbs => {
+            crate::api::pack::install_mcbbs::install_mcbbs_pack_with_reporter(
+                instance_id,
+                path,
+                detected.base_folder,
+                source_filename,
+                reporter,
+            )
+            .await?;
+        }
+        LocalPackFormat::Hmcl => {
+            crate::api::pack::install_hmcl::install_hmcl_pack_with_reporter(
+                instance_id,
+                path,
+                detected.base_folder,
+                source_filename,
+                reporter,
+            )
+            .await?;
+        }
+        LocalPackFormat::MmcExport => {
+            crate::api::pack::install_mmc_zip::install_mmc_zip_with_reporter(
+                instance_id,
+                path,
+                detected.base_folder,
+                source_filename,
+                reporter,
+            )
+            .await?;
+        }
+        LocalPackFormat::LauncherBundled => {
+            let inner_entry = detected.inner_pack_entry.ok_or_else(|| {
+                ErrorKind::InputError(
+                    "Launcher bundle is missing its inner modpack file"
+                        .to_string(),
+                )
+            })?;
+            let state = State::get().await?;
+            let scratch =
+                crate::api::pack::archive_util::create_import_scratch_dir(
+                    &state,
+                )
+                .await?;
+            let inner_name = inner_entry
+                .rsplit('/')
+                .next()
+                .unwrap_or("modpack.zip")
+                .to_string();
+            let inner_path = scratch.join(&inner_name);
+            crate::api::pack::archive_util::extract_archive_entry_to_file(
+                path,
+                inner_entry,
+                inner_path.clone(),
+            )
+            .await?;
+            let inner_detected =
+                crate::api::pack::detect::detect_local_pack(&inner_path)
+                    .await?;
+            let result = if inner_detected.format
+                == LocalPackFormat::LauncherBundled
+            {
+                Err(ErrorKind::InputError(
+                    "Nested launcher bundles are not supported".to_string(),
+                )
+                .into())
+            } else {
+                Box::pin(install_local_pack_file(
+                    inner_detected,
+                    inner_path,
+                    instance_id,
+                    reporter,
+                ))
+                .await
+            };
+            if let Err(error) = tokio::fs::remove_dir_all(&scratch).await {
+                tracing::warn!(
+                    "Failed to clean up modpack import scratch directory {}: {error}",
+                    scratch.display()
+                );
+            }
+            return result;
+        }
+        LocalPackFormat::PlainArchive => {
+            let version_id = detected.plain_version_id.ok_or_else(|| {
+                ErrorKind::InputError(
+                    "Could not locate the instance version in the archive"
+                        .to_string(),
+                )
+            })?;
+            crate::api::pack::install_plain_archive::install_plain_archive_with_reporter(
+                instance_id,
+                path,
+                detected.base_folder,
+                version_id,
+                source_filename,
+                reporter,
+            )
+            .await?;
+        }
+    }
     Ok(())
 }
 

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -92,6 +92,33 @@ impl MinecraftDownloadProgress {
         self.emit_if_needed(current, total, false).await
     }
 
+    /// Rolls back bytes that were counted for an abandoned download attempt,
+    /// so retried files do not inflate the progress bar to 100% early.
+    async fn sub_bytes(&self, bytes: u64) -> crate::Result<()> {
+        if bytes == 0 {
+            return Ok(());
+        }
+
+        let mut current = self.current.load(Ordering::Relaxed);
+        loop {
+            let next = current.saturating_sub(bytes);
+            match self.current.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    current = next;
+                    break;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+        let total = self.total.load(Ordering::Relaxed);
+        self.emit_if_needed(current, total, true).await
+    }
+
     async fn emit_if_needed(
         &self,
         current: u64,
@@ -220,9 +247,16 @@ async fn download_minecraft_file(
               -> Pin<Box<dyn Future<Output = crate::Result<()>> + Send>> {
             let previous =
                 last_downloaded.swap(downloaded, Ordering::Relaxed);
-            let delta = downloaded.saturating_sub(previous);
             let progress = progress.clone();
-            Box::pin(async move { progress.add_bytes(delta).await })
+            Box::pin(async move {
+                if downloaded >= previous {
+                    progress.add_bytes(downloaded - previous).await
+                } else {
+                    // The downloaded count went backwards, meaning a failed
+                    // attempt restarted; un-count the abandoned bytes.
+                    progress.sub_bytes(previous - downloaded).await
+                }
+            })
         }
     };
 

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -724,16 +724,25 @@ pub async fn download_version_info(
                     )
                     .await?;
             }
-            let partial: d::modded::PartialVersionInfo = fetch_json(
-                Method::GET,
-                &loader.url,
-                None,
-                None,
-                None,
-                &st.api_semaphore,
-                &st.pool,
-            )
-            .await?;
+            let partial: d::modded::PartialVersionInfo = if mod_loader
+                == ModLoader::OptiFine
+            {
+                crate::launcher::optifine::build_partial_version_info(
+                    st, &info, &version.id, &loader.id,
+                )
+                .await?
+            } else {
+                fetch_json(
+                    Method::GET,
+                    &loader.url,
+                    None,
+                    None,
+                    None,
+                    &st.api_semaphore,
+                    &st.pool,
+                )
+                .await?
+            };
             info = d::modded::merge_partial_version(partial, info);
         }
 

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -724,25 +724,27 @@ pub async fn download_version_info(
                     )
                     .await?;
             }
-            let partial: d::modded::PartialVersionInfo = if mod_loader
-                == ModLoader::OptiFine
-            {
-                crate::launcher::optifine::build_partial_version_info(
-                    st, &info, &version.id, &loader.id,
-                )
-                .await?
-            } else {
-                fetch_json(
-                    Method::GET,
-                    &loader.url,
-                    None,
-                    None,
-                    None,
-                    &st.api_semaphore,
-                    &st.pool,
-                )
-                .await?
-            };
+            let partial: d::modded::PartialVersionInfo =
+                if mod_loader == ModLoader::OptiFine {
+                    crate::launcher::optifine::build_partial_version_info(
+                        st,
+                        &info,
+                        &version.id,
+                        &loader.id,
+                    )
+                    .await?
+                } else {
+                    fetch_json(
+                        Method::GET,
+                        &loader.url,
+                        None,
+                        None,
+                        None,
+                        &st.api_semaphore,
+                        &st.pool,
+                    )
+                    .await?
+                };
             info = d::modded::merge_partial_version(partial, info);
         }
 

--- a/packages/app-lib/src/launcher/mod.rs
+++ b/packages/app-lib/src/launcher/mod.rs
@@ -36,6 +36,7 @@ use tokio::process::Command;
 mod args;
 
 pub mod download;
+pub mod optifine;
 pub mod quick_play_version;
 
 // All nones -> disallowed
@@ -179,6 +180,11 @@ pub async fn get_loader_version_from_profile_with_cache(
 ) -> crate::Result<Option<LoaderVersion>> {
     if loader == ModLoader::Vanilla {
         return Ok(None);
+    }
+
+    if loader == ModLoader::OptiFine {
+        return optifine::resolve_loader_version(game_version, loader_version)
+            .await;
     }
 
     let version = loader_version.unwrap_or("latest");
@@ -495,6 +501,29 @@ pub async fn install_minecraft_with_reporter(
         .directories
         .version_dir(&version_jar)
         .join(format!("{version_jar}.jar"));
+
+    if content_set.loader == ModLoader::OptiFine
+        && let Some(loader_version) = &loader_version
+    {
+        if let Some(reporter) = &reporter {
+            reporter
+                .update(
+                    InstallPhaseId::RunningLoaderProcessors,
+                    None,
+                    phase_details.clone(),
+                )
+                .await?;
+        }
+        optifine::install_optifine_libraries(
+            &state,
+            std::path::Path::new(&java_version.path),
+            &content_set.game_version,
+            &loader_version.id,
+            &client_path,
+        )
+        .await?;
+    }
+
     if let Some(processors) = &version_info.processors {
         let libraries_dir = state.directories.libraries_dir();
 

--- a/packages/app-lib/src/launcher/optifine.rs
+++ b/packages/app-lib/src/launcher/optifine.rs
@@ -1,0 +1,462 @@
+//! OptiFine loader support.
+//!
+//! OptiFine has no official metadata API, so available versions and installer
+//! downloads are resolved through BMCLAPI. Standalone OptiFine instances are
+//! launched through LaunchWrapper with `optifine.OptiFineTweaker`, mirroring
+//! the approach used by HMCL and PCL.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use daedalus::minecraft::{
+    Argument, ArgumentType, Library, VersionInfo as GameVersionInfo,
+};
+use daedalus::modded::{LoaderVersion, PartialVersionInfo};
+use reqwest::Method;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use crate::State;
+use crate::util::fetch::{
+    ContentValidation, DownloadRequest, Integrity, ResourceClass,
+    download_to_path, fetch_json,
+};
+use crate::util::io;
+
+const BMCLAPI_OPTIFINE_BASE: &str = "https://bmclapi2.bangbang93.com/optifine";
+pub const OPTIFINE_LOADER_PREFIX: &str = "OptiFine_";
+const OPTIFINE_TWEAK_CLASS: &str = "optifine.OptiFineTweaker";
+const LAUNCH_WRAPPER_MAIN_CLASS: &str = "net.minecraft.launchwrapper.Launch";
+const FALLBACK_LAUNCH_WRAPPER: &str = "net.minecraft:launchwrapper:1.12";
+
+#[derive(Deserialize, Debug, Clone)]
+struct BmclapiOptifineEntry {
+    mcversion: String,
+    #[serde(rename = "type")]
+    type_: String,
+    patch: String,
+}
+
+impl BmclapiOptifineEntry {
+    fn version_id(&self) -> String {
+        format!("{}_{}", self.type_, self.patch)
+    }
+
+    fn download_url(&self) -> String {
+        format!(
+            "{BMCLAPI_OPTIFINE_BASE}/{}/{}/{}",
+            self.mcversion, self.type_, self.patch
+        )
+    }
+
+    fn is_stable(&self) -> bool {
+        !self.patch.to_ascii_lowercase().contains("pre")
+    }
+}
+
+async fn list_entries(
+    game_version: &str,
+) -> crate::Result<Vec<BmclapiOptifineEntry>> {
+    let state = State::get().await?;
+    let entries: Vec<BmclapiOptifineEntry> = fetch_json(
+        Method::GET,
+        &format!("{BMCLAPI_OPTIFINE_BASE}/{game_version}"),
+        None,
+        None,
+        None,
+        &state.api_semaphore,
+        &state.pool,
+    )
+    .await?;
+    Ok(entries
+        .into_iter()
+        .filter(|entry| entry.mcversion == game_version)
+        .collect())
+}
+
+/// Lists installable OptiFine versions for a game version as loader versions,
+/// ordered oldest to newest as reported by BMCLAPI.
+pub async fn list_loader_versions(
+    game_version: &str,
+) -> crate::Result<Vec<LoaderVersion>> {
+    Ok(list_entries(game_version)
+        .await?
+        .iter()
+        .map(|entry| LoaderVersion {
+            id: format!("{OPTIFINE_LOADER_PREFIX}{}", entry.version_id()),
+            url: entry.download_url(),
+            stable: entry.is_stable(),
+        })
+        .collect())
+}
+
+/// Strips launcher-specific prefixes so pack-provided OptiFine version strings
+/// like `OptiFine_1.12.2_HD_U_G5`, `1.12.2_HD_U_G5`, or `HD_U_G5` all resolve
+/// to the same BMCLAPI entry.
+fn normalize_version_id(game_version: &str, requested: &str) -> String {
+    let mut value = requested.trim();
+    if let Some(stripped) = value.strip_prefix(OPTIFINE_LOADER_PREFIX) {
+        value = stripped;
+    }
+    if let Some(stripped) = value.strip_prefix(game_version)
+        && let Some(stripped) = stripped.strip_prefix('_')
+    {
+        value = stripped;
+    }
+    value.to_string()
+}
+
+pub async fn resolve_loader_version(
+    game_version: &str,
+    requested: Option<&str>,
+) -> crate::Result<Option<LoaderVersion>> {
+    let resolved = match requested.unwrap_or("latest") {
+        "latest" => list_loader_versions(game_version).await?.pop(),
+        "stable" => {
+            let versions = list_loader_versions(game_version).await?;
+            versions
+                .iter()
+                .rev()
+                .find(|version| version.stable)
+                .or(versions.last())
+                .cloned()
+        }
+        // A pinned version resolves without the network so offline launches of
+        // installed instances keep working; the installer download resolves
+        // the actual BMCLAPI URL itself when needed.
+        id => {
+            let of_id = normalize_version_id(game_version, id);
+            Some(LoaderVersion {
+                id: format!("{OPTIFINE_LOADER_PREFIX}{of_id}"),
+                url: String::new(),
+                stable: !of_id.to_ascii_lowercase().contains("pre"),
+            })
+        }
+    };
+    Ok(resolved)
+}
+
+fn optifine_library_name(game_version: &str, of_id: &str) -> String {
+    format!("optifine:OptiFine:{game_version}_{of_id}")
+}
+
+fn library(name: String, downloadable: bool) -> Library {
+    Library {
+        downloads: None,
+        extract: None,
+        name,
+        url: None,
+        natives: None,
+        rules: None,
+        checksums: None,
+        include_in_classpath: true,
+        downloadable,
+    }
+}
+
+struct InstallerInfo {
+    launchwrapper_library: Library,
+    launchwrapper_entry: Option<String>,
+    needs_patching: bool,
+}
+
+fn inspect_installer(path: &Path) -> crate::Result<InstallerInfo> {
+    let file = std::fs::File::open(path)
+        .map_err(|error| io::IOError::with_path(error, path))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+        crate::ErrorKind::InputError(format!(
+            "OptiFine installer archive is invalid: {error}"
+        ))
+    })?;
+
+    let mut launchwrapper_version = None;
+    if let Ok(mut entry) = archive.by_name("launchwrapper-of.txt") {
+        let mut version = String::new();
+        entry.read_to_string(&mut version)?;
+        let version = version.trim().to_string();
+        if !version.is_empty() {
+            launchwrapper_version = Some(version);
+        }
+    }
+    if launchwrapper_version.is_none() {
+        launchwrapper_version = archive.file_names().find_map(|name| {
+            name.strip_prefix("launchwrapper-of-")
+                .and_then(|rest| rest.strip_suffix(".jar"))
+                .map(str::to_string)
+        });
+    }
+
+    let needs_patching = archive.by_name("optifine/Patcher.class").is_ok();
+
+    let (launchwrapper_library, launchwrapper_entry) =
+        match launchwrapper_version {
+            Some(version) => (
+                library(
+                    format!("optifine:launchwrapper-of:{version}"),
+                    false,
+                ),
+                Some(format!("launchwrapper-of-{version}.jar")),
+            ),
+            // Very old OptiFine builds ship without their own LaunchWrapper;
+            // Mojang's launchwrapper 1.12 from libraries.minecraft.net works.
+            None => (library(FALLBACK_LAUNCH_WRAPPER.to_string(), true), None),
+        };
+
+    Ok(InstallerInfo {
+        launchwrapper_library,
+        launchwrapper_entry,
+        needs_patching,
+    })
+}
+
+async fn ensure_installer(
+    state: &State,
+    game_version: &str,
+    of_id: &str,
+) -> crate::Result<PathBuf> {
+    let path = state
+        .directories
+        .caches_dir()
+        .join("optifine")
+        .join(game_version)
+        .join(format!("{OPTIFINE_LOADER_PREFIX}{of_id}.jar"));
+    if path.is_file() {
+        return Ok(path);
+    }
+
+    let entries = list_entries(game_version).await?;
+    let entry = entries
+        .iter()
+        .find(|entry| entry.version_id() == of_id)
+        .ok_or_else(|| {
+            crate::ErrorKind::InputError(format!(
+                "OptiFine {of_id} is not available for Minecraft {game_version}"
+            ))
+        })?;
+
+    download_to_path(
+        DownloadRequest::new(&entry.download_url(), ResourceClass::Loader)
+            .with_integrity(Integrity {
+                content: ContentValidation::Jar,
+                ..Integrity::default()
+            }),
+        &path,
+        &state.download_semaphore,
+        &state.pool,
+        None,
+    )
+    .await?;
+
+    Ok(path)
+}
+
+fn strip_loader_prefix(loader_version_id: &str) -> &str {
+    loader_version_id
+        .strip_prefix(OPTIFINE_LOADER_PREFIX)
+        .unwrap_or(loader_version_id)
+}
+
+/// Builds the loader profile for a standalone OptiFine version locally, taking
+/// the place of the Daedalus partial version metadata used by other loaders.
+pub(crate) async fn build_partial_version_info(
+    state: &State,
+    vanilla: &GameVersionInfo,
+    game_version: &str,
+    loader_version_id: &str,
+) -> crate::Result<PartialVersionInfo> {
+    let of_id = strip_loader_prefix(loader_version_id).to_string();
+    let installer = ensure_installer(state, game_version, &of_id).await?;
+    let installer_for_inspect = installer.clone();
+    let info = tokio::task::spawn_blocking(move || {
+        inspect_installer(&installer_for_inspect)
+    })
+    .await??;
+
+    let libraries = vec![
+        library(optifine_library_name(game_version, &of_id), false),
+        info.launchwrapper_library,
+    ];
+
+    let mut minecraft_arguments = None;
+    let mut arguments = None;
+    if let Some(vanilla_arguments) = &vanilla.minecraft_arguments {
+        minecraft_arguments = Some(format!(
+            "{vanilla_arguments} --tweakClass {OPTIFINE_TWEAK_CLASS}"
+        ));
+    } else {
+        arguments = Some(HashMap::from([(
+            ArgumentType::Game,
+            vec![
+                Argument::Normal("--tweakClass".to_string()),
+                Argument::Normal(OPTIFINE_TWEAK_CLASS.to_string()),
+            ],
+        )]));
+    }
+
+    Ok(PartialVersionInfo {
+        id: format!("{game_version}-{loader_version_id}"),
+        inherits_from: game_version.to_string(),
+        release_time: vanilla.release_time,
+        time: vanilla.time,
+        main_class: Some(LAUNCH_WRAPPER_MAIN_CLASS.to_string()),
+        minecraft_arguments,
+        arguments,
+        libraries,
+        type_: vanilla.type_.clone(),
+        data: None,
+        processors: None,
+    })
+}
+
+fn extract_installer_entry(
+    installer: &Path,
+    entry_name: &str,
+    target: &Path,
+) -> crate::Result<()> {
+    let file = std::fs::File::open(installer)
+        .map_err(|error| io::IOError::with_path(error, installer))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+        crate::ErrorKind::InputError(format!(
+            "OptiFine installer archive is invalid: {error}"
+        ))
+    })?;
+    let mut entry = archive.by_name(entry_name).map_err(|_| {
+        crate::ErrorKind::InputError(format!(
+            "OptiFine installer is missing {entry_name}"
+        ))
+    })?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| io::IOError::with_path(error, parent))?;
+    }
+    let mut output = std::fs::File::create(target)
+        .map_err(|error| io::IOError::with_path(error, target))?;
+    std::io::copy(&mut entry, &mut output)
+        .map_err(|error| io::IOError::with_path(error, target))?;
+    Ok(())
+}
+
+/// Materializes the OptiFine libraries after the vanilla client jar has been
+/// downloaded: extracts the bundled LaunchWrapper and produces the OptiFine
+/// library jar, running the installer's patcher against the client jar when
+/// the installer only ships patch data.
+pub(crate) async fn install_optifine_libraries(
+    state: &State,
+    java_path: &Path,
+    game_version: &str,
+    loader_version_id: &str,
+    client_jar_path: &Path,
+) -> crate::Result<()> {
+    let of_id = strip_loader_prefix(loader_version_id).to_string();
+    let installer = ensure_installer(state, game_version, &of_id).await?;
+    let installer_for_inspect = installer.clone();
+    let info = tokio::task::spawn_blocking(move || {
+        inspect_installer(&installer_for_inspect)
+    })
+    .await??;
+    let libraries_dir = state.directories.libraries_dir();
+
+    if let Some(entry_name) = info.launchwrapper_entry {
+        let target = libraries_dir.join(daedalus::get_path_from_artifact(
+            &info.launchwrapper_library.name,
+        )?);
+        if !target.exists() {
+            let installer = installer.clone();
+            tokio::task::spawn_blocking(move || {
+                extract_installer_entry(&installer, &entry_name, &target)
+            })
+            .await??;
+        }
+    }
+
+    let optifine_target = libraries_dir.join(daedalus::get_path_from_artifact(
+        &optifine_library_name(game_version, &of_id),
+    )?);
+    if optifine_target.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = optifine_target.parent() {
+        io::create_dir_all(parent).await?;
+    }
+
+    if info.needs_patching {
+        let output = Command::new(java_path)
+            .arg("-cp")
+            .arg(&installer)
+            .arg("optifine.Patcher")
+            .arg(client_jar_path)
+            .arg(&installer)
+            .arg(&optifine_target)
+            .output()
+            .await
+            .map_err(|error| {
+                crate::ErrorKind::LauncherError(format!(
+                    "Error running OptiFine patcher: {error}"
+                ))
+            })?;
+        if !output.status.success() {
+            return Err(crate::ErrorKind::LauncherError(format!(
+                "OptiFine patcher error: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .as_error());
+        }
+    } else {
+        io::copy(&installer, &optifine_target).await?;
+    }
+
+    Ok(())
+}
+
+/// Downloads the OptiFine jar usable as a Forge/NeoForge mod into the given
+/// directory, patching it against the client jar when required. Returns the
+/// target file path.
+pub async fn install_optifine_as_mod(
+    state: &State,
+    java_path: &Path,
+    game_version: &str,
+    requested_version: &str,
+    client_jar_path: &Path,
+    mods_dir: &Path,
+) -> crate::Result<PathBuf> {
+    let of_id = normalize_version_id(game_version, requested_version);
+    let installer = ensure_installer(state, game_version, &of_id).await?;
+    let installer_for_inspect = installer.clone();
+    let info = tokio::task::spawn_blocking(move || {
+        inspect_installer(&installer_for_inspect)
+    })
+    .await??;
+
+    let target =
+        mods_dir.join(format!("{OPTIFINE_LOADER_PREFIX}{game_version}_{of_id}.jar"));
+    io::create_dir_all(mods_dir).await?;
+
+    if info.needs_patching {
+        let output = Command::new(java_path)
+            .arg("-cp")
+            .arg(&installer)
+            .arg("optifine.Patcher")
+            .arg(client_jar_path)
+            .arg(&installer)
+            .arg(&target)
+            .output()
+            .await
+            .map_err(|error| {
+                crate::ErrorKind::LauncherError(format!(
+                    "Error running OptiFine patcher: {error}"
+                ))
+            })?;
+        if !output.status.success() {
+            return Err(crate::ErrorKind::LauncherError(format!(
+                "OptiFine patcher error: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .as_error());
+        }
+    } else {
+        io::copy(&installer, &target).await?;
+    }
+
+    Ok(target)
+}

--- a/packages/app-lib/src/launcher/optifine.rs
+++ b/packages/app-lib/src/launcher/optifine.rs
@@ -192,10 +192,7 @@ fn inspect_installer(path: &Path) -> crate::Result<InstallerInfo> {
     let (launchwrapper_library, launchwrapper_entry) =
         match launchwrapper_version {
             Some(version) => (
-                library(
-                    format!("optifine:launchwrapper-of:{version}"),
-                    false,
-                ),
+                library(format!("optifine:launchwrapper-of:{version}"), false),
                 Some(format!("launchwrapper-of-{version}.jar")),
             ),
             // Very old OptiFine builds ship without their own LaunchWrapper;
@@ -428,8 +425,9 @@ pub async fn install_optifine_as_mod(
     })
     .await??;
 
-    let target =
-        mods_dir.join(format!("{OPTIFINE_LOADER_PREFIX}{game_version}_{of_id}.jar"));
+    let target = mods_dir.join(format!(
+        "{OPTIFINE_LOADER_PREFIX}{game_version}_{of_id}.jar"
+    ));
     io::create_dir_all(mods_dir).await?;
 
     if info.needs_patching {

--- a/packages/app-lib/src/state/instance_types.rs
+++ b/packages/app-lib/src/state/instance_types.rs
@@ -78,6 +78,7 @@ pub enum ModLoader {
     Fabric,
     Quilt,
     NeoForge,
+    OptiFine,
 }
 
 impl ModLoader {
@@ -88,6 +89,7 @@ impl ModLoader {
             Self::Fabric => "fabric",
             Self::Quilt => "quilt",
             Self::NeoForge => "neoforge",
+            Self::OptiFine => "optifine",
         }
     }
 
@@ -98,6 +100,9 @@ impl ModLoader {
             Self::Fabric => "fabric",
             Self::Quilt => "quilt",
             Self::NeoForge => "neo",
+            // OptiFine has no Daedalus metadata; versions resolve through
+            // launcher::optifine instead of the meta server.
+            Self::OptiFine => "optifine",
         }
     }
 
@@ -108,6 +113,7 @@ impl ModLoader {
             "fabric" => Self::Fabric,
             "quilt" => Self::Quilt,
             "neoforge" => Self::NeoForge,
+            "optifine" => Self::OptiFine,
             _ => Self::Vanilla,
         }
     }


### PR DESCRIPTION
1.支持导入CurseForge 整合包 zip：清单内模组自动下载，无法自动获取的文件进入手动下载列表
2.支持导入 MCBBS 整合包：识别游戏版本与加载器，自动下载附带的 CurseForge 文件，迁移自定义 JVM 参数
3.支持导入 HMCL 整合包：识别游戏版本与加载器
4..支持导入MultiMC / Prism 导出的实例压缩包：实例图标与名称一并迁移
5.支持导入PCL等导出的附带启动器的整合包：自动提取内部整合包文件继续安装
6.支持导入打包的 `.minecraft` 游戏目录：自动识别游戏版本与加载器
7.新增 OptiFine 支持：整合包声明 OptiFine 时自动安装——单独存在时作为加载器，与 Forge/NeoForge 共存时作为模组安装
8.文件选择器、拖拽与文件关联现在接受 .zip文件

导入CurseForge 整合包zip的示例

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/90c6f11a-5c8b-4164-8a26-07c10b700a48" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import modpacks from `.zip` files with automatic format detection.
  * Added support for CurseForge, MCBBS, HMCL, MultiMC/Prism, launcher bundles, and plain Minecraft archives.
  * Added OptiFine installation support, including Forge and NeoForge compatibility.
  * Improved support for archives with nested folders and localized filenames.

* **Bug Fixes**
  * Fixed download progress overshooting after retries.
  * Improved extraction of Chinese filenames encoded with GB18030/GBK.
  * OptiFine exports now show a clear unsupported-format message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->