### PR TITLE
feat(ci): 在ci时替换Gradle镜像为官方源

### DIFF
--- a/.github/actions/replace-gradle-mirror/action.yml
+++ b/.github/actions/replace-gradle-mirror/action.yml
@@ -1,0 +1,18 @@
+name: Replace Gradle mirror with official distribution URL
+description: Replaces the Tencent Cloud Gradle mirror URL with the official Gradle distribution URL in gradle-wrapper.properties
+
+runs:
+  using: composite
+  steps:
+    - name: Replace (Linux / macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+        rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
+
+    - name: Replace (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        (Get-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties) -replace 'https\\://mirrors\.cloud\.tencent\.com/gradle/', 'https\://services.gradle.org/distributions/' | Set-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties

--- a/.github/workflows/axolotl-ci.yml
+++ b/.github/workflows/axolotl-ci.yml
@@ -44,15 +44,7 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - run: pnpm install --frozen-lockfile
-      - name: Replace Gradle mirror with official distribution URL
-        if: runner.os != 'Windows'
-        run: |
-          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
-          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
-      - name: Replace Gradle mirror with official distribution URL (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          (Get-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties) -replace 'https\\://mirrors\.cloud\.tencent\.com/gradle/', 'https\://services.gradle.org/distributions/' | Set-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+      - uses: ./.github/actions/replace-gradle-mirror
       - run: pnpm --filter @modrinth/app-frontend build
       - name: Test version metadata writes
         run: cargo test --package theseus writing_version_info_creates_missing_parent_directory

--- a/.github/workflows/axolotl-ci.yml
+++ b/.github/workflows/axolotl-ci.yml
@@ -44,6 +44,15 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - run: pnpm install --frozen-lockfile
+      - name: Replace Gradle mirror with official distribution URL
+        if: runner.os != 'Windows'
+        run: |
+          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
+      - name: Replace Gradle mirror with official distribution URL (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          (Get-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties) -replace 'https\\://mirrors\.cloud\.tencent\.com/gradle/', 'https\://services.gradle.org/distributions/' | Set-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
       - run: pnpm --filter @modrinth/app-frontend build
       - name: Test version metadata writes
         run: cargo test --package theseus writing_version_info_creates_missing_parent_directory

--- a/.github/workflows/axolotl-release.yml
+++ b/.github/workflows/axolotl-release.yml
@@ -123,6 +123,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Replace Gradle mirror with official distribution URL
+        if: runner.os != 'Windows'
+        run: |
+          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
+      - name: Replace Gradle mirror with official distribution URL (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          (Get-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties) -replace 'https\\://mirrors\.cloud\.tencent\.com/gradle/', 'https\://services.gradle.org/distributions/' | Set-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+
       - name: Set release version
         run: node scripts/axolotl/set-version.mjs "${{ github.ref_name }}"
 

--- a/.github/workflows/axolotl-release.yml
+++ b/.github/workflows/axolotl-release.yml
@@ -123,15 +123,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Replace Gradle mirror with official distribution URL
-        if: runner.os != 'Windows'
-        run: |
-          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
-          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
-      - name: Replace Gradle mirror with official distribution URL (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          (Get-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties) -replace 'https\\://mirrors\.cloud\.tencent\.com/gradle/', 'https\://services.gradle.org/distributions/' | Set-Content packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+      - uses: ./.github/actions/replace-gradle-mirror
 
       - name: Set release version
         run: node scripts/axolotl/set-version.mjs "${{ github.ref_name }}"

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -138,10 +138,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Replace Gradle mirror with official distribution URL
-        run: |
-          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
-          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
+      - uses: ./.github/actions/replace-gradle-mirror
 
       - name: Set app environment
         working-directory: packages/app-lib

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Replace Gradle mirror with official distribution URL
+        run: |
+          sed -i.bak 's|https\\://mirrors\.cloud\.tencent\.com/gradle/|https\\://services.gradle.org/distributions/|' packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties
+          rm -f packages/app-lib/java/gradle/wrapper/gradle-wrapper.properties.bak
+
       - name: Set app environment
         working-directory: packages/app-lib
         run: cp .env.staging .env


### PR DESCRIPTION
## 由 Sourcery 提供的总结

CI：
- 在 release、axolotl CI 和 turbo CI 工作流中添加跨平台步骤，重写 Gradle wrapper 配置以使用 `services.gradle.org` 作为分发源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在 `axolotl-release`、`axolotl-ci` 和 `turbo-ci` 工作流中添加跨平台步骤，将腾讯 Gradle 镜像替换为 `services.gradle.org` 作为 distribution URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add cross-platform steps in axolotl-release, axolotl-ci, and turbo-ci workflows to replace the Tencent Gradle mirror with services.gradle.org as the distribution URL.

</details>

</details>