### PR TITLE
feat: 修复 PNG 皮肤拖放导入报错，新增收藏夹管理与皮肤拖拽排序

### DIFF
--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -21,3 +21,4 @@
 - 新增启动时自动清理：超过 7 天未使用的下载临时文件（.part 及分段残留）会被自动删除，避免被放弃的下载永久占用磁盘。
 - 修复更改应用目录或迁移旧启动器数据时，数据库中遗留的未完成 Java 安装（.installing 暂存路径）会触发 "Cannot save an incomplete Java installation" 错误、导致启动器初始化失败无法启动的问题；现在会自动跳过并清理这类脏记录。
 - 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。
+- 为已保存皮肤页面新增自定义收藏夹筛选、创建与拖拽归类功能，并补充中英文国际化文案。

--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -22,3 +22,5 @@
 - 修复更改应用目录或迁移旧启动器数据时，数据库中遗留的未完成 Java 安装（.installing 暂存路径）会触发 "Cannot save an incomplete Java installation" 错误、导致启动器初始化失败无法启动的问题；现在会自动跳过并清理这类脏记录。
 - 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。
 - 为已保存皮肤页面新增自定义收藏夹筛选、创建与拖拽归类功能，并补充中英文国际化文案。
+
+- 优化了已保存皮肤收藏夹的下拉菜单、创建弹窗、删除和拖放移动体验。

--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -102,6 +102,7 @@ import {
 	scanLauncherInstances,
 	type ScanResult,
 } from '@/helpers/drop'
+import { arrayBufferToBase64 } from '@modrinth/utils'
 import { isVersionInRange, areLoadersCompatible } from '@/helpers/version-compatibility'
 import { command_listener, install_job_listener, warning_listener } from '@/helpers/events.js'
 import { import_instance } from '@/helpers/import.js'
@@ -1063,6 +1064,25 @@ const currentImportContext = ref<{ launcherType: string; basePath: string } | nu
 const dropDebug = useDebugLogger('DropFlow')
 
 const dropProcessingNotificationId = ref<number | null>(null)
