### PR TITLE
fix: 修复切换实例面包屑不更新、内容标签背景消失的问题

### DIFF
--- a/apps/app-frontend/src/pages/instance/Index.vue
+++ b/apps/app-frontend/src/pages/instance/Index.vue
@@ -543,6 +543,15 @@ async function fetchInstance() {
 			staleTime: 30_000,
 		})
 	}
+
+	breadcrumbs.setName(
+		'Instance',
+		nextInstance
+			? nextInstance.name.length > 40
+				? nextInstance.name.substring(0, 40) + '...'
+				: nextInstance.name
+			: '',
+	)
 }
 
 function fetchDeferredData(instanceId?: string) {
@@ -640,20 +649,6 @@ const tabs = computed(() => [
 		icon: TerminalSquareIcon,
 	},
 ])
-
-if (instance.value) {
-	breadcrumbs.setName(
-		'Instance',
-		instance.value.name.length > 40
-			? instance.value.name.substring(0, 40) + '...'
-			: instance.value.name,
-	)
-	breadcrumbs.setContext({
-		name: instance.value.name,
-		link: displayedInstanceRoute.value.path,
-		query: displayedInstanceRoute.value.query,
-	})
-}
 
 const options = ref<InstanceType<typeof ContextMenu> | null>(null)
 

--- a/apps/app-frontend/src/routes.js
+++ b/apps/app-frontend/src/routes.js
@@ -241,7 +241,7 @@ export default new createRouter({
 					component: Instance.Worlds,
 					meta: {
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Worlds' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Worlds' }],
 					},
 				},
 				{
@@ -250,7 +250,7 @@ export default new createRouter({
 					component: Instance.Screenshots,
 					meta: {
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Screenshots' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Screenshots' }],
 					},
 				},
 				{
@@ -259,7 +259,7 @@ export default new createRouter({
 					component: Instance.Mods,
 					meta: {
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Content' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Content' }],
 					},
 				},
 				{
@@ -268,7 +268,7 @@ export default new createRouter({
 					component: Instance.Mods,
 					meta: {
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Content' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Content' }],
 					},
 				},
 				{
@@ -277,7 +277,7 @@ export default new createRouter({
 					component: Instance.Files,
 					meta: {
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Files' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Files' }],
 					},
 				},
 				{
@@ -287,7 +287,7 @@ export default new createRouter({
 					meta: {
 						renderMode: 'fixed',
 						useRootContext: true,
-						breadcrumb: [{ name: '?Instance', link: '/instance/{id}/' }, { name: 'Logs' }],
+						breadcrumb: [{ name: '?Instance', link: '/instance/{id}' }, { name: 'Logs' }],
 					},
 				},
 			],


### PR DESCRIPTION
fixes #59

### **Bug 1：侧边栏切换实例时顶部面包屑标签不更新**

`apps/app-frontend/src/pages/instance/Index.vue`
- 将 `breadcrumbs.setName()` 从仅执行一次的顶层移入 `fetchInstance()`，切换实例时重新设置面包屑名称
- 删除无用的 `setContext()` 调用（实例页面全部使用 `useRootContext`，不读取 context）

### **Bug 2：面包屑导航回到内容页时标签背景消失**

`apps/app-frontend/src/routes.js`
- 6 处面包屑链接 `/instance/{id}/` → `/instance/{id}`，去掉尾随斜杠
- 尾随斜杠导致 `NavTabs` 无法精确匹配 Content 标签页，滑块背景丢失

## Summary by Sourcery

修复实例级导航状态，以便在切换实例或通过面包屑导航时，面包屑和内容选项卡保持同步。

Bug 修复：
- 确保从侧边栏切换实例时，实例面包屑标签能够正确更新。
- 通过移除路由末尾的斜杠，使实例面包屑路由与内容选项卡路由对齐，从而保持活动选项卡的背景高亮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix instance-level navigation state so breadcrumbs and content tabs stay in sync when switching instances or navigating via breadcrumbs.

Bug Fixes:
- Ensure the instance breadcrumb label updates correctly when switching instances from the sidebar.
- Align instance breadcrumb routes with content tab routes by removing trailing slashes so the active tab background is preserved.

</details>