### PR TITLE
修复 Linux 打包和启用系统代理

### DIFF
--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -21,3 +21,5 @@
 - 新增启动时自动清理：超过 7 天未使用的下载临时文件（.part 及分段残留）会被自动删除，避免被放弃的下载永久占用磁盘。
 - 修复更改应用目录或迁移旧启动器数据时，数据库中遗留的未完成 Java 安装（.installing 暂存路径）会触发 "Cannot save an incomplete Java installation" 错误、导致启动器初始化失败无法启动的问题；现在会自动跳过并清理这类脏记录。
 - 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。
+- 优化 Linux 桌面文件（.desktop）：补充 Comment、Keywords、StartupWMClass、StartupNotify 等字段，添加 x-scheme-handler/axolotl 协议关联与中文本地化，并为 Exec 添加 WEBKIT_DISABLE_DMABUF_RENDERER=1 环境变量。
+- 将 Linux 桌面文件模板从 Tauri 模板变量格式改为固定值格式，确保编译后的 .desktop 文件直接使用 "Axolotl Launcher" 作为名称、图标和可执行文件。

--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -23,3 +23,5 @@
 - 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。
 - 优化 Linux 桌面文件（.desktop）：补充 Comment、Keywords、StartupWMClass、StartupNotify 等字段，添加 x-scheme-handler/axolotl 协议关联与中文本地化，并为 Exec 添加 WEBKIT_DISABLE_DMABUF_RENDERER=1 环境变量。
 - 将 Linux 桌面文件模板从 Tauri 模板变量格式改为固定值格式，确保编译后的 .desktop 文件直接使用 "Axolotl Launcher" 作为名称、图标和可执行文件。
+- 启用系统代理支持：默认请求逻辑现在会使用系统代理设置，不再强制禁用代理。
+- 修复 Linux deb 打包：添加 deb 依赖项（libwebkit2gtk、libgtk-3、libayatana-appindicator），修复 vite 配置使用 rolldownOptions 替代 rollupOptions。

--- a/apps/app-frontend/src/announcements/catalog.ts
+++ b/apps/app-frontend/src/announcements/catalog.ts
@@ -56,6 +56,10 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 						'To avoid confusion caused by loaders that have not yet been parsed during batch imports, instances are now imported one by one with progress displayed.',
 					'zh-CN': '为避免批量导入过程中还未来得及解析的加载器造成误解，现在逐个导入实例并显示进度',
 				},