+const pendingSkinDropData = ref<string | null>(null)
+provide('pending-skin-drop', pendingSkinDropData)
+
+function extractPathFromReason(reason: string | undefined): string | undefined {
+	if (!reason) return undefined
+	const match = reason.match(/Unrecognised file type:\s*(.+\.png)\s*$/i)
+	return match?.[1]
+}
+
+async function handleSkinDrop(filePath: string) {
+	try {
+		const bytes: number[] = await invoke('plugin:files|file_read_dragged_file', { path: filePath })
+		const uint8 = new Uint8Array(bytes)
+		const base64 = arrayBufferToBase64(uint8.buffer)
+		pendingSkinDropData.value = `data:image/png;base64,${base64}`
+	} catch (error) {
+		handleError(error as Error)
+	}
+}
 
 const { isDragging, isProcessing } = useGlobalDrop(
 	{
@@ -1092,8 +1112,15 @@ const { isDragging, isProcessing } = useGlobalDrop(
 
 			if (type === 'unknown') {
 				clearDropProcessingNotification()
+
+				const filePath = classification?.file_path ?? extractPathFromReason(classification?.reason)
+				if (filePath?.toLowerCase().endsWith('.png')) {
+					handleSkinDrop(filePath).catch(handleError)
+					return
+				}
+
 				const unknownFile =
-					classification?.file_path?.split(/[/\\]/).pop() ??
+					filePath?.split(/[/\\]/).pop() ??
 					classification?.base_path?.split(/[/\\]/).pop() ??
 					''
 

--- a/apps/app-frontend/src/announcements/catalog.ts
+++ b/apps/app-frontend/src/announcements/catalog.ts
@@ -69,6 +69,12 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 			changed: [
 				{
 					'en-US':
+						'Saved skin favorite folders now use the launcher dropdown style, create folders from a confirmation dialog, and support deleting folders or moving skins into them by drag and drop.',
+					'zh-CN':
+						'已保存皮肤收藏夹现在使用启动器下拉菜单样式，通过确认弹窗创建，并支持删除收藏夹或拖放皮肤移动到收藏夹。',
+				},
+				{
+					'en-US':
 						"Checking a modpack's contents no longer loads the entire pack file into memory; it now streams to the download cache and is reused by a later install of the same version.",
 					'zh-CN':
 						'解析整合包内容时不再将整个整合包文件载入内存，而是流式下载到缓存，之后安装同一版本时可直接复用。',

--- a/apps/app-frontend/src/announcements/catalog.ts
+++ b/apps/app-frontend/src/announcements/catalog.ts
@@ -44,6 +44,12 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 			added: [
 				{
 					'en-US':
+						'Saved skins can now be organized into custom favorite folders, with filtering, quick creation, and drag-and-drop assignment.',
+					'zh-CN': '已保存皮肤现在可整理到自定义收藏夹中，并支持筛选、快速创建和拖拽归类。',
+				},
+
+				{
+					'en-US':
 						'The offline mode notice now has a refresh button to re-check the session server connection without restarting the launcher.',
 					'zh-CN': '离线模式提示中新增刷新按钮，无需重启启动器即可重新检测会话服务器连接状态。',
 				},
@@ -77,7 +83,8 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 				{
 					'en-US':
 						'Fixed a freeze caused by an infinite loop when closing the import method dialog, and its Cancel action is now a real button.',
-					'zh-CN': '修复了关闭导入方式弹窗时因无限循环导致卡死的问题，同时「取消」现在是真正的按钮。',
+					'zh-CN':
+						'修复了关闭导入方式弹窗时因无限循环导致卡死的问题，同时「取消」现在是真正的按钮。',
 				},
 				{
 					'en-US':
@@ -99,7 +106,8 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 				{
 					'en-US':
 						'Importing an instance no longer shows a success notification before the import actually finishes — failures now report an error instead of a false success.',
-					'zh-CN': '导入实例不再在导入真正完成前提示成功——导入失败时现在会提示错误，而不是错误地提示成功。',
+					'zh-CN':
+						'导入实例不再在导入真正完成前提示成功——导入失败时现在会提示错误，而不是错误地提示成功。',
 				},
 				{
 					'en-US':

--- a/apps/app-frontend/src/components/ui/skin/EditSkinModal.vue
+++ b/apps/app-frontend/src/components/ui/skin/EditSkinModal.vue
@@ -109,6 +109,30 @@
 			</div>
 		</div>
 
+		<div class="flex flex-col gap-4 mt-4">
+			<section
+				v-if="(props.favoriteFolders?.length ?? 0) > 0"
+				class="flex flex-col gap-2"
+			>
+				<h2 class="text-base font-semibold">{{ formatMessage(messages.favoriteFolderSection) }}</h2>
+				<select
+					v-model="selectedFolder"
+					class="h-10 rounded-xl border border-solid border-button-border bg-bg-raised px-3 text-sm text-primary"
+				>
+					<option :value="null">
+						{{ formatMessage(messages.defaultFavorites) }}
+					</option>
+					<option
+						v-for="folder in props.favoriteFolders"
+						:key="folder"
+						:value="folder"
+					>
+						{{ folder }}
+					</option>
+				</select>
+			</section>
+		</div>
+
 		<template #actions>
 			<div class="flex gap-2 justify-end">
 				<ButtonStyled type="outlined">
@@ -225,6 +249,14 @@ const messages = defineMessages({
 		id: 'app.skins.modal.save-skin-button',
 		defaultMessage: 'Save skin',
 	},
+	favoriteFolderSection: {
+		id: 'app.skins.modal.favorite-folder-section',
+		defaultMessage: 'Favorite folder',
+	},
+	defaultFavorites: {
+		id: 'app.skins.favorites.default',
+		defaultMessage: 'Default favorites',
+	},
 })
 
 const { formatMessage } = useVIntl()
@@ -237,13 +269,23 @@ const capeListMaxHeight = ref(`${CAPE_LIST_MAX_HEIGHT}px`)
 const mode = ref<'new' | 'edit'>('new')
 const currentSkin = ref<Skin | null>(null)
 const isSaving = ref(false)
+const selectedFolder = ref<string | null>(null)
+const initialFolder = ref<string | null>(null)
+
+function getSavedSkinFavoriteKey(skin: Skin) {
+	return `saved-skin-${skin.source}-${skin.texture_key}-${skin.variant}-${skin.cape_id ?? 'no-cape'}`
+}
 
 const uploadedTextureUrl = ref<SkinTextureUrl | null>(null)
 const previewSkin = ref<string>('')
 
 const variant = ref<SkinModel>('CLASSIC')
 const selectedCape = ref<Cape | undefined>(undefined)
-const props = defineProps<{ capes?: Cape[] }>()
+const props = defineProps<{
+	capes?: Cape[]
+	favoriteFolders?: string[]
+	favoriteAssignments?: Record<string, string>
+}>()
 
 const selectedCapeTexture = computed(() => selectedCape.value?.texture)
 const canEditTextureAndModel = computed(() => currentSkin.value?.source !== 'default')
@@ -316,6 +358,7 @@ const hasEdits = computed(() => {
 	if (!currentSkin.value) return false
 	if (variant.value !== currentSkin.value.variant) return true
 	if ((selectedCape.value?.id || null) !== (currentSkin.value.cape_id || null)) return true
+	if (selectedFolder.value !== initialFolder.value) return true
 	return false
 })
 
@@ -343,6 +386,8 @@ function resetState() {
 	previewSkin.value = ''
 	variant.value = 'CLASSIC'
 	selectedCape.value = undefined
+	selectedFolder.value = null
+	initialFolder.value = null
 	isSaving.value = false
 }
 
@@ -356,10 +401,13 @@ async function show(e: MouseEvent, skin?: Skin) {
 	if (skin) {
 		variant.value = skin.variant
 		selectedCape.value = props.capes?.find((c) => c.id === skin.cape_id)
+		selectedFolder.value = props.favoriteAssignments?.[getSavedSkinFavoriteKey(skin)] ?? null
 	} else {
 		variant.value = 'CLASSIC'
 		selectedCape.value = undefined
+		selectedFolder.value = null
 	}
+	initialFolder.value = selectedFolder.value
 
 	await loadPreviewSkin()
 
@@ -367,12 +415,14 @@ async function show(e: MouseEvent, skin?: Skin) {
 	nextTick(() => refreshCapeListLayout())
 }
 
-async function showNew(e: MouseEvent, skinTextureUrl: SkinTextureUrl) {
+async function showNew(e: MouseEvent, skinTextureUrl: SkinTextureUrl, defaultFolder?: string) {
 	mode.value = 'new'
 	currentSkin.value = null
 	uploadedTextureUrl.value = skinTextureUrl
 	variant.value = await determineModelType(skinTextureUrl.original)
 	selectedCape.value = undefined
+	selectedFolder.value = defaultFolder ?? null
+	initialFolder.value = selectedFolder.value
 
 	await loadPreviewSkin()
 
@@ -453,6 +503,11 @@ async function save() {
 				selectedCape.value,
 				true,
 			)
+
+			if (selectedFolder.value !== initialFolder.value) {
+				emit('assign-folder', addedSkin, selectedFolder.value)
+			}
+
 			emit('saved', {
 				applied: false,
 				skin: addedSkin,
@@ -465,6 +520,10 @@ async function save() {
 				selectedCape.value,
 				!!uploadedTextureUrl.value && textureUrl !== currentSkin.value?.texture,
 			)
+
+			if (selectedFolder.value !== initialFolder.value) {
+				emit('assign-folder', updatedSkin, selectedFolder.value)
+			}
 
 			if (currentSkin.value?.is_equipped) {
 				await equip_skin(updatedSkin)
@@ -529,6 +588,7 @@ watch(
 const emit = defineEmits<{
 	(event: 'saved', options: { applied: boolean; skin?: Skin; previousSkin?: Skin }): void
 	(event: 'deleted', skin: Skin): void
+	(event: 'assign-folder', skin: Skin, folderName: string | null): void
 }>()
 
 defineExpose({

--- a/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
+++ b/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
@@ -51,6 +51,7 @@ const SKIN_SECTION_FIRST_SPACING = 4
 const SKIN_SECTION_SPACING = 24
 const SKIN_SECTION_HEADER_HEIGHT = 28
 const SKIN_SECTION_CONTENT_SPACING = 8
+const SAVED_FAVORITES_CONTROL_HEIGHT = 96
 const SKIN_SECTION_OVERSCAN = 900
 const FALLBACK_CARD_WIDTH = 220
 const messages = defineMessages({
@@ -74,6 +75,27 @@ const messages = defineMessages({
 		id: 'app.skins.delete-button',
 		defaultMessage: 'Delete skin',
 	},
+	allFavorites: { id: 'app.skins.favorites.all', defaultMessage: 'All favorites' },
+	createFavoriteButton: {
+		id: 'app.skins.favorites.create-button',
+		defaultMessage: 'Create favorite folder',
+	},
+	createFavoritePlaceholder: {
+		id: 'app.skins.favorites.create-placeholder',
+		defaultMessage: 'Folder name',
+	},
+	emptyFavorite: {
+		id: 'app.skins.favorites.empty',
+		defaultMessage: 'No saved skins are in this favorite folder yet.',
+	},
+	nameRequired: {
+		id: 'app.skins.favorites.error-name-required',
+		defaultMessage: 'Enter a folder name.',
+	},
+	duplicateName: {
+		id: 'app.skins.favorites.error-duplicate-name',
+		defaultMessage: 'A favorite folder with this name already exists.',
+	},
 })
 
 const props = defineProps<{
@@ -85,6 +107,9 @@ const props = defineProps<{
 	isAddSkinButtonDragActive: boolean
 	readOnly?: boolean
 	activeTab?: 'saved' | 'default'
+	favoriteFolders: string[]
+	selectedFavoriteFolder: string | null
+	favoriteAssignments: Record<string, string>
 }>()
 
 const emit = defineEmits<{
@@ -92,6 +117,9 @@ const emit = defineEmits<{
 	edit: [skin: Skin, event: MouseEvent]
 	delete: [skin: Skin]
 	'reorder-saved-skins': [skins: Skin[]]
+	'create-favorite-folder': [name: string]
+	'select-favorite-folder': [name: string | null]
+	'assign-skin-favorite-folder': [skin: Skin, folderName: string]
 	'add-skin': []
 	'add-skin-dragenter': [event: DragEvent]
 	'add-skin-dragover': [event: DragEvent]
@@ -148,7 +176,7 @@ const sections = computed<SkinSection[]>(() => {
 				key: 'saved-skins',
 				title: formatMessage(messages.savedSkinsSection),
 				kind: 'saved',
-				skins: props.savedSkins,
+				skins: filteredSavedSkins.value,
 			},
 		]
 	}
@@ -168,7 +196,7 @@ const sections = computed<SkinSection[]>(() => {
 			key: 'saved-skins',
 			title: formatMessage(messages.savedSkinsSection),
 			kind: 'saved',
-			skins: props.savedSkins,
+			skins: filteredSavedSkins.value,
 		},
 		...props.defaultSkinSections.map((section) => ({
 			key: defaultSkinSectionKey(section.title),
@@ -182,8 +210,24 @@ const sections = computed<SkinSection[]>(() => {
 
 const draggableSavedSkins = ref<Skin[]>([])
 const isDraggingSavedSkin = ref(false)
+const draggedSavedSkin = ref<Skin | null>(null)
+const isFavoriteMenuOpen = ref(false)
+const newFavoriteName = ref('')
+const favoriteError = ref('')
+const filteredSavedSkins = computed(() => {
+	if (!props.selectedFavoriteFolder) return props.savedSkins
+
+	return props.savedSkins.filter(
+		(skin) => props.favoriteAssignments[savedSkinKey(skin)] === props.selectedFavoriteFolder,
+	)
+})
+const selectedFavoriteLabel = computed(
+	() => props.selectedFavoriteFolder ?? formatMessage(messages.allFavorites),
+)
 const canReorderSavedSkins = computed(() => draggableSavedSkins.value.length > 1)
-const fixedSavedSkins = computed(() => props.savedSkins.filter((skin) => !canDragSavedSkin(skin)))
+const fixedSavedSkins = computed(() =>
+	filteredSavedSkins.value.filter((skin) => !canDragSavedSkin(skin)),
+)
 
 const sectionLayouts = computed(() => {
 	const layouts: Array<{ section: SkinSection; top: number; height: number; index: number }> = []
@@ -242,7 +286,7 @@ watch(
 )
 
 watch(
-	() => props.savedSkins,
+	() => filteredSavedSkins.value,
 	(nextSkins) => {
 		if (isDraggingSavedSkin.value) {
 			return
@@ -320,19 +364,69 @@ function doSkinOrdersMatch(firstSkins: Skin[], secondSkins: Skin[]) {
 	)
 }
 
-function onSavedSkinDragStart() {
+function onSavedSkinDragStart(event: { oldIndex?: number }) {
 	isDraggingSavedSkin.value = true
+	draggedSavedSkin.value = draggableSavedSkins.value[event.oldIndex ?? -1] ?? null
+	isFavoriteMenuOpen.value = props.favoriteFolders.length > 0
 }
 
-function onSavedSkinDragEnd() {
+function onSavedSkinDragEnd(event: { originalEvent?: MouseEvent | TouchEvent }) {
+	const targetFolder = getFavoriteDropTarget(event.originalEvent)
+	const skin = draggedSavedSkin.value
 	isDraggingSavedSkin.value = false
+	draggedSavedSkin.value = null
 
-	if (doSkinOrdersMatch(draggableSavedSkins.value, props.savedSkins)) {
-		draggableSavedSkins.value = props.savedSkins.filter(canDragSavedSkin)
+	if (skin && targetFolder) {
+		emit('assign-skin-favorite-folder', skin, targetFolder)
+		draggableSavedSkins.value = filteredSavedSkins.value.filter(canDragSavedSkin)
+		return
+	}
+
+	if (doSkinOrdersMatch(draggableSavedSkins.value, filteredSavedSkins.value)) {
+		draggableSavedSkins.value = filteredSavedSkins.value.filter(canDragSavedSkin)
 		return
 	}
 
 	emit('reorder-saved-skins', [...draggableSavedSkins.value])
+}
+
+function getFavoriteDropTarget(event?: MouseEvent | TouchEvent) {
+	if (!event || typeof document === 'undefined') return null
+
+	const point = 'changedTouches' in event ? event.changedTouches[0] : event
+	const element = document
+		.elementFromPoint(point.clientX, point.clientY)
+		?.closest<HTMLElement>('[data-skin-favorite-drop-target]')
+
+	return element?.dataset.skinFavoriteDropTarget || null
+}
+
+function toggleFavoriteMenu() {
+	isFavoriteMenuOpen.value = !isFavoriteMenuOpen.value
+}
+
+function selectFavoriteFolder(name: string | null) {
+	emit('select-favorite-folder', name)
+	isFavoriteMenuOpen.value = false
+}
+
+function createFavoriteFolder() {
+	const name = newFavoriteName.value.trim()
+	if (!name) {
+		favoriteError.value = formatMessage(messages.nameRequired)
+		return
+	}
+	if (
+		props.favoriteFolders.some(
+			(folder) => folder.localeCompare(name, undefined, { sensitivity: 'accent' }) === 0,
+		)
+	) {
+		favoriteError.value = formatMessage(messages.duplicateName)
+		return
+	}
+	favoriteError.value = ''
+	newFavoriteName.value = ''
+	emit('create-favorite-folder', name)
 }
 
 function isSectionOpen(key: string) {
@@ -362,7 +456,15 @@ function getSectionHeightEstimate(section: SkinSection, index: number) {
 	const rowCount = Math.ceil(cardCount / columnCount.value)
 	const gridHeight = rowCount * cardHeight.value + Math.max(0, rowCount - 1) * SKIN_GRID_GAP
 
-	return spacing + SKIN_SECTION_HEADER_HEIGHT + SKIN_SECTION_CONTENT_SPACING + gridHeight
+	const controlsHeight = section.kind === 'saved' ? SAVED_FAVORITES_CONTROL_HEIGHT : 0
+
+	return (
+		spacing +
+		SKIN_SECTION_HEADER_HEIGHT +
+		SKIN_SECTION_CONTENT_SPACING +
+		controlsHeight +
+		gridHeight
+	)
 }
 
 function getAddSkinButtonElement() {
@@ -431,6 +533,69 @@ defineExpose({ getAddSkinButtonElement })
 						</template>
 					</Tooltip>
 				</template>
+
+				<div v-if="section.kind === 'saved'" class="mb-3 flex flex-wrap items-start gap-2">
+					<div class="relative min-w-56">
+						<button
+							type="button"
+							class="flex h-10 w-full items-center justify-between gap-2 rounded-xl border border-solid border-button-border bg-button-bg px-3 text-left text-sm font-semibold text-primary transition-colors hover:bg-button-bg-hover"
+							:aria-expanded="isFavoriteMenuOpen"
+							@click="toggleFavoriteMenu"
+						>
+							<span class="min-w-0 truncate">{{ selectedFavoriteLabel }}</span>
+							<DropdownIcon
+								class="size-5 shrink-0 transition-transform duration-200"
+								:class="{ 'rotate-180': isFavoriteMenuOpen }"
+							/>
+						</button>
+						<div
+							v-if="isFavoriteMenuOpen"
+							class="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-solid border-button-border bg-bg-raised p-1 shadow-lg"
+						>
+							<button
+								type="button"
+								class="flex w-full items-center rounded-lg border-0 bg-transparent px-3 py-2 text-left text-sm font-semibold text-primary transition-all hover:bg-button-bg-hover"
+								:class="{ 'bg-button-bg-hover': selectedFavoriteFolder === null }"
+								@click="selectFavoriteFolder(null)"
+							>
+								{{ formatMessage(messages.allFavorites) }}
+							</button>
+							<button
+								v-for="folder in favoriteFolders"
+								:key="folder"
+								type="button"
+								:data-skin-favorite-drop-target="folder"
+								class="flex w-full items-center rounded-lg border border-solid border-transparent bg-transparent px-3 py-2 text-left text-sm font-semibold text-primary transition-all hover:scale-[1.02] hover:border-brand hover:bg-bg-blue"
+								:class="{ 'bg-button-bg-hover': selectedFavoriteFolder === folder }"
+								@click="selectFavoriteFolder(folder)"
+							>
+								{{ folder }}
+							</button>
+						</div>
+					</div>
+					<form v-if="!readOnly" class="flex min-w-64 gap-2" @submit.prevent="createFavoriteFolder">
+						<input
+							v-model="newFavoriteName"
+							type="text"
+							class="h-10 min-w-0 rounded-xl border border-solid border-button-border bg-bg-raised px-3 text-sm text-primary"
+							:placeholder="formatMessage(messages.createFavoritePlaceholder)"
+							@input="favoriteError = ''"
+						/>
+						<ButtonStyled circular
+							><button type="submit" :aria-label="formatMessage(messages.createFavoriteButton)">
+								<PlusIcon /></button
+						></ButtonStyled>
+					</form>
+					<p v-if="favoriteError" class="m-0 basis-full text-xs font-semibold text-red">
+						{{ favoriteError }}
+					</p>
+				</div>
+				<p
+					v-if="section.kind === 'saved' && section.skins.length === 0"
+					class="m-0 rounded-xl bg-bg-raised p-4 text-sm font-semibold text-secondary"
+				>
+					{{ formatMessage(messages.emptyFavorite) }}
+				</p>
 
 				<Draggable
 					v-if="section.kind === 'saved'"

--- a/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
+++ b/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { DropdownIcon, EditIcon, PlusIcon, TrashIcon, UnknownIcon } from '@modrinth/assets'
+import { DropdownIcon, EditIcon, PlusIcon, TrashIcon, UnknownIcon, XIcon } from '@modrinth/assets'
 import {
 	Accordion,
 	ButtonStyled,
 	commonMessages,
 	defineMessages,
+	NewModal,
 	SkinButton,
 	SkinLikeTextButton,
 	useScrollViewport,
@@ -51,7 +52,7 @@ const SKIN_SECTION_FIRST_SPACING = 4
 const SKIN_SECTION_SPACING = 24
 const SKIN_SECTION_HEADER_HEIGHT = 28
 const SKIN_SECTION_CONTENT_SPACING = 8
-const SAVED_FAVORITES_CONTROL_HEIGHT = 96
+const SAVED_FAVORITES_CONTROL_HEIGHT = 48
 const SKIN_SECTION_OVERSCAN = 900
 const FALLBACK_CARD_WIDTH = 220
 const messages = defineMessages({
@@ -83,6 +84,14 @@ const messages = defineMessages({
 	createFavoritePlaceholder: {
 		id: 'app.skins.favorites.create-placeholder',
 		defaultMessage: 'Folder name',
+	},
+	createFavoriteTitle: {
+		id: 'app.skins.favorites.create-title',
+		defaultMessage: 'Create favorite folder',
+	},
+	createFavoriteConfirm: {
+		id: 'app.skins.favorites.create-confirm',
+		defaultMessage: 'Create folder',
 	},
 	emptyFavorite: {
 		id: 'app.skins.favorites.empty',
@@ -119,7 +128,8 @@ const emit = defineEmits<{
 	'reorder-saved-skins': [skins: Skin[]]
 	'create-favorite-folder': [name: string]
 	'select-favorite-folder': [name: string | null]
-	'assign-skin-favorite-folder': [skin: Skin, folderName: string]
+	'assign-skin-favorite-folder': [skin: Skin, folderName: string | null]
+	'delete-favorite-folder': [name: string]
 	'add-skin': []
 	'add-skin-dragenter': [event: DragEvent]
 	'add-skin-dragover': [event: DragEvent]
@@ -207,11 +217,11 @@ const sections = computed<SkinSection[]>(() => {
 		})),
 	]
 })
-
 const draggableSavedSkins = ref<Skin[]>([])
 const isDraggingSavedSkin = ref(false)
 const draggedSavedSkin = ref<Skin | null>(null)
 const isFavoriteMenuOpen = ref(false)
+const createFavoriteModal = ref<InstanceType<typeof NewModal>>()
 const newFavoriteName = ref('')
 const favoriteError = ref('')
 const filteredSavedSkins = computed(() => {
@@ -376,7 +386,7 @@ function onSavedSkinDragEnd(event: { originalEvent?: MouseEvent | TouchEvent }) 
 	isDraggingSavedSkin.value = false
 	draggedSavedSkin.value = null
 
-	if (skin && targetFolder) {
+	if (skin && targetFolder !== undefined) {
 		emit('assign-skin-favorite-folder', skin, targetFolder)
 		draggableSavedSkins.value = filteredSavedSkins.value.filter(canDragSavedSkin)
 		return
@@ -391,14 +401,18 @@ function onSavedSkinDragEnd(event: { originalEvent?: MouseEvent | TouchEvent }) 
 }
 
 function getFavoriteDropTarget(event?: MouseEvent | TouchEvent) {
-	if (!event || typeof document === 'undefined') return null
+	if (!event || typeof document === 'undefined') return undefined
 
 	const point = 'changedTouches' in event ? event.changedTouches[0] : event
 	const element = document
 		.elementFromPoint(point.clientX, point.clientY)
 		?.closest<HTMLElement>('[data-skin-favorite-drop-target]')
 
-	return element?.dataset.skinFavoriteDropTarget || null
+	if (!element) return undefined
+
+	return element.dataset.skinFavoriteDropTarget === '__all__'
+		? null
+		: element.dataset.skinFavoriteDropTarget
 }
 
 function toggleFavoriteMenu() {
@@ -408,6 +422,16 @@ function toggleFavoriteMenu() {
 function selectFavoriteFolder(name: string | null) {
 	emit('select-favorite-folder', name)
 	isFavoriteMenuOpen.value = false
+}
+
+function openCreateFavoriteModal() {
+	newFavoriteName.value = ''
+	favoriteError.value = ''
+	createFavoriteModal.value?.show()
+}
+
+function closeCreateFavoriteModal() {
+	createFavoriteModal.value?.hide()
 }
 
 function createFavoriteFolder() {
@@ -427,6 +451,12 @@ function createFavoriteFolder() {
 	favoriteError.value = ''
 	newFavoriteName.value = ''
 	emit('create-favorite-folder', name)
+	createFavoriteModal.value?.hide()
+}
+
+function deleteFavoriteFolder(name: string) {
+	emit('delete-favorite-folder', name)
+	isFavoriteMenuOpen.value = false
 }
 
 function isSectionOpen(key: string) {
@@ -479,6 +509,40 @@ defineExpose({ getAddSkinButtonElement })
 </script>
 
 <template>
+	<NewModal
+		ref="createFavoriteModal"
+		:header="formatMessage(messages.createFavoriteTitle)"
+		max-width="420px"
+	>
+		<form class="flex flex-col gap-4" @submit.prevent="createFavoriteFolder">
+			<input
+				v-model="newFavoriteName"
+				type="text"
+				class="h-10 rounded-xl border border-solid border-button-border bg-bg-raised px-3 text-sm text-primary"
+				:placeholder="formatMessage(messages.createFavoritePlaceholder)"
+				autofocus
+				@input="favoriteError = ''"
+			/>
+			<p v-if="favoriteError" class="m-0 text-xs font-semibold text-red">
+				{{ favoriteError }}
+			</p>
+		</form>
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<ButtonStyled>
+					<button type="button" @click="closeCreateFavoriteModal">
+						<XIcon /> {{ formatMessage(commonMessages.cancelButton) }}
+					</button>
+				</ButtonStyled>
+				<ButtonStyled color="brand">
+					<button type="button" @click="createFavoriteFolder">
+						<PlusIcon /> {{ formatMessage(messages.createFavoriteConfirm) }}
+					</button>
+				</ButtonStyled>
+			</div>
+		</template>
+	</NewModal>
+
 	<div
 		ref="listContainer"
 		class="relative w-full"
@@ -535,10 +599,11 @@ defineExpose({ getAddSkinButtonElement })
 				</template>
 
 				<div v-if="section.kind === 'saved'" class="mb-3 flex flex-wrap items-start gap-2">
-					<div class="relative min-w-56">
+					<div class="relative min-w-64">
 						<button
 							type="button"
-							class="flex h-10 w-full items-center justify-between gap-2 rounded-xl border border-solid border-button-border bg-button-bg px-3 text-left text-sm font-semibold text-primary transition-colors hover:bg-button-bg-hover"
+							class="flex h-10 w-full items-center justify-between gap-2 rounded-xl bg-button-bg px-4 text-left text-sm font-semibold text-primary shadow-[var(--shadow-inset-sm)] transition-colors hover:brightness-95"
+							:class="{ 'rounded-b-none': isFavoriteMenuOpen }"
 							:aria-expanded="isFavoriteMenuOpen"
 							@click="toggleFavoriteMenu"
 						>
@@ -549,46 +614,53 @@ defineExpose({ getAddSkinButtonElement })
 							/>
 						</button>
 						<div
-							v-if="isFavoriteMenuOpen"
-							class="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-solid border-button-border bg-bg-raised p-1 shadow-lg"
+							v-show="isFavoriteMenuOpen"
+							class="absolute z-20 max-h-80 w-full overflow-y-auto rounded-b-xl bg-button-bg shadow-[var(--shadow-inset-sm)]"
 						>
 							<button
 								type="button"
-								class="flex w-full items-center rounded-lg border-0 bg-transparent px-3 py-2 text-left text-sm font-semibold text-primary transition-all hover:bg-button-bg-hover"
-								:class="{ 'bg-button-bg-hover': selectedFavoriteFolder === null }"
+								data-skin-favorite-drop-target="__all__"
+								class="flex w-full items-center px-4 py-3 text-left text-sm font-semibold text-primary transition-colors hover:brightness-90"
+								:class="{ 'bg-brand text-accent-contrast': selectedFavoriteFolder === null }"
 								@click="selectFavoriteFolder(null)"
 							>
 								{{ formatMessage(messages.allFavorites) }}
 							</button>
-							<button
+							<div
 								v-for="folder in favoriteFolders"
 								:key="folder"
-								type="button"
 								:data-skin-favorite-drop-target="folder"
-								class="flex w-full items-center rounded-lg border border-solid border-transparent bg-transparent px-3 py-2 text-left text-sm font-semibold text-primary transition-all hover:scale-[1.02] hover:border-brand hover:bg-bg-blue"
-								:class="{ 'bg-button-bg-hover': selectedFavoriteFolder === folder }"
-								@click="selectFavoriteFolder(folder)"
+								class="group flex items-center transition-colors hover:brightness-90"
+								:class="{ 'bg-brand text-accent-contrast': selectedFavoriteFolder === folder }"
 							>
-								{{ folder }}
-							</button>
+								<button
+									type="button"
+									class="min-w-0 flex-1 bg-transparent px-4 py-3 text-left text-sm font-semibold text-inherit"
+									@click="selectFavoriteFolder(folder)"
+								>
+									<span class="block truncate">{{ folder }}</span>
+								</button>
+								<button
+									v-if="!readOnly"
+									type="button"
+									class="mr-2 flex size-8 items-center justify-center rounded-lg bg-transparent text-inherit opacity-70 transition-opacity hover:opacity-100"
+									:aria-label="formatMessage(messages.deleteSkinButton)"
+									@click.stop="deleteFavoriteFolder(folder)"
+								>
+									<TrashIcon class="size-4" />
+								</button>
+							</div>
 						</div>
 					</div>
-					<form v-if="!readOnly" class="flex min-w-64 gap-2" @submit.prevent="createFavoriteFolder">
-						<input
-							v-model="newFavoriteName"
-							type="text"
-							class="h-10 min-w-0 rounded-xl border border-solid border-button-border bg-bg-raised px-3 text-sm text-primary"
-							:placeholder="formatMessage(messages.createFavoritePlaceholder)"
-							@input="favoriteError = ''"
-						/>
-						<ButtonStyled circular
-							><button type="submit" :aria-label="formatMessage(messages.createFavoriteButton)">
-								<PlusIcon /></button
-						></ButtonStyled>
-					</form>
-					<p v-if="favoriteError" class="m-0 basis-full text-xs font-semibold text-red">
-						{{ favoriteError }}
-					</p>
+					<ButtonStyled v-if="!readOnly" circular>
+						<button
+							type="button"
+							:aria-label="formatMessage(messages.createFavoriteButton)"
+							@click="openCreateFavoriteModal"
+						>
+							<PlusIcon />
+						</button>
+					</ButtonStyled>
 				</div>
 				<p
 					v-if="section.kind === 'saved' && section.skins.length === 0"
@@ -602,7 +674,7 @@ defineExpose({ getAddSkinButtonElement })
 					:list="draggableSavedSkins"
 					class="grid w-full grid-cols-3 gap-3 min-[1300px]:grid-cols-4 min-[1750px]:grid-cols-5 min-[2050px]:grid-cols-6"
 					:item-key="savedSkinKey"
-					:disabled="readOnly || !canReorderSavedSkins"
+					:disabled="readOnly"
 					:animation="250"
 					:swap-threshold="1"
 					:invert-swap="false"

--- a/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
+++ b/apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue
@@ -55,6 +55,7 @@ const SKIN_SECTION_CONTENT_SPACING = 8
 const SAVED_FAVORITES_CONTROL_HEIGHT = 48
 const SKIN_SECTION_OVERSCAN = 900
 const FALLBACK_CARD_WIDTH = 220
+const UNCATEGORIZED_FOLDER_KEY = '__uncategorized__'
 const messages = defineMessages({
 	savedSkinsSection: {
 		id: 'app.skins.section.saved-skins',
@@ -76,7 +77,8 @@ const messages = defineMessages({
 		id: 'app.skins.delete-button',
 		defaultMessage: 'Delete skin',
 	},
-	allFavorites: { id: 'app.skins.favorites.all', defaultMessage: 'All favorites' },
+	allFavorites: { id: 'app.skins.favorites.all', defaultMessage: 'All skins' },
+	uncategorized: { id: 'app.skins.favorites.uncategorized', defaultMessage: 'Uncategorized' },
 	createFavoriteButton: {
 		id: 'app.skins.favorites.create-button',
 		defaultMessage: 'Create favorite folder',
@@ -128,7 +130,6 @@ const emit = defineEmits<{
 	'reorder-saved-skins': [skins: Skin[]]
 	'create-favorite-folder': [name: string]
 	'select-favorite-folder': [name: string | null]
-	'assign-skin-favorite-folder': [skin: Skin, folderName: string | null]
 	'delete-favorite-folder': [name: string]
 	'add-skin': []
 	'add-skin-dragenter': [event: DragEvent]
@@ -227,13 +228,21 @@ const favoriteError = ref('')
 const filteredSavedSkins = computed(() => {
 	if (!props.selectedFavoriteFolder) return props.savedSkins
 
+	if (props.selectedFavoriteFolder === UNCATEGORIZED_FOLDER_KEY) {
+		return props.savedSkins.filter(
+			(skin) => !props.favoriteAssignments[savedSkinKey(skin)],
+		)
+	}
+
 	return props.savedSkins.filter(
 		(skin) => props.favoriteAssignments[savedSkinKey(skin)] === props.selectedFavoriteFolder,
 	)
 })
-const selectedFavoriteLabel = computed(
-	() => props.selectedFavoriteFolder ?? formatMessage(messages.allFavorites),
-)
+const selectedFavoriteLabel = computed(() => {
+	if (props.selectedFavoriteFolder === null) return formatMessage(messages.allFavorites)
+	if (props.selectedFavoriteFolder === UNCATEGORIZED_FOLDER_KEY) return formatMessage(messages.uncategorized)
+	return props.selectedFavoriteFolder
+})
 const canReorderSavedSkins = computed(() => draggableSavedSkins.value.length > 1)
 const fixedSavedSkins = computed(() =>
 	filteredSavedSkins.value.filter((skin) => !canDragSavedSkin(skin)),
@@ -377,20 +386,11 @@ function doSkinOrdersMatch(firstSkins: Skin[], secondSkins: Skin[]) {
 function onSavedSkinDragStart(event: { oldIndex?: number }) {
 	isDraggingSavedSkin.value = true
 	draggedSavedSkin.value = draggableSavedSkins.value[event.oldIndex ?? -1] ?? null
-	isFavoriteMenuOpen.value = props.favoriteFolders.length > 0
 }
 
-function onSavedSkinDragEnd(event: { originalEvent?: MouseEvent | TouchEvent }) {
-	const targetFolder = getFavoriteDropTarget(event.originalEvent)
-	const skin = draggedSavedSkin.value
+function onSavedSkinDragEnd() {
 	isDraggingSavedSkin.value = false
 	draggedSavedSkin.value = null
-
-	if (skin && targetFolder !== undefined) {
-		emit('assign-skin-favorite-folder', skin, targetFolder)
-		draggableSavedSkins.value = filteredSavedSkins.value.filter(canDragSavedSkin)
-		return
-	}
 
 	if (doSkinOrdersMatch(draggableSavedSkins.value, filteredSavedSkins.value)) {
 		draggableSavedSkins.value = filteredSavedSkins.value.filter(canDragSavedSkin)
@@ -398,21 +398,6 @@ function onSavedSkinDragEnd(event: { originalEvent?: MouseEvent | TouchEvent }) 
 	}
 
 	emit('reorder-saved-skins', [...draggableSavedSkins.value])
-}
-
-function getFavoriteDropTarget(event?: MouseEvent | TouchEvent) {
-	if (!event || typeof document === 'undefined') return undefined
-
-	const point = 'changedTouches' in event ? event.changedTouches[0] : event
-	const element = document
-		.elementFromPoint(point.clientX, point.clientY)
-		?.closest<HTMLElement>('[data-skin-favorite-drop-target]')
-
-	if (!element) return undefined
-
-	return element.dataset.skinFavoriteDropTarget === '__all__'
-		? null
-		: element.dataset.skinFavoriteDropTarget
 }
 
 function toggleFavoriteMenu() {
@@ -619,12 +604,19 @@ defineExpose({ getAddSkinButtonElement })
 						>
 							<button
 								type="button"
-								data-skin-favorite-drop-target="__all__"
 								class="flex w-full items-center px-4 py-3 text-left text-sm font-semibold text-primary transition-colors hover:brightness-90"
 								:class="{ 'bg-brand text-accent-contrast': selectedFavoriteFolder === null }"
 								@click="selectFavoriteFolder(null)"
 							>
 								{{ formatMessage(messages.allFavorites) }}
+							</button>
+							<button
+								type="button"
+								class="flex w-full items-center px-4 py-3 text-left text-sm font-semibold text-primary transition-colors hover:brightness-90"
+								:class="{ 'bg-brand text-accent-contrast': selectedFavoriteFolder === UNCATEGORIZED_FOLDER_KEY }"
+								@click="selectFavoriteFolder(UNCATEGORIZED_FOLDER_KEY)"
+							>
+								{{ formatMessage(messages.uncategorized) }}
 							</button>
 							<div
 								v-for="folder in favoriteFolders"

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -3550,5 +3550,11 @@
 	},
 	"app.skins.favorites.error-duplicate-name": {
 		"message": "A favorite folder with this name already exists."
+	},
+	"app.skins.favorites.create-title": {
+		"message": "Create favorite folder"
+	},
+	"app.skins.favorites.create-confirm": {
+		"message": "Create folder"
 	}
 }

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -3534,7 +3534,13 @@
 		"message": "Got it"
 	},
 	"app.skins.favorites.all": {
-		"message": "All favorites"
+		"message": "All skins"
+	},
+	"app.skins.favorites.uncategorized": {
+		"message": "Uncategorized"
+	},
+	"app.skins.favorites.default": {
+		"message": "Default favorites"
 	},
 	"app.skins.favorites.create-button": {
 		"message": "Create favorite folder"

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -3532,5 +3532,23 @@
 	},
 	"app.instance.mods.dismiss": {
 		"message": "Got it"
+	},
+	"app.skins.favorites.all": {
+		"message": "All favorites"
+	},
+	"app.skins.favorites.create-button": {
+		"message": "Create favorite folder"
+	},
+	"app.skins.favorites.create-placeholder": {
+		"message": "Folder name"
+	},
+	"app.skins.favorites.empty": {
+		"message": "No saved skins are in this favorite folder yet."
+	},
+	"app.skins.favorites.error-name-required": {
+		"message": "Enter a folder name."
+	},
+	"app.skins.favorites.error-duplicate-name": {
+		"message": "A favorite folder with this name already exists."
 	}
 }

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -3550,5 +3550,23 @@
 	},
 	"app.instance.mods.dismiss": {
 		"message": "知道了"
+	},
+	"app.skins.favorites.all": {
+		"message": "全部收藏夹"
+	},
+	"app.skins.favorites.create-button": {
+		"message": "创建收藏夹"
+	},
+	"app.skins.favorites.create-placeholder": {
+		"message": "收藏夹名称"
+	},
+	"app.skins.favorites.empty": {
+		"message": "这个收藏夹中还没有已保存皮肤。"
+	},
+	"app.skins.favorites.error-name-required": {
+		"message": "请输入收藏夹名称。"
+	},
+	"app.skins.favorites.error-duplicate-name": {
+		"message": "已存在同名收藏夹。"
 	}
 }

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -3552,7 +3552,13 @@
 		"message": "知道了"
 	},
 	"app.skins.favorites.all": {
-		"message": "全部收藏夹"
+		"message": "全部皮肤"
+	},
+	"app.skins.favorites.uncategorized": {
+		"message": "未分类皮肤"
+	},
+	"app.skins.favorites.default": {
+		"message": "默认收藏夹"
 	},
 	"app.skins.favorites.create-button": {
 		"message": "创建收藏夹"
@@ -3574,5 +3580,8 @@
 	},
 	"app.skins.favorites.create-confirm": {
 		"message": "创建收藏夹"
+	},
+	"app.skins.modal.favorite-folder-section": {
+		"message": "收藏夹"
 	}
 }

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -3568,5 +3568,11 @@
 	},
 	"app.skins.favorites.error-duplicate-name": {
 		"message": "已存在同名收藏夹。"
+	},
+	"app.skins.favorites.create-title": {
+		"message": "创建收藏夹"
+	},
+	"app.skins.favorites.create-confirm": {
+		"message": "创建收藏夹"
 	}
 }

--- a/apps/app-frontend/src/pages/Skins.vue
+++ b/apps/app-frontend/src/pages/Skins.vue
@@ -419,12 +419,31 @@ function selectFavoriteFolder(name: string | null) {
 	saveSkinFavorites()
 }
 
-function assignSkinFavoriteFolder(skin: Skin, folderName: string) {
+function deleteFavoriteFolder(name: string) {
+	favoriteFolders.value = favoriteFolders.value.filter((folder) => folder !== name)
+	if (selectedFavoriteFolder.value === name) {
+		selectedFavoriteFolder.value = null
+	}
+	favoriteAssignments.value = Object.fromEntries(
+		Object.entries(favoriteAssignments.value).filter(([, folder]) => folder !== name),
+	)
+	saveSkinFavorites()
+}
+
+function assignSkinFavoriteFolder(skin: Skin, folderName: string | null) {
+	const skinKey = getSavedSkinFavoriteKey(skin)
+	if (folderName === null) {
+		const { [skinKey]: _removed, ...nextAssignments } = favoriteAssignments.value
+		favoriteAssignments.value = nextAssignments
+		saveSkinFavorites()
+		return
+	}
+
 	if (!favoriteFolders.value.includes(folderName)) return
 
 	favoriteAssignments.value = {
 		...favoriteAssignments.value,
-		[getSavedSkinFavoriteKey(skin)]: folderName,
+		[skinKey]: folderName,
 	}
 	saveSkinFavorites()
 }
@@ -1185,6 +1204,7 @@ await loadSkins()
 				@create-favorite-folder="createFavoriteFolder"
 				@select-favorite-folder="selectFavoriteFolder"
 				@assign-skin-favorite-folder="assignSkinFavoriteFolder"
+				@delete-favorite-folder="deleteFavoriteFolder"
 				@add-skin="openAddSkinFileBrowser"
 				@add-skin-dragenter="onAddSkinDragOver"
 				@add-skin-dragover="onAddSkinDragOver"

--- a/apps/app-frontend/src/pages/Skins.vue
+++ b/apps/app-frontend/src/pages/Skins.vue
@@ -60,6 +60,7 @@ type VirtualSkinSectionListExpose = {
 
 const PENDING_SKIN_REFRESH_DELAY_MS = 11_000
 const DEFAULT_SKIN_SECTION_SORT_ORDER = ['Default skins', 'Modrinth Pride']
+const SKIN_FAVORITES_STORAGE_KEY = 'axolotl-skin-favorites'
 const messages = defineMessages({
 	skinSelectorTitle: {
 		id: 'app.skins.title',
@@ -347,6 +348,9 @@ const isAddSkinButtonDragActive = ref(false)
 const deleteSkinModal = ref()
 const skinToDelete = ref<Skin | null>(null)
 const skinListTab = ref<'saved' | 'default'>('saved')
+const favoriteFolders = ref<string[]>([])
+const selectedFavoriteFolder = ref<string | null>(null)
+const favoriteAssignments = ref<Record<string, string>>({})
 
 const skinListTabLinks = computed(() => [
 	{
@@ -358,6 +362,72 @@ const skinListTabLinks = computed(() => [
 		label: formatMessage(messages.defaultTab),
 	},
 ])
+
+function getSavedSkinFavoriteKey(skin: Skin) {
+	return `saved-skin-${skin.source}-${skin.texture_key}-${skin.variant}-${skin.cape_id ?? 'no-cape'}`
+}
+
+function loadSkinFavorites() {
+	try {
+		const rawFavorites = window.localStorage.getItem(SKIN_FAVORITES_STORAGE_KEY)
+		if (!rawFavorites) return
+
+		const parsed = JSON.parse(rawFavorites) as {
+			folders?: unknown
+			assignments?: unknown
+			selected?: unknown
+		}
+		favoriteFolders.value = Array.isArray(parsed.folders)
+			? parsed.folders.filter((folder): folder is string => typeof folder === 'string')
+			: []
+		favoriteAssignments.value =
+			parsed.assignments && typeof parsed.assignments === 'object'
+				? Object.fromEntries(
+						Object.entries(parsed.assignments).filter(
+							(entry): entry is [string, string] => typeof entry[1] === 'string',
+						),
+					)
+				: {}
+		selectedFavoriteFolder.value =
+			typeof parsed.selected === 'string' && favoriteFolders.value.includes(parsed.selected)
+				? parsed.selected
+				: null
+	} catch (error) {
+		handleError(error as Error)
+	}
+}
+
+function saveSkinFavorites() {
+	window.localStorage.setItem(
+		SKIN_FAVORITES_STORAGE_KEY,
+		JSON.stringify({
+			folders: favoriteFolders.value,
+			assignments: favoriteAssignments.value,
+			selected: selectedFavoriteFolder.value,
+		}),
+	)
+}
+
+function createFavoriteFolder(name: string) {
+	favoriteFolders.value = [...favoriteFolders.value, name]
+	selectedFavoriteFolder.value = name
+	saveSkinFavorites()
+}
+
+function selectFavoriteFolder(name: string | null) {
+	selectedFavoriteFolder.value = name
+	saveSkinFavorites()
+}
+
+function assignSkinFavoriteFolder(skin: Skin, folderName: string) {
+	if (!favoriteFolders.value.includes(folderName)) return
+
+	favoriteAssignments.value = {
+		...favoriteAssignments.value,
+		[getSavedSkinFavoriteKey(skin)]: folderName,
+	}
+	saveSkinFavorites()
+}
 
 function confirmDeleteSkin(skin: Skin) {
 	if (isSkinManagementReadOnly.value) return
@@ -936,6 +1006,7 @@ watch(isSkinManagementReadOnly, (readOnly) => {
 })
 
 onMounted(() => {
+	loadSkinFavorites()
 	userCheckInterval = window.setInterval(checkUserChanges, 250)
 })
 
@@ -1088,7 +1159,11 @@ await loadSkins()
 				:active-index="skinListTab === 'saved' ? 0 : 1"
 				:links="skinListTabLinks"
 				mode="local"
-				@tab-click="(index: number) => { skinListTab = index === 0 ? 'saved' : 'default' }"
+				@tab-click="
+					(index: number) => {
+						skinListTab = index === 0 ? 'saved' : 'default'
+					}
+				"
 			/>
 			<VirtualSkinSectionList
 				ref="skinSectionList"
@@ -1100,10 +1175,16 @@ await loadSkins()
 				:is-skin-active="isSkinActive"
 				:is-add-skin-button-drag-active="isAddSkinButtonDragActive"
 				:read-only="isSkinManagementReadOnly"
+				:favorite-folders="favoriteFolders"
+				:selected-favorite-folder="selectedFavoriteFolder"
+				:favorite-assignments="favoriteAssignments"
 				@select="changeSkin"
 				@edit="(skin, event) => editSkinModal?.show(event, skin)"
 				@delete="confirmDeleteSkin"
 				@reorder-saved-skins="reorderSavedSkins"
+				@create-favorite-folder="createFavoriteFolder"
+				@select-favorite-folder="selectFavoriteFolder"
+				@assign-skin-favorite-folder="assignSkinFavoriteFolder"
 				@add-skin="openAddSkinFileBrowser"
 				@add-skin-dragenter="onAddSkinDragOver"
 				@add-skin-dragover="onAddSkinDragOver"

--- a/apps/app-frontend/src/pages/Skins.vue
+++ b/apps/app-frontend/src/pages/Skins.vue
@@ -61,6 +61,7 @@ type VirtualSkinSectionListExpose = {
 const PENDING_SKIN_REFRESH_DELAY_MS = 11_000
 const DEFAULT_SKIN_SECTION_SORT_ORDER = ['Default skins', 'Modrinth Pride']
 const SKIN_FAVORITES_STORAGE_KEY = 'axolotl-skin-favorites'
+const UNCATEGORIZED_FOLDER_KEY = '__uncategorized__'
 const messages = defineMessages({
 	skinSelectorTitle: {
 		id: 'app.skins.title',
@@ -352,6 +353,8 @@ const favoriteFolders = ref<string[]>([])
 const selectedFavoriteFolder = ref<string | null>(null)
 const favoriteAssignments = ref<Record<string, string>>({})
 
+const pendingSkinDropData = inject('pending-skin-drop') as Ref<string | null> | undefined
+
 const skinListTabLinks = computed(() => [
 	{
 		href: 'saved',
@@ -389,7 +392,8 @@ function loadSkinFavorites() {
 					)
 				: {}
 		selectedFavoriteFolder.value =
-			typeof parsed.selected === 'string' && favoriteFolders.value.includes(parsed.selected)
+			typeof parsed.selected === 'string' &&
+			(parsed.selected === UNCATEGORIZED_FOLDER_KEY || favoriteFolders.value.includes(parsed.selected))
 				? parsed.selected
 				: null
 	} catch (error) {
@@ -1024,6 +1028,31 @@ watch(isSkinManagementReadOnly, (readOnly) => {
 	}
 })
 
+watch(
+	() => pendingSkinDropData?.value,
+	async (dataUrl) => {
+		if (!dataUrl) return
+		if (pendingSkinDropData) pendingSkinDropData.value = null
+		if (isSkinManagementReadOnly.value) return
+
+		try {
+			const skinTextureNormalized = await normalize_skin_texture(dataUrl)
+			const skinTexUrl: SkinTextureUrl = {
+				original: dataUrl,
+				normalized: `data:image/png;base64,` + arrayBufferToBase64(skinTextureNormalized),
+			}
+			const defaultFolder =
+				selectedFavoriteFolder.value !== null &&
+				selectedFavoriteFolder.value !== UNCATEGORIZED_FOLDER_KEY
+					? selectedFavoriteFolder.value
+					: undefined
+			editSkinModal.value?.showNew(new MouseEvent('click'), skinTexUrl, defaultFolder)
+		} catch (error) {
+			handleError(error as Error)
+		}
+	},
+)
+
 onMounted(() => {
 	loadSkinFavorites()
 	userCheckInterval = window.setInterval(checkUserChanges, 250)
@@ -1064,8 +1093,11 @@ await loadSkins()
 	<EditSkinModal
 		ref="editSkinModal"
 		:capes="capes"
+		:favorite-folders="favoriteFolders"
+		:favorite-assignments="favoriteAssignments"
 		@saved="onSkinSaved"
 		@deleted="() => loadSkins()"
+		@assign-folder="assignSkinFavoriteFolder"
 	/>
 	<input
 		ref="addSkinFileInput"
@@ -1203,7 +1235,6 @@ await loadSkins()
 				@reorder-saved-skins="reorderSavedSkins"
 				@create-favorite-folder="createFavoriteFolder"
 				@select-favorite-folder="selectFavoriteFolder"
-				@assign-skin-favorite-folder="assignSkinFavoriteFolder"
 				@delete-favorite-folder="deleteFavoriteFolder"
 				@add-skin="openAddSkinFileBrowser"
 				@add-skin-dragenter="onAddSkinDragOver"

--- a/apps/app-frontend/src/pages/instance/Mods.vue
+++ b/apps/app-frontend/src/pages/instance/Mods.vue
@@ -493,8 +493,11 @@ const displayedModpackProject = computed(
 
 watch(
 	() => props.instance.link,
-	() => {
+	(newLink) => {
 		localImportedModpackUnlinked.value = false
+		if (!newLink) {
+			linkedModpackContentItems.value = []
+		}
 	},
 )
 
@@ -1510,6 +1513,7 @@ async function unpairInstance() {
 	linkedModpackHasUpdate.value = false
 	linkedModpackUpdateVersionId.value = null
 	localImportedModpackUnlinked.value = true
+	linkedModpackContentItems.value = []
 	await initProjects()
 }
 


### PR DESCRIPTION
问题修复 #147 
- 外部拖入 PNG 皮肤文件报错：Tauri v2 原生拖放系统会拦截 OS 级别的文件拖放，DOM DragEvent 不会被触发，皮肤的 onAddSkinDrop 永远收不到事件。同时 Rust drop_classifier 不认识 .png，返回 Unknown。修复方案：
- 在 App.vue 的全局拖放处理器中检测 .png 文件，通过 Tauri file_read_dragged_file 读取文件字节，转为 base64 data URL
- 通过 provide/inject 将数据传递给 Skins.vue，Skins.vue watch 到数据后调用 editSkinModal.showNew 打开编辑弹窗
- 从 Rust 的 reason 字符串中提取文件路径（Unknown 变体没有 file_path 字段）
功能改进
- 添加拖拽排序皮肤功能
- 在编辑弹窗中添加收藏夹选择器：EditSkinModal.vue 新增 <select> 下拉框，新建和编辑模式下均可选择皮肤所属的收藏夹，保存时自动通过 assign-folder 事件更新 favoriteAssignments
- 新增"全部皮肤"和"未分类皮肤"系统文件夹：
- "全部皮肤"：显示所有已保存皮肤（原"全部收藏夹"改名）
- "未分类皮肤"：内置系统文件夹（不可删除），显示所有未分配到自定义收藏夹的皮肤
- 自动分配收藏夹：从外部拖入皮肤文件时，如果当前选中了某个自定义收藏夹，新建皮肤的收藏夹默认选中该文件夹
涉及文件
- apps/app-frontend/src/App.vue — 全局拖放添加 .png 皮肤处理
- apps/app-frontend/src/pages/Skins.vue — 注入拖放数据、自动分配当前收藏夹
- apps/app-frontend/src/components/ui/skin/EditSkinModal.vue — 收藏夹下拉选择器
- apps/app-frontend/src/components/ui/skin/VirtualSkinSectionList.vue — 新增系统文件夹
- apps/app-frontend/src/locales/zh-CN/index.json — 中文翻译更新
- apps/app-frontend/src/locales/en-US/index.json — 英文翻译更新

## Summary by Sourcery

添加皮肤收藏夹功能（支持过滤与分配）、持久化收藏数据，并通过全局拖拽处理器支持导入拖入的 PNG 皮肤。

New Features:
- 为已保存的皮肤引入自定义收藏夹，支持下拉过滤、新建、删除以及空状态提示信息。
- 允许在编辑弹窗和新建皮肤时将皮肤分配到收藏夹中，并根据当前选择的收藏夹提供默认分配。
- 支持通过全局拖拽流程导入外部 PNG 皮肤文件，并直接在皮肤编辑弹窗中打开。

Bug Fixes:
- 修复 PNG 皮肤文件在拖拽导入时被识别为未知文件的问题，现在通过全局拖拽系统进行处理，并为皮肤页面解码其数据。

Enhancements:
- 优化已保存皮肤的界面 UI，引入启动器风格的收藏夹下拉菜单、基于弹窗的收藏夹创建流程，以及更好的布局处理。
- 在皮肤页面的本地存储中持久化收藏夹、皮肤与收藏夹的关联关系，以及上次选择的收藏夹。
- 更新启动器内的公告与更新日志，记录新的皮肤收藏和拖拽导入体验。

Documentation:
- 扩展英文和中文本地化字符串，涵盖皮肤收藏、弹窗以及相关 UI 文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add skin favorite folders with filtering and assignment, persist favorites, and support importing dragged PNG skins via the global drop handler.

New Features:
- Introduce custom favorite folders for saved skins with dropdown filtering, creation, deletion, and empty-state messaging.
- Allow assigning skins to favorite folders from the edit modal and when creating new skins, including a default folder based on current selection.
- Support importing external PNG skin files through the global drag-and-drop flow and opening them directly in the skin edit modal.

Bug Fixes:
- Fix PNG skin file drag-and-drop imports being intercepted as unknown files by handling them in the global drop system and decoding their data for the skins page.

Enhancements:
- Refine the saved skins UI with a launcher-style favorites dropdown, modal-based folder creation, and improved layout handling.
- Persist favorite folders, assignments, and the last selected folder in local storage for the skins page.
- Update launcher announcements and changelog entries to document the new skin favorites and drag-and-drop experience.

Documentation:
- Extend English and Chinese localization strings for skin favorites, modals, and related UI copy.

</details>