### PR TITLE
fix(app): Fix database backup path to use app's own directory instead of Modrinth directory 修复数据库备份路径，使用应用自有目录而非 Modrinth 目录

### DIFF
--- a/packages/app-lib/src/state/db_backup.rs
+++ b/packages/app-lib/src/state/db_backup.rs
@@ -128,14 +128,22 @@ pub fn app_db_backup_dir() -> crate::Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    let base = dirs::data_local_dir().or_else(dirs::data_dir).ok_or(
-        crate::ErrorKind::FSError(
-            "Could not find valid data dir for app database backups"
-                .to_string(),
-        ),
-    )?;
+    let app_identifier = if let Some(dir_info) =
+        crate::state::DirectoryInfo::global_handle_if_ready()
+    {
+        dir_info.app_identifier.clone()
+    } else {
+        "red.ghs.axolotl".to_string()
+    };
 
-    Ok(base.join("Modrinth").join("Backups").join("app-db"))
+    let base =
+        crate::state::DirectoryInfo::initial_settings_dir_path(&app_identifier)
+            .ok_or(crate::ErrorKind::FSError(
+                "Could not find valid config dir for app database backups"
+                    .to_string(),
+            ))?;
+
+    Ok(base.join("Backups").join("app-db"))
 }
 
 async fn has_user_tables(conn: &mut SqliteConnection) -> crate::Result<bool> {

--- a/packages/app-lib/src/state/db_backup.rs
+++ b/packages/app-lib/src/state/db_backup.rs
@@ -133,7 +133,7 @@ pub fn app_db_backup_dir() -> crate::Result<PathBuf> {
     {
         dir_info.app_identifier.clone()
     } else {
-        "red.ghs.axolotl".to_string()
+        crate::brand::BUNDLE_IDENTIFIER.to_string()
     };
 
     let base =


### PR DESCRIPTION
修复数据库备份路径错误，避免使用 Modrinth 目录

- 将数据库备份路径从 {LocalAppData}/Modrinth/Backups/app-db
  修改为 {settings_dir}/Backups/app-db
- 作为 Modrinth 下游独立分支，应使用自己的应用数据目录
- 使用 DirectoryInfo::global_handle_if_ready() 动态获取 app_identifier
- 保留 THESEUS_DB_BACKUP_DIR 环境变量最高优先级

修复前: {LocalAppData}/Modrinth/Backups/app-db
修复后: {settings_dir}/Backups/app-db

## Summary by Sourcery

Bug Fixes:
- 确保数据库备份存储在应用自身的设置目录中，而不是存储在 Modrinth 的 LocalAppData 目录中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure database backups are stored under the app's own settings directory rather than the Modrinth LocalAppData directory.

</details>