+				{
+					'en-US': 'System proxy is now enabled by default for all network requests.',
+					'zh-CN': '默认启用系统代理支持，所有网络请求现在会使用系统代理设置。',
+				},
 			],
 			fixed: [
 				{
@@ -65,6 +69,10 @@ export const launcherAnnouncements: readonly LauncherAnnouncement[] = [
 				{
 					'en-US': 'Fixed the import page failing to import instances.',
 					'zh-CN': '修复了导入界面无法正常导入的bug。',
+				},
+				{
+					'en-US': 'Fixed Linux deb package dependencies and desktop file configuration.',
+					'zh-CN': '修复 Linux deb 打包依赖项和桌面文件配置。',
 				},
 			],
 		},

--- a/apps/app-frontend/vite.config.ts
+++ b/apps/app-frontend/vite.config.ts
@@ -96,10 +96,8 @@ export default defineConfig({
 	// https://v2.tauri.app/reference/environment-variables/#tauri-cli-hook-commands
 	envPrefix: ['VITE_', 'TAURI_', 'MODRINTH_'],
 	build: {
-		rollupOptions: {
-			external: ['@tauri-apps/plugin-dialog'],
-		},
 		rolldownOptions: {
+			external: ['@tauri-apps/plugin-dialog'],
 			onwarn(warning, defaultHandler) {
 				if (warning.code === 'INEFFECTIVE_DYNAMIC_IMPORT') return
 				defaultHandler(warning)

--- a/apps/app/desktop-template.desktop
+++ b/apps/app/desktop-template.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Name=Axolotl Launcher
+Comment=Minecraft Java Edition Launcher
+Comment[zh_CN]=Minecraft Java版启动器
+Exec=env WEBKIT_DISABLE_DMABUF_RENDERER=1 "Axolotl Launcher"
+StartupWMClass=Axolotl Launcher
+Icon=Axolotl Launcher
+Terminal=false
+StartupNotify=true
+Categories=Game;ArcadeGame;AdventureGame;
+MimeType=application/x-modrinth-modpack+zip;x-scheme-handler/axolotl;
+Keywords=minecraft;game;launcher;mod;modpack;
+Keywords[zh_CN]=我的世界;游戏;启动器;模组;整合包;

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -47,15 +47,22 @@
 				}
 			}
 		},
-		"shortDescription": "",
+		"shortDescription": "Minecraft Java Edition Launcher",
 		"linux": {
 			"deb": {
-				"depends": []
+				"depends": [
+					"libwebkit2gtk-4.1-0",
+					"libgtk-3-0",
+					"libayatana-appindicator3-1"
+				],
+				"desktopTemplate": "desktop-template.desktop"
 			}
 		},
 		"fileAssociations": [
 			{
-				"ext": ["mrpack"],
+				"ext": [
+					"mrpack"
+				],
 				"mimeType": "application/x-modrinth-modpack+zip"
 			}
 		]
@@ -67,7 +74,9 @@
 	"plugins": {
 		"deep-link": {
 			"desktop": {
-				"schemes": ["axolotl"]
+				"schemes": [
+					"axolotl"
+				]
 			},
 			"mobile": []
 		}
@@ -106,11 +115,16 @@
 				],
 				"enable": true
 			},
-			"capabilities": ["core", "plugins"],
+			"capabilities": [
+				"core",
+				"plugins"
+			],
 			"csp": {
 				"default-src": "'self' customprotocol: asset:",
 				"connect-src": "ipc: http://ipc.localhost https://modrinth.com https://*.modrinth.com https://api.mclo.gs http://textures.minecraft.net https://textures.minecraft.net https://fill.papermc.io https://api.purpurmc.org 'self' data: blob:",
-				"font-src": ["https://cdn-raw.modrinth.com/fonts/"],
+				"font-src": [
+					"https://cdn-raw.modrinth.com/fonts/"
+				],
 				"img-src": "https: 'unsafe-inline' 'self' asset: http://asset.localhost http://textures.minecraft.net blob: data:",
 				"style-src": "'unsafe-inline' 'self'",
 				"script-src": "'self'",

--- a/packages/app-lib/src/api/curseforge.rs
+++ b/packages/app-lib/src/api/curseforge.rs
@@ -88,7 +88,6 @@ static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .read_timeout(Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none())
         .user_agent(crate::launcher_user_agent())
-        .no_proxy()
         .build()
         .expect("CurseForge client configuration should be valid")
 });
@@ -110,7 +109,6 @@ static LOCAL_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .read_timeout(Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none())
         .user_agent(crate::launcher_user_agent())
-        .no_proxy()
         .build()
         .expect("Local CurseForge client configuration should be valid")
 });

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -788,15 +788,16 @@ static MIRROR_REQUEST_SLOTS: LazyLock<AsyncMutex<[Instant; 2]>> =
     LazyLock::new(|| AsyncMutex::new([Instant::now(); 2]));
 
 fn reqwest_client_builder() -> reqwest::ClientBuilder {
-    reqwest::Client::builder()
-        .connect_timeout(FILE_TRANSFER_CONNECT_TIMEOUT)
-        .read_timeout(FILE_TRANSFER_READ_TIMEOUT)
-        .tcp_keepalive(Some(time::Duration::from_secs(10)))
-        .tcp_nodelay(true)
-        .pool_max_idle_per_host(64)
-        .http1_only()
-        .dns_resolver(Arc::clone(&DOWNLOAD_DNS_RESOLVER))
-        .user_agent(crate::launcher_user_agent())
+	reqwest::Client::builder()
+		.connect_timeout(FILE_TRANSFER_CONNECT_TIMEOUT)
+		.read_timeout(FILE_TRANSFER_READ_TIMEOUT)
+		.tcp_keepalive(Some(time::Duration::from_secs(10)))
+		.tcp_nodelay(true)
+		.pool_max_idle_per_host(64)
+		.http1_only()
+		.dns_resolver(Arc::clone(&DOWNLOAD_DNS_RESOLVER))
+		.user_agent(crate::launcher_user_agent())
+		.proxy(reqwest::Proxy::system())
 }
 
 pub static INSECURE_REQWEST_CLIENT: LazyLock<reqwest::Client> =


### PR DESCRIPTION
## 更改内容

### 修复
- 将 Linux 桌面文件模板从 Tauri 模板变量格式改为固定值格式
- 修复 deb 打包依赖项，添加 libwebkit2gtk、libgtk-3、libayatana-appindicator
- 修复 vite 配置使用 rolldownOptions 替代 rollupOptions

### 功能
- 启用系统代理支持：默认请求逻辑现在会使用系统代理设置，不再强制禁用代理
- 更新公告目录和更新日志

## Summary by Sourcery

为网络请求启用系统代理支持，并修复 Linux 打包和桌面集成相关问题。

新功能：
- 现在默认的网络请求会遵循系统代理配置。
- 添加面向用户的公告，说明新的系统代理行为以及 Linux 打包方面的变更。

错误修复：
- 通过修正构建配置和依赖项并更新桌面文件模板，修复 Linux deb 打包问题。
- 更正 Vite 构建配置，将外部依赖的设置从 `rollupOptions` 改为使用 `rolldownOptions`。
- 从与 CurseForge 相关的 HTTP 客户端中移除强制禁用代理的逻辑，以便它们可以使用系统代理设置。

文档：
- 更新变更日志，加入关于 Linux 桌面文件改进、启用系统代理以及 deb 打包修复的详细说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable system proxy support for network requests and fix Linux packaging and desktop integration issues.

New Features:
- Default network requests now respect the system proxy configuration.
- Add user-facing announcements describing the new system proxy behavior and Linux packaging changes.

Bug Fixes:
- Fix Linux deb packaging by correcting build configuration and dependencies and updating the desktop file template.
- Correct Vite build configuration to use rolldownOptions for external dependencies instead of rollupOptions.
- Remove forced proxy disabling from CurseForge-related HTTP clients so they can use system proxy settings.

Documentation:
- Update the changelog with details about Linux desktop file improvements, system proxy enablement, and deb packaging fixes.

</details>