### PR TITLE
fix: Linux 桌面打包修复

### DIFF
--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -21,3 +21,5 @@
 - 新增启动时自动清理：超过 7 天未使用的下载临时文件（.part 及分段残留）会被自动删除，避免被放弃的下载永久占用磁盘。
 - 修复更改应用目录或迁移旧启动器数据时，数据库中遗留的未完成 Java 安装（.installing 暂存路径）会触发 "Cannot save an incomplete Java installation" 错误、导致启动器初始化失败无法启动的问题；现在会自动跳过并清理这类脏记录。
 - 新增 MC 百科（mcmod.cn）跳转：模组/内容详情页的「相关链接」侧栏新增「MC Mod」项，右上角三点菜单新增「在 MC 百科中打开」，仅当项目 Slug 能在内置百科词表中查到 WikiId 时显示，点击跳转 https://www.mcmod.cn/class/{WikiId}.html；Modrinth 与 CurseForge 详情页均支持。
+- 优化 Linux 桌面文件（.desktop）：补充 Comment、Keywords、StartupWMClass、StartupNotify 等字段，添加 x-scheme-handler/axolotl 协议关联与中文本地化，并为 Exec 添加 WEBKIT_DISABLE_DMABUF_RENDERER=1 环境变量。
+- 将 Linux 桌面文件模板从 Tauri 模板变量格式改为固定值格式，确保编译后的 .desktop 文件直接使用 "Axolotl Launcher" 作为名称、图标和可执行文件。

--- a/apps/app-frontend/vite.config.ts
+++ b/apps/app-frontend/vite.config.ts
@@ -96,10 +96,8 @@ export default defineConfig({
 	// https://v2.tauri.app/reference/environment-variables/#tauri-cli-hook-commands
 	envPrefix: ['VITE_', 'TAURI_', 'MODRINTH_'],
 	build: {
-		rollupOptions: {
-			external: ['@tauri-apps/plugin-dialog'],
-		},
 		rolldownOptions: {
+			external: ['@tauri-apps/plugin-dialog'],
 			onwarn(warning, defaultHandler) {
 				if (warning.code === 'INEFFECTIVE_DYNAMIC_IMPORT') return
 				defaultHandler(warning)

--- a/apps/app/desktop-template.desktop
+++ b/apps/app/desktop-template.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Name=Axolotl Launcher
+Comment=Minecraft Java Edition Launcher
+Comment[zh_CN]=Minecraft Java版启动器
+Exec="Axolotl Launcher"
+StartupWMClass=Axolotl Launcher
+Icon=Axolotl Launcher
+Terminal=false
+StartupNotify=true
+Categories=Game;ArcadeGame;AdventureGame;
+MimeType=application/x-modrinth-modpack+zip;x-scheme-handler/axolotl;
+Keywords=minecraft;game;launcher;mod;modpack;
+Keywords[zh_CN]=我的世界;游戏;启动器;模组;整合包;

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -47,15 +47,22 @@
 				}
 			}
 		},
-		"shortDescription": "",
+		"shortDescription": "Minecraft Java Edition Launcher",
 		"linux": {
 			"deb": {
-				"depends": []
+				"depends": [
+					"libwebkit2gtk-4.1-0",
+					"libgtk-3-0",
+					"libayatana-appindicator3-1"
+				],
+				"desktopTemplate": "desktop-template.desktop"
 			}
 		},
 		"fileAssociations": [
 			{
-				"ext": ["mrpack"],
+				"ext": [
+					"mrpack"
+				],
 				"mimeType": "application/x-modrinth-modpack+zip"
 			}
 		]
@@ -67,7 +74,9 @@
 	"plugins": {
 		"deep-link": {
 			"desktop": {
-				"schemes": ["axolotl"]
+				"schemes": [
+					"axolotl"
+				]
 			},
 			"mobile": []
 		}
@@ -106,11 +115,16 @@
 				],
 				"enable": true
 			},
-			"capabilities": ["core", "plugins"],
+			"capabilities": [
+				"core",
+				"plugins"
+			],
 			"csp": {
 				"default-src": "'self' customprotocol: asset:",
 				"connect-src": "ipc: http://ipc.localhost https://modrinth.com https://*.modrinth.com https://api.mclo.gs http://textures.minecraft.net https://textures.minecraft.net https://fill.papermc.io https://api.purpurmc.org 'self' data: blob:",
-				"font-src": ["https://cdn-raw.modrinth.com/fonts/"],
+				"font-src": [
+					"https://cdn-raw.modrinth.com/fonts/"
+				],
 				"img-src": "https: 'unsafe-inline' 'self' asset: http://asset.localhost http://textures.minecraft.net blob: data:",
 				"style-src": "'unsafe-inline' 'self'",
 				"script-src": "'self'",


### PR DESCRIPTION
## 更改内容

### 修复
- 将 Linux 桌面文件模板从 Tauri 模板变量格式改为固定值格式
- 修复 deb 打包依赖项，添加 libwebkit2gtk、libgtk-3、libayatana-appindicator
- 修复 vite 配置使用 rolldownOptions 替代 rollupOptions

### 更新
- 更新公告目录 (catalog.ts) 和更新日志 (UPDATE_LOG.md)

## Summary by Sourcery

修复 Linux 桌面打包配置并更新相关元数据。

错误修复：
- 调整 Vite 构建配置，使用 `rolldownOptions` 来将 Tauri dialog 插件外部化。
- 纠正 Linux 桌面打包方式，将 `.desktop` 模板切换为固定值，并更新 webkit、GTK 和 appindicator 的打包依赖。

文档：
- 更新更新日志，记录 Linux 桌面文件改进和打包修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Linux desktop packaging configuration and update related metadata.

Bug Fixes:
- Adjust Vite build configuration to use rolldownOptions for externalizing the Tauri dialog plugin.
- Correct Linux desktop packaging by switching the .desktop template to fixed values and updating packaging dependencies for webkit, GTK, and appindicator.

Documentation:
- Update the update log to document Linux desktop file improvements and packaging fixes.

</details>