### PR TITLE
feat: 支持跳转到MC百科页面

### DIFF
--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -19,3 +19,4 @@
 - 强化断点续传健壮性：分段下载回退到单连接时不再误删已保留的续传数据；响应被截断或续传应答的 Content-Range 无效时保留已下载数据供后续续传；兼容 RFC 允许的未知总长（`*`）Content-Range；续传前缀哈希推迟到响应校验通过后进行，避免对不可达下载源反复全量读盘。
 - 新增启动时自动清理：超过 7 天未使用的下载临时文件（.part 及分段残留）会被自动删除，避免被放弃的下载永久占用磁盘。
 - 修复更改应用目录或迁移旧启动器数据时，数据库中遗留的未完成 Java 安装（.installing 暂存路径）会触发 "Cannot save an incomplete Java installation" 错误、导致启动器初始化失败无法启动的问题；现在会自动跳过并清理这类脏记录。
+- 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。

--- a/apps/app-frontend/src/announcements/catalog.ts
+++ b/apps/app-frontend/src/announcements/catalog.ts
@@ -53,6 +53,12 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 					'zh-CN':
 						'大文件下载中断后现在会从断点继续，而不是从头重新下载——切换下载源或重试失败的安装时同样生效。',
 				},
+				{
+					'en-US':
+						'Project pages now link to the matching MC Mod (mcmod.cn) wiki page — in the sidebar links and the top-right menu — when the project is found in the bundled wiki index. Works for both Modrinth and CurseForge projects.',
+					'zh-CN':
+						'项目详情页现在会链接到对应的 MC 百科（mcmod.cn）页面——位于侧栏相关链接和右上角菜单中，仅当项目能在内置百科索引中找到时显示。Modrinth 和 CurseForge 项目均支持。',
+				},
 			],
 			changed: [
 				{

--- a/apps/app-frontend/src/helpers/content-search.ts
+++ b/apps/app-frontend/src/helpers/content-search.ts
@@ -23,6 +23,11 @@ export interface ChineseNameLookup {
 	curseforge: Record<string, string>
 }
 
+export interface WikiIdLookup {
+	modrinth: Record<string, number>
+	curseforge: Record<string, number>
+}
+
 export function containsChineseSearchText(query: string): boolean {
 	return /[\u3400-\u4dbf\u4e00-\u9fff]/u.test(query)
 }
@@ -38,6 +43,30 @@ export function lookupChineseContentNames(modrinthSlugs: string[], curseforgeSlu
 		modrinthSlugs,
 		curseforgeSlugs,
 	})
+}
+
+export function lookupContentWikiIds(modrinthSlugs: string[], curseforgeSlugs: string[]) {
+	return invoke<WikiIdLookup>('plugin:content-search|lookup_content_wiki_ids', {
+		modrinthSlugs,
+		curseforgeSlugs,
+	})
+}
+
+/**
+ * Resolves the MC 百科 (mcmod.cn) page URL for a project slug, or `null`
+ * when the bundled wiki dictionary has no entry for it.
+ */
+export async function resolveMcmodUrl(
+	slug: string | null | undefined,
+	provider: 'modrinth' | 'curseforge',
+): Promise<string | null> {
+	if (!slug) return null
+	const lookup = await lookupContentWikiIds(
+		provider === 'modrinth' ? [slug] : [],
+		provider === 'curseforge' ? [slug] : [],
+	).catch(() => null)
+	const wikiId = provider === 'curseforge' ? lookup?.curseforge[slug] : lookup?.modrinth[slug]
+	return wikiId ? `https://www.mcmod.cn/class/${wikiId}.html` : null
 }
 
 export function bilingualTitle(chineseName: string, originalTitle: string) {

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -1817,6 +1817,9 @@
 	"app.project.install-context.install-content-to-instance": {
 		"message": "Install content to instance"
 	},
+	"app.project.open-in-mcmod": {
+		"message": "Open in MC Mod"
+	},
 	"app.project.translation.failed": {
 		"message": "Translation failed. The original content was kept. Try again."
 	},

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -1784,6 +1784,9 @@
 	"app.project.install-context.install-content-to-instance": {
 		"message": "将内容安装到实例中"
 	},
+	"app.project.open-in-mcmod": {
+		"message": "在 MC 百科中打开"
+	},
 	"app.project.translation.failed": {
 		"message": "翻译失败，已保留原文。请重试。"
 	},

--- a/apps/app-frontend/src/pages/project/CurseForge.vue
+++ b/apps/app-frontend/src/pages/project/CurseForge.vue
@@ -10,7 +10,12 @@
 				:tags="{ loaders: allLoaders, gameVersions: allGameVersions }"
 				class="project-sidebar-section"
 			/>
-			<ProjectSidebarLinks link-target="_blank" :project="data" class="project-sidebar-section" />
+			<ProjectSidebarLinks
+				link-target="_blank"
+				:project="data"
+				:mcmod-url="mcmodUrl"
+				class="project-sidebar-section"
+			/>
 			<ProjectSidebarTags :project="data" class="project-sidebar-section" />
 			<ProjectSidebarCreators
 				:members="members"
@@ -66,21 +71,42 @@
 							}}
 						</button>
 					</ButtonStyled>
-					<ButtonStyled v-if="data.site_url" size="large" circular type="transparent">
+					<ButtonStyled
+						v-if="data.site_url || mcmodUrl"
+						size="large"
+						circular
+						type="transparent"
+					>
 						<OverflowMenu
 							:tooltip="formatMessage(commonMessages.moreOptionsButton)"
 							:options="[
-								{
-									id: 'open-in-browser',
-									link: data.site_url,
-									external: true,
-								},
+								...(data.site_url
+									? [
+											{
+												id: 'open-in-browser',
+												link: data.site_url,
+												external: true,
+											},
+										]
+									: []),
+								...(mcmodUrl
+									? [
+											{
+												id: 'open-in-mcmod',
+												link: mcmodUrl,
+												external: true,
+											},
+										]
+									: []),
 							]"
 							:aria-label="formatMessage(commonMessages.moreOptionsButton)"
 						>
 							<MoreVerticalIcon aria-hidden="true" />
 							<template #open-in-browser>
 								<ExternalIcon /> {{ formatMessage(commonMessages.openInBrowserButton) }}
+							</template>
+							<template #open-in-mcmod>
+								<BookOpenIcon /> {{ formatMessage(messages.openInMcmod) }}
 							</template>
 						</OverflowMenu>
 					</ButtonStyled>
@@ -150,6 +176,7 @@
 
 <script setup lang="ts">
 import {
+	BookOpenIcon,
 	DownloadIcon,
 	ExternalIcon,
 	LanguagesIcon,
@@ -178,6 +205,7 @@ import { computed, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import TranslatedProjectDescription from '@/components/ui/TranslatedProjectDescription.vue'
+import { resolveMcmodUrl } from '@/helpers/content-search'
 import {
 	type CurseForgeFile,
 	type CurseForgeProject,
@@ -213,6 +241,10 @@ const messages = defineMessages({
 	loading: {
 		id: 'app.project.curseforge.loading',
 		defaultMessage: 'Loading CurseForge project…',
+	},
+	openInMcmod: {
+		id: 'app.project.open-in-mcmod',
+		defaultMessage: 'Open in MC Mod',
 	},
 	description: {
 		id: 'project.description.title',
@@ -275,6 +307,7 @@ const messages = defineMessages({
 const loading = ref(true)
 const installing = ref(false)
 const project = shallowRef<CurseForgeProject | null>(null)
+const mcmodUrl = ref<string | null>(null)
 const description = ref('')
 const files = shallowRef<CurseForgeFile[]>([])
 const allLoaders = ref([])
@@ -495,6 +528,7 @@ async function loadProject(projectId: number) {
 	translations.value = {}
 	loading.value = true
 	project.value = null
+	mcmodUrl.value = null
 	description.value = ''
 	files.value = []
 	allLoaders.value = []
@@ -512,6 +546,9 @@ async function loadProject(projectId: number) {
 		project.value = projectData
 		breadcrumbs.setName('Project', projectData.name)
 		loading.value = false
+		void resolveMcmodUrl(projectData.slug, 'curseforge').then((url) => {
+			if (requestVersion === projectRequestVersion) mcmodUrl.value = url
+		})
 
 		const [projectDescription, projectFiles, loaders, gameVersions] = await supplementaryData
 		if (requestVersion !== projectRequestVersion) return

--- a/apps/app-frontend/src/pages/project/Index.vue
+++ b/apps/app-frontend/src/pages/project/Index.vue
@@ -24,6 +24,7 @@
 				link-target="_blank"
 				:project="data"
 				:project-v3="projectV3"
+				:mcmod-url="mcmodUrl"
 				class="project-sidebar-section"
 			/>
 			<ProjectSidebarTags :project="data" class="project-sidebar-section" />
@@ -122,6 +123,15 @@
 										link: `https://modrinth.com/project/${data.slug}`,
 										external: true,
 									},
+									...(mcmodUrl
+										? [
+												{
+													id: 'open-in-mcmod',
+													link: mcmodUrl,
+													external: true,
+												},
+											]
+										: []),
 									{
 										divider: true,
 									},
@@ -137,6 +147,9 @@
 								<MoreVerticalIcon aria-hidden="true" />
 								<template #open-in-browser>
 									<ExternalIcon /> {{ formatMessage(commonMessages.openInBrowserButton) }}
+								</template>
+								<template #open-in-mcmod>
+									<BookOpenIcon /> {{ formatMessage(messages.openInMcmod) }}
 								</template>
 								<template #report>
 									<ReportIcon /> {{ formatMessage(commonMessages.reportButton) }}
@@ -208,6 +221,15 @@
 										link: `https://modrinth.com/${data.project_type}/${data.slug}`,
 										external: true,
 									},
+									...(mcmodUrl
+										? [
+												{
+													id: 'open-in-mcmod',
+													link: mcmodUrl,
+													external: true,
+												},
+											]
+										: []),
 									{
 										divider: true,
 									},
@@ -223,6 +245,9 @@
 								<MoreVerticalIcon aria-hidden="true" />
 								<template #open-in-browser>
 									<ExternalIcon /> {{ formatMessage(commonMessages.openInBrowserButton) }}
+								</template>
+								<template #open-in-mcmod>
+									<BookOpenIcon /> {{ formatMessage(messages.openInMcmod) }}
 								</template>
 								<template #follow>
 									<HeartIcon /> {{ formatMessage(commonMessages.followButton) }}
@@ -309,6 +334,7 @@
 <script setup>
 import {
 	BookmarkIcon,
+	BookOpenIcon,
 	CheckIcon,
 	ClipboardCopyIcon,
 	DownloadIcon,
@@ -369,6 +395,7 @@ import {
 	get_version,
 	get_version_many,
 } from '@/helpers/cache.js'
+import { resolveMcmodUrl } from '@/helpers/content-search'
 import { process_listener } from '@/helpers/events'
 import {
 	get as getInstance,
@@ -423,6 +450,10 @@ const messages = defineMessages({
 		id: 'app.project.install-button.switch-version',
 		defaultMessage: 'Switch version',
 	},
+	openInMcmod: {
+		id: 'app.project.open-in-mcmod',
+		defaultMessage: 'Open in MC Mod',
+	},
 	translateProject: {
 		id: 'app.project.translation.translate',
 		defaultMessage: 'Translate',
@@ -465,6 +496,7 @@ const { installingServerProjects, playServerProject, showAddServerToInstanceModa
 	injectServerInstall()
 const installing = ref(false)
 const data = shallowRef(null)
+const mcmodUrl = ref(null)
 const versions = shallowRef([])
 const members = shallowRef([])
 const categories = shallowRef([])
@@ -700,6 +732,10 @@ async function fetchProjectData() {
 	}
 
 	data.value = project
+	mcmodUrl.value = null
+	void resolveMcmodUrl(project.slug, 'modrinth').then((url) => {
+		if (String(route.params.id) === requestedProjectId) mcmodUrl.value = url
+	})
 	const relatedData = await Promise.all([
 		get_version_many(project.versions, 'must_revalidate').catch(handleError),
 		get_team(project.team).catch(handleError),

--- a/apps/app/build.rs
+++ b/apps/app/build.rs
@@ -63,6 +63,7 @@ fn main() {
                     .commands(&[
                         "resolve_chinese_content_search",
                         "lookup_chinese_content_names",
+                        "lookup_content_wiki_ids",
                     ])
                     .default_permission(
                         DefaultPermissionRule::AllowAllCommands,

--- a/apps/app/src/api/content_search.rs
+++ b/apps/app/src/api/content_search.rs
@@ -1,10 +1,13 @@
-use theseus::content_search::{ChineseNameLookup, ChineseSearchResolution};
+use theseus::content_search::{
+    ChineseNameLookup, ChineseSearchResolution, WikiIdLookup,
+};
 
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new("content-search")
         .invoke_handler(tauri::generate_handler![
             resolve_chinese_content_search,
             lookup_chinese_content_names,
+            lookup_content_wiki_ids,
         ])
         .build()
 }
@@ -22,6 +25,17 @@ pub fn lookup_chinese_content_names(
     curseforge_slugs: Vec<String>,
 ) -> ChineseNameLookup {
     theseus::content_search::lookup_chinese_content_names(
+        &modrinth_slugs,
+        &curseforge_slugs,
+    )
+}
+
+#[tauri::command]
+pub fn lookup_content_wiki_ids(
+    modrinth_slugs: Vec<String>,
+    curseforge_slugs: Vec<String>,
+) -> WikiIdLookup {
+    theseus::content_search::lookup_content_wiki_ids(
         &modrinth_slugs,
         &curseforge_slugs,
     )

--- a/packages/app-lib/src/api/content_search.rs
+++ b/packages/app-lib/src/api/content_search.rs
@@ -15,8 +15,15 @@ static WIKI_ENTRIES: LazyLock<Vec<WikiEntry>> =
 static CHINESE_NAME_INDEX: LazyLock<ChineseNameIndex> =
     LazyLock::new(|| build_chinese_name_index(&WIKI_ENTRIES));
 
+static WIKI_ID_INDEX: LazyLock<WikiIdIndex> =
+    LazyLock::new(|| build_wiki_id_index(&WIKI_ENTRIES));
+
 #[derive(Clone, Debug)]
 struct WikiEntry {
+    /// MC 百科 (mcmod.cn) class ID, encoded as the entry's 1-based line
+    /// number in `WikiEntries.txt`; empty lines reserve the IDs of entries
+    /// without a platform slug.
+    wiki_id: u32,
     chinese_name: Option<String>,
     curseforge_slug: Option<String>,
     modrinth_slug: Option<String>,
@@ -100,6 +107,80 @@ fn collect_chinese_names(
                 .map(|name| (slug.clone(), name.clone()))
         })
         .collect()
+}
+
+#[derive(Debug, Default)]
+struct WikiIdIndex {
+    modrinth: HashMap<String, u32>,
+    curseforge: HashMap<String, u32>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikiIdLookup {
+    pub modrinth: HashMap<String, u32>,
+    pub curseforge: HashMap<String, u32>,
+}
+
+/// Batch-resolves MC 百科 (mcmod.cn) class IDs for known platform slugs,
+/// keyed by each input slug exactly as it was passed in.
+pub fn lookup_content_wiki_ids(
+    modrinth_slugs: &[String],
+    curseforge_slugs: &[String],
+) -> WikiIdLookup {
+    WikiIdLookup {
+        modrinth: collect_wiki_ids(modrinth_slugs, &WIKI_ID_INDEX.modrinth),
+        curseforge: collect_wiki_ids(
+            curseforge_slugs,
+            &WIKI_ID_INDEX.curseforge,
+        ),
+    }
+}
+
+fn collect_wiki_ids(
+    slugs: &[String],
+    index: &HashMap<String, u32>,
+) -> HashMap<String, u32> {
+    slugs
+        .iter()
+        .filter_map(|slug| {
+            index
+                .get(&slug.to_lowercase())
+                .map(|wiki_id| (slug.clone(), *wiki_id))
+        })
+        .collect()
+}
+
+fn build_wiki_id_index(entries: &[WikiEntry]) -> WikiIdIndex {
+    let mut modrinth = HashMap::<String, (u32, u32)>::new();
+    let mut curseforge = HashMap::<String, (u32, u32)>::new();
+    for entry in entries {
+        for (slug, index) in [
+            (entry.modrinth_slug.as_deref(), &mut modrinth),
+            (entry.curseforge_slug.as_deref(), &mut curseforge),
+        ] {
+            let Some(slug) = slug else {
+                continue;
+            };
+            let key = slug.to_lowercase();
+            let is_better = index
+                .get(&key)
+                .is_none_or(|(_, popularity)| *popularity < entry.popularity);
+            if is_better {
+                index.insert(key, (entry.wiki_id, entry.popularity));
+            }
+        }
+    }
+    WikiIdIndex {
+        modrinth: modrinth
+            .into_iter()
+            .map(|(key, (wiki_id, _))| (key, wiki_id))
+            .collect(),
+        curseforge: curseforge
+            .into_iter()
+            .map(|(key, (wiki_id, _))| (key, wiki_id))
+            .collect(),
+    }
 }
 
 fn build_chinese_name_index(entries: &[WikiEntry]) -> ChineseNameIndex {
@@ -345,7 +426,11 @@ fn parse_wiki_entries(source: &str) -> Vec<WikiEntry> {
     let mut popularity_iter = popularities.into_iter();
     let mut results = Vec::new();
 
-    for line in lines.into_iter().filter(|line| !line.is_empty()) {
+    for (line_index, line) in lines.into_iter().enumerate() {
+        if line.is_empty() {
+            continue;
+        }
+        let wiki_id = line_index as u32 + 1;
         let popularity = popularity_iter.next().unwrap_or_default();
         for raw_entry in line.split('¨') {
             let mut parts = raw_entry.split('|');
@@ -369,6 +454,7 @@ fn parse_wiki_entries(source: &str) -> Vec<WikiEntry> {
                 }
             });
             results.push(WikiEntry {
+                wiki_id,
                 chinese_name,
                 curseforge_slug,
                 modrinth_slug,
@@ -719,8 +805,20 @@ mod tests {
         assert_eq!(entries[0].modrinth_slug.as_deref(), Some("modrinth"));
         assert_eq!(entries[0].chinese_name.as_deref(), Some("中文 (Curse)"));
         assert_eq!(entries[0].popularity, 1);
+        assert_eq!(entries[0].wiki_id, 1);
         assert_eq!(entries[1].curseforge_slug, None);
         assert_eq!(entries[1].modrinth_slug.as_deref(), Some("only-mr"));
+        assert_eq!(entries[1].wiki_id, 1);
+    }
+
+    #[test]
+    fn empty_lines_reserve_wiki_ids_and_keep_popularity_aligned() {
+        let entries = parse_wiki_entries("first@|甲\n\nthird@|乙\n001002");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].wiki_id, 1);
+        assert_eq!(entries[0].popularity, 1);
+        assert_eq!(entries[1].wiki_id, 3);
+        assert_eq!(entries[1].popularity, 2);
     }
 
     #[test]
@@ -797,6 +895,28 @@ mod tests {
             lookup.modrinth.get("AE2").map(String::as_str),
             Some("应用能源2 (Applied Energistics 2)")
         );
+    }
+
+    #[test]
+    fn looks_up_wiki_ids_for_known_slugs() {
+        let lookup = lookup_content_wiki_ids(
+            &[
+                "industrial-craft".to_string(),
+                "totally-unknown-project".to_string(),
+            ],
+            &["Industrial-Craft".to_string()],
+        );
+        assert_eq!(lookup.modrinth.get("industrial-craft"), Some(&2));
+        assert!(!lookup.modrinth.contains_key("totally-unknown-project"));
+        assert_eq!(lookup.curseforge.get("Industrial-Craft"), Some(&2));
+    }
+
+    #[test]
+    fn wiki_id_index_prefers_more_popular_entries_for_duplicate_slugs() {
+        let entries = parse_wiki_entries("dup@|旧名\ndup@|新名\n001002");
+        let index = build_wiki_id_index(&entries);
+        assert_eq!(index.modrinth.get("dup"), Some(&2));
+        assert_eq!(index.curseforge.get("dup"), Some(&2));
     }
 
     #[test]
@@ -889,6 +1009,7 @@ mod tests {
     #[test]
     fn removes_words_that_can_be_composed_from_shorter_words() {
         let entry = WikiEntry {
+            wiki_id: 1,
             chinese_name: Some("末影接口 (Ender IO EnderIO)".to_string()),
             curseforge_slug: Some("ender-io-enderio".to_string()),
             modrinth_slug: None,

--- a/packages/ui/src/components/project/ProjectSidebarLinks.vue
+++ b/packages/ui/src/components/project/ProjectSidebarLinks.vue
@@ -4,6 +4,7 @@
 			project.issues_url ||
 			project.source_url ||
 			project.wiki_url ||
+			mcmodUrl ||
 			project.discord_url ||
 			project.site_url ||
 			projectV3?.link_urls.store?.url ||
@@ -45,6 +46,11 @@
 				{{ formatMessage(messages.wiki) }}
 				<ExternalIcon aria-hidden="true" class="external-icon" />
 			</a>
+			<a v-if="mcmodUrl" :href="mcmodUrl" :target="linkTarget" rel="noopener nofollow ugc">
+				<BookOpenIcon aria-hidden="true" />
+				{{ formatMessage(messages.mcmod) }}
+				<ExternalIcon aria-hidden="true" class="external-icon" />
+			</a>
 			<a
 				v-if="project.discord_url"
 				:href="project.discord_url"
@@ -80,6 +86,7 @@
 					(project.issues_url ||
 						project.source_url ||
 						project.wiki_url ||
+						mcmodUrl ||
 						project.discord_url ||
 						projectV3?.link_urls.site?.url ||
 						project.site_url ||
@@ -118,6 +125,7 @@
 <script setup lang="ts">
 import type { Labrinth } from '@modrinth/api-client'
 import {
+	BookOpenIcon,
 	BuyMeACoffeeIcon,
 	CodeIcon,
 	CurrencyIcon,
@@ -153,6 +161,7 @@ defineProps<{
 	}
 	projectV3?: Labrinth.Projects.v3.Project
 	linkTarget: string
+	mcmodUrl?: string | null
 }>()
 
 const messages = defineMessages({
@@ -171,6 +180,10 @@ const messages = defineMessages({
 	wiki: {
 		id: 'project.about.links.wiki',
 		defaultMessage: 'Visit wiki',
+	},
+	mcmod: {
+		id: 'project.about.links.mcmod',
+		defaultMessage: 'MC Mod',
 	},
 	discord: {
 		id: 'project.about.links.discord',

--- a/packages/ui/src/locales/en-US/index.json
+++ b/packages/ui/src/locales/en-US/index.json
@@ -3383,6 +3383,9 @@
 	"project.about.links.issues": {
 		"defaultMessage": "Report issues"
 	},
+	"project.about.links.mcmod": {
+		"defaultMessage": "MC Mod"
+	},
 	"project.about.links.site": {
 		"defaultMessage": "Visit website"
 	},

--- a/packages/ui/src/locales/zh-CN/index.json
+++ b/packages/ui/src/locales/zh-CN/index.json
@@ -3407,6 +3407,9 @@
 	"project.about.links.issues": {
 		"defaultMessage": "报告问题"
 	},
+	"project.about.links.mcmod": {
+		"defaultMessage": "MC Mod"
+	},
 	"project.about.links.site": {
 		"defaultMessage": "访问网站"
 	},


### PR DESCRIPTION
Closes #9 
在模组详情的右上角菜单中和右侧相关链接中增加跳转至MC百科的链接

## Summary by Sourcery

在项目页面中添加 MC Mod（mcmod.cn）Wiki 集成功能，并由新的内容搜索 API 提供支持，该 API 可为 Modrinth 和 CurseForge 的 slug 暴露稳定的 Wiki ID。

新功能：
- 暴露一个内容搜索 API，用于从 Modrinth 和 CurseForge 的 slug 批量解析 MC Mod（mcmod.cn）Wiki 条目 ID，供前端使用。
- 当在内置索引中存在匹配的 Wiki 条目时，在 Modrinth 和 CurseForge 项目的侧边栏和更多菜单中显示 MC Mod 链接。

增强改进：
- 扩展 Wiki 条目索引，加入稳定的 Wiki ID 映射，并在存在重复 slug 时优先选择更受欢迎的条目。
- 更新启动器公告和更新日志，记录新的 MC Mod Wiki 集成功能。

构建：
- 在 Tauri 内容搜索插件的构建配置中注册新的 Wiki ID 查询命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MC Mod (mcmod.cn) wiki integration to project pages, backed by a new content search API that exposes stable wiki IDs for Modrinth and CurseForge slugs.

New Features:
- Expose a content search API to batch-resolve MC Mod (mcmod.cn) wiki entry IDs from Modrinth and CurseForge slugs for frontend use.
- Show MC Mod links in Modrinth and CurseForge project sidebars and overflow menus when a matching wiki entry exists in the bundled index.

Enhancements:
- Extend the wiki entry index with stable wiki ID mapping that prefers more popular entries when slugs are duplicated.
- Update launcher announcements and changelog to document the new MC Mod wiki integration.

Build:
- Register the new wiki ID lookup command in the Tauri content-search plugin build configuration.

</details>

新功能：
- 暴露一个内容搜索 API，用于根据 Modrinth 和 CurseForge 的 slug 批量解析 MC百科词条 ID，并将其提供给前端使用。
- 当存在匹配的 MC百科词条时，在 Modrinth 和 CurseForge 项目页面的项目侧边栏链接以及右上角溢出菜单中添加 MC百科链接条目。

改进：
- 扩展百科词条索引，引入稳定的词条 ID 映射，并在存在重复 slug 时按热度进行选择。
- 更新启动器公告和更新日志，说明新的 MC百科集成。

构建：
- 在 Tauri 插件的构建配置中注册新的内容搜索命令，用于进行词条 ID 查询。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在项目页面中添加 MC Mod（mcmod.cn）Wiki 集成功能，并由新的内容搜索 API 提供支持，该 API 可为 Modrinth 和 CurseForge 的 slug 暴露稳定的 Wiki ID。

新功能：
- 暴露一个内容搜索 API，用于从 Modrinth 和 CurseForge 的 slug 批量解析 MC Mod（mcmod.cn）Wiki 条目 ID，供前端使用。
- 当在内置索引中存在匹配的 Wiki 条目时，在 Modrinth 和 CurseForge 项目的侧边栏和更多菜单中显示 MC Mod 链接。

增强改进：
- 扩展 Wiki 条目索引，加入稳定的 Wiki ID 映射，并在存在重复 slug 时优先选择更受欢迎的条目。
- 更新启动器公告和更新日志，记录新的 MC Mod Wiki 集成功能。

构建：
- 在 Tauri 内容搜索插件的构建配置中注册新的 Wiki ID 查询命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MC Mod (mcmod.cn) wiki integration to project pages, backed by a new content search API that exposes stable wiki IDs for Modrinth and CurseForge slugs.

New Features:
- Expose a content search API to batch-resolve MC Mod (mcmod.cn) wiki entry IDs from Modrinth and CurseForge slugs for frontend use.
- Show MC Mod links in Modrinth and CurseForge project sidebars and overflow menus when a matching wiki entry exists in the bundled index.

Enhancements:
- Extend the wiki entry index with stable wiki ID mapping that prefers more popular entries when slugs are duplicated.
- Update launcher announcements and changelog to document the new MC Mod wiki integration.

Build:
- Register the new wiki ID lookup command in the Tauri content-search plugin build configuration.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在项目页面中添加 MC Mod（mcmod.cn）Wiki 集成功能，并由新的内容搜索 API 提供支持，该 API 可为 Modrinth 和 CurseForge 的 slug 暴露稳定的 Wiki ID。

新功能：
- 暴露一个内容搜索 API，用于从 Modrinth 和 CurseForge 的 slug 批量解析 MC Mod（mcmod.cn）Wiki 条目 ID，供前端使用。
- 当在内置索引中存在匹配的 Wiki 条目时，在 Modrinth 和 CurseForge 项目的侧边栏和更多菜单中显示 MC Mod 链接。

增强改进：
- 扩展 Wiki 条目索引，加入稳定的 Wiki ID 映射，并在存在重复 slug 时优先选择更受欢迎的条目。
- 更新启动器公告和更新日志，记录新的 MC Mod Wiki 集成功能。

构建：
- 在 Tauri 内容搜索插件的构建配置中注册新的 Wiki ID 查询命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MC Mod (mcmod.cn) wiki integration to project pages, backed by a new content search API that exposes stable wiki IDs for Modrinth and CurseForge slugs.

New Features:
- Expose a content search API to batch-resolve MC Mod (mcmod.cn) wiki entry IDs from Modrinth and CurseForge slugs for frontend use.
- Show MC Mod links in Modrinth and CurseForge project sidebars and overflow menus when a matching wiki entry exists in the bundled index.

Enhancements:
- Extend the wiki entry index with stable wiki ID mapping that prefers more popular entries when slugs are duplicated.
- Update launcher announcements and changelog to document the new MC Mod wiki integration.

Build:
- Register the new wiki ID lookup command in the Tauri content-search plugin build configuration.

</details>

新功能：
- 暴露一个内容搜索 API，用于根据 Modrinth 和 CurseForge 的 slug 批量解析 MC百科词条 ID，并将其提供给前端使用。
- 当存在匹配的 MC百科词条时，在 Modrinth 和 CurseForge 项目页面的项目侧边栏链接以及右上角溢出菜单中添加 MC百科链接条目。

改进：
- 扩展百科词条索引，引入稳定的词条 ID 映射，并在存在重复 slug 时按热度进行选择。
- 更新启动器公告和更新日志，说明新的 MC百科集成。

构建：
- 在 Tauri 插件的构建配置中注册新的内容搜索命令，用于进行词条 ID 查询。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在项目页面中添加 MC Mod（mcmod.cn）Wiki 集成功能，并由新的内容搜索 API 提供支持，该 API 可为 Modrinth 和 CurseForge 的 slug 暴露稳定的 Wiki ID。

新功能：
- 暴露一个内容搜索 API，用于从 Modrinth 和 CurseForge 的 slug 批量解析 MC Mod（mcmod.cn）Wiki 条目 ID，供前端使用。
- 当在内置索引中存在匹配的 Wiki 条目时，在 Modrinth 和 CurseForge 项目的侧边栏和更多菜单中显示 MC Mod 链接。

增强改进：
- 扩展 Wiki 条目索引，加入稳定的 Wiki ID 映射，并在存在重复 slug 时优先选择更受欢迎的条目。
- 更新启动器公告和更新日志，记录新的 MC Mod Wiki 集成功能。

构建：
- 在 Tauri 内容搜索插件的构建配置中注册新的 Wiki ID 查询命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MC Mod (mcmod.cn) wiki integration to project pages, backed by a new content search API that exposes stable wiki IDs for Modrinth and CurseForge slugs.

New Features:
- Expose a content search API to batch-resolve MC Mod (mcmod.cn) wiki entry IDs from Modrinth and CurseForge slugs for frontend use.
- Show MC Mod links in Modrinth and CurseForge project sidebars and overflow menus when a matching wiki entry exists in the bundled index.

Enhancements:
- Extend the wiki entry index with stable wiki ID mapping that prefers more popular entries when slugs are duplicated.
- Update launcher announcements and changelog to document the new MC Mod wiki integration.

Build:
- Register the new wiki ID lookup command in the Tauri content-search plugin build configuration.

</details>

</details>

</details>