### PR TITLE
在拉起陶瓦联机进程的时候就加入参数--hmcl

### DIFF
--- a/packages/app-lib/src/api/terracotta.rs
+++ b/packages/app-lib/src/api/terracotta.rs
@@ -30,16 +30,16 @@ mod lan;
 const MAX_TERRACOTTA_ARCHIVE_SIZE: u64 = 256 * 1024 * 1024;
 const MAX_CONSECUTIVE_POLL_FAILURES: u8 = 3;
 const TERRACOTTA_REQUEST_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(10);
+std::time::Duration::from_secs(10);
 
 static TERRACOTTA_STATE: LazyLock<Mutex<TerracottaState>> =
-    LazyLock::new(|| Mutex::new(TerracottaState::default()));
+LazyLock::new(|| Mutex::new(TerracottaState::default()));
 
 static TERRACOTTA_RUNTIME: LazyLock<Mutex<TerracottaRuntime>> =
-    LazyLock::new(|| Mutex::new(TerracottaRuntime::default()));
+LazyLock::new(|| Mutex::new(TerracottaRuntime::default()));
 
 static TERRACOTTA_OPERATION: LazyLock<Mutex<()>> =
-    LazyLock::new(|| Mutex::new(()));
+LazyLock::new(|| Mutex::new(()));
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TerracottaState {
@@ -218,7 +218,7 @@ fn capture_terracotta_output<R>(
     pid: u32,
     output: Arc<Mutex<VecDeque<String>>>,
 ) where
-    R: AsyncRead + Unpin + Send + 'static,
+R: AsyncRead + Unpin + Send + 'static,
 {
     tokio::spawn(async move {
         let mut lines = BufReader::new(reader).lines();
@@ -241,11 +241,11 @@ async fn request_terracotta_port(
     let result = tokio::time::timeout(
         TERRACOTTA_REQUEST_TIMEOUT,
         Command::new(binary_path)
-            .arg("--hmcl")
-            .arg(port_file)
-            .stdin(Stdio::null())
-            .kill_on_drop(true)
-            .output(),
+        .arg("--hmcl")
+        .arg(port_file)
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output(),
     )
     .await
     .wrap_err("timed out requesting terracotta HTTP port")?
@@ -255,41 +255,41 @@ async fn request_terracotta_port(
 
     for (stream, bytes) in
         [("stdout", result.stdout), ("stderr", result.stderr)]
-    {
-        let text = String::from_utf8_lossy(&bytes);
-        for line in text.lines() {
-            let line = format!("{stream}: {line}");
-            tracing::debug!(target: "terracotta", stream, "{line}");
-            let mut captured = output.lock().await;
-            captured.push_back(line.clone());
-            if captured.len() > 50 {
-                captured.pop_front();
+        {
+            let text = String::from_utf8_lossy(&bytes);
+            for line in text.lines() {
+                let line = format!("{stream}: {line}");
+                tracing::debug!(target: "terracotta", stream, "{line}");
+                let mut captured = output.lock().await;
+                captured.push_back(line.clone());
+                if captured.len() > 50 {
+                    captured.pop_front();
+                }
+                command_output.push(line);
             }
-            command_output.push(line);
         }
-    }
 
-    if !status.success() {
-        let details = command_output.join("\n");
-        if details.is_empty() {
-            bail!("terracotta port request exited with {status}");
+        if !status.success() {
+            let details = command_output.join("\n");
+            if details.is_empty() {
+                bail!("terracotta port request exited with {status}");
+            }
+            bail!("terracotta port request exited with {status}:\n{details}");
         }
-        bail!("terracotta port request exited with {status}:\n{details}");
-    }
-    Ok(())
+        Ok(())
 }
 
 async fn take_terminated_terracotta_process() -> eyre::Result<
-    Option<(std::process::ExitStatus, Arc<Mutex<VecDeque<String>>>)>,
+Option<(std::process::ExitStatus, Arc<Mutex<VecDeque<String>>>)>,
 > {
     let mut runtime = TERRACOTTA_RUNTIME.lock().await;
     let Some(process) = runtime.process.as_mut() else {
         return Ok(None);
     };
     let Some(status) = process
-        .child
-        .try_wait()
-        .wrap_err("failed to inspect terracotta process")?
+    .child
+    .try_wait()
+    .wrap_err("failed to inspect terracotta process")?
     else {
         return Ok(None);
     };
@@ -343,19 +343,19 @@ async fn get_latest_terracotta_version() -> eyre::Result<String> {
 
     for endpoint in endpoints {
         let response = crate::util::fetch::INSECURE_REQWEST_CLIENT
-            .get(endpoint)
-            .header("Accept", "application/json")
-            .header("User-Agent", crate::launcher_user_agent())
-            .send()
-            .await;
+        .get(endpoint)
+        .header("Accept", "application/json")
+        .header("User-Agent", crate::launcher_user_agent())
+        .send()
+        .await;
         match response {
             Ok(response) if response.status().is_success() => {
                 match response.json::<ReleaseInfo>().await {
                     Ok(info) => {
                         return Ok(info
-                            .tag_name
-                            .trim_start_matches('v')
-                            .to_string());
+                        .tag_name
+                        .trim_start_matches('v')
+                        .to_string());
                     }
                     Err(error) => failures.push(format!("{endpoint}: {error}")),
                 }
@@ -412,9 +412,9 @@ async fn download_terracotta_inner(
         }
 
         match crate::util::fetch::INSECURE_REQWEST_CLIENT
-            .get(url)
-            .send()
-            .await
+        .get(url)
+        .send()
+        .await
         {
             Ok(response) if response.status().is_success() => {
                 let total_size = response.content_length().unwrap_or(0);
@@ -451,9 +451,9 @@ async fn download_terracotta_inner(
 
                     if total_size > 0 {
                         let pct = ((downloaded as f64 / total_size as f64)
-                            * 100.0)
-                            .clamp(0.0, 100.0)
-                            as u8;
+                        * 100.0)
+                        .clamp(0.0, 100.0)
+                        as u8;
                         let mut state = TERRACOTTA_STATE.lock().await;
                         state.download_progress = Some(pct);
                     }
@@ -468,33 +468,33 @@ async fn download_terracotta_inner(
                 {
                     let mut state = TERRACOTTA_STATE.lock().await;
                     state.download_stage =
-                        Some(TerracottaDownloadStage::Verifying);
+                    Some(TerracottaDownloadStage::Verifying);
                 }
 
                 let hash_url = format!("{url}.sha512");
                 match crate::util::fetch::INSECURE_REQWEST_CLIENT
-                    .get(&hash_url)
-                    .send()
-                    .await
+                .get(&hash_url)
+                .send()
+                .await
                 {
                     Ok(hash_resp) if hash_resp.status().is_success() => {
                         let checksum = hash_resp
-                            .text()
-                            .await
-                            .unwrap_or_default()
-                            .trim()
-                            .to_string();
+                        .text()
+                        .await
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
                         let expected_hash = checksum.split_whitespace().next();
                         if expected_hash.is_none_or(|hash| {
                             hash.len() != 128
-                                || !hash.chars().all(|character| {
-                                    character.is_ascii_hexdigit()
-                                })
-                                || !computed_hash.eq_ignore_ascii_case(hash)
+                            || !hash.chars().all(|character| {
+                                character.is_ascii_hexdigit()
+                            })
+                            || !computed_hash.eq_ignore_ascii_case(hash)
                         }) {
                             warn!(
                                 "SHA-512 mismatch for terracotta archive from {url}: \
-								 expected {expected_hash:?}, computed {computed_hash}"
+expected {expected_hash:?}, computed {computed_hash}"
                             );
                             continue;
                         }
@@ -505,7 +505,7 @@ async fn download_terracotta_inner(
                     _ => {
                         warn!(
                             "no SHA-512 checksum available at {hash_url}, \
-							 skipping verification"
+skipping verification"
                         );
                     }
                 }
@@ -536,20 +536,20 @@ async fn download_terracotta_inner(
     }
 
     let target_dir = terracotta_binary_path()
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("terracotta"));
+    .parent()
+    .map(|p| p.to_path_buf())
+    .unwrap_or_else(|| PathBuf::from("terracotta"));
 
     tokio::fs::create_dir_all(&target_dir)
-        .await
-        .wrap_err("failed to create terracotta directory")?;
+    .await
+    .wrap_err("failed to create terracotta directory")?;
 
     let staging_dir = tempfile::Builder::new()
-        .prefix("terracotta-install-")
-        .tempdir_in(&target_dir)
-        .wrap_err(
-            "failed to create terracotta installation staging directory",
-        )?;
+    .prefix("terracotta-install-")
+    .tempdir_in(&target_dir)
+    .wrap_err(
+        "failed to create terracotta installation staging directory",
+    )?;
     let staging_path = staging_dir.path().to_path_buf();
     let archive_data_clone = archive_data;
 
@@ -557,8 +557,8 @@ async fn download_terracotta_inner(
         let decoder = GzDecoder::new(&archive_data_clone[..]);
         let mut archive = tar::Archive::new(decoder);
         archive
-            .unpack(&staging_path)
-            .wrap_err("failed to extract terracotta archive")?;
+        .unpack(&staging_path)
+        .wrap_err("failed to extract terracotta archive")?;
         Ok(())
     })
     .await??;
@@ -571,12 +571,12 @@ async fn download_terracotta_inner(
     let expected_path = target_dir.join(terracotta_binary_name());
     let versioned_name = versioned_terracotta_binary_name(&version, platform);
     let candidate =
-        find_terracotta_executable(staging_dir.path(), Some(&versioned_name))
-            .ok_or_else(|| {
-            eyre::eyre!(
-                "no valid terracotta executable found in downloaded archive"
-            )
-        })?;
+    find_terracotta_executable(staging_dir.path(), Some(&versioned_name))
+    .ok_or_else(|| {
+        eyre::eyre!(
+            "no valid terracotta executable found in downloaded archive"
+        )
+    })?;
 
     #[cfg(unix)]
     {
@@ -594,7 +594,7 @@ async fn download_terracotta_inner(
     info!(
         "installed {} as {}",
         candidate.display(),
-        expected_path.display()
+          expected_path.display()
     );
 
     cleanup_legacy_versions(&version).await?;
@@ -642,11 +642,11 @@ pub async fn download_terracotta(version: Option<String>) -> eyre::Result<()> {
 fn terracotta_client() -> &'static reqwest::Client {
     static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         reqwest::Client::builder()
-            .no_proxy()
-            .connect_timeout(std::time::Duration::from_secs(2))
-            .timeout(TERRACOTTA_REQUEST_TIMEOUT)
-            .build()
-            .expect("terracotta client should build")
+        .no_proxy()
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .timeout(TERRACOTTA_REQUEST_TIMEOUT)
+        .build()
+        .expect("terracotta client should build")
     });
     &CLIENT
 }
@@ -662,15 +662,15 @@ async fn terracotta_get<T: serde::de::DeserializeOwned>(
     })?;
     let status = resp.status();
     let body = resp
-        .text()
-        .await
-        .wrap_err("failed to read terracotta response")?;
+    .text()
+    .await
+    .wrap_err("failed to read terracotta response")?;
     if !status.is_success() {
         bail!(
             "terracotta returned {} for {}: {}",
             status.as_u16(),
-            path,
-            body
+              path,
+              body
         );
     }
     let parsed: T = serde_json::from_str(&body).wrap_err_with(|| {
@@ -681,8 +681,8 @@ async fn terracotta_get<T: serde::de::DeserializeOwned>(
 
 fn terracotta_server_port(url: Option<&str>) -> Option<u16> {
     url?.parse::<std::net::SocketAddr>()
-        .ok()
-        .map(|url| url.port())
+    .ok()
+    .map(|url| url.port())
 }
 
 async fn sync_minecraft_lan_announcer(port: Option<u16>) {
@@ -723,10 +723,10 @@ async fn poll_terracotta_state(port: u16) {
                 state.profile_index = api_state.profile_index;
 
                 state.status = TerracottaStatus::from_api(&api_state.state)
-                    .unwrap_or_else(|| {
-                        warn!("unknown terracotta state: {}", api_state.state);
-                        TerracottaStatus::Error
-                    });
+                .unwrap_or_else(|| {
+                    warn!("unknown terracotta state: {}", api_state.state);
+                    TerracottaStatus::Error
+                });
 
                 if TerracottaStatus::from_api(&api_state.state).is_none() {
                     state.error_type = Some(TerracottaErrorType::Terracotta);
@@ -736,7 +736,7 @@ async fn poll_terracotta_state(port: u16) {
                     ));
                 } else if state.status == TerracottaStatus::Fatal {
                     state.error_type =
-                        api_state.r#type.map(TerracottaErrorType::from);
+                    api_state.r#type.map(TerracottaErrorType::from);
                     state.error_message = api_state.url.clone();
                 } else if state.status != TerracottaStatus::Error {
                     state.error_type = None;
@@ -745,14 +745,14 @@ async fn poll_terracotta_state(port: u16) {
 
                 if let Some(profiles) = api_state.profiles {
                     state.players = profiles
-                        .into_iter()
-                        .map(|p| PlayerInfo {
-                            machine_id: p.machine_id,
-                            name: p.name,
-                            vendor: p.vendor,
-                            kind: TerracottaPlayerKind::from(p.kind.as_str()),
-                        })
-                        .collect();
+                    .into_iter()
+                    .map(|p| PlayerInfo {
+                        machine_id: p.machine_id,
+                        name: p.name,
+                        vendor: p.vendor,
+                        kind: TerracottaPlayerKind::from(p.kind.as_str()),
+                    })
+                    .collect();
                 }
                 drop(state);
                 sync_minecraft_lan_announcer(server_port).await;
@@ -794,8 +794,8 @@ pub async fn get_state() -> TerracottaState {
 pub async fn get_meta() -> eyre::Result<TerracottaMeta> {
     let state = TERRACOTTA_STATE.lock().await;
     let port = state
-        .http_port
-        .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
+    .http_port
+    .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
     drop(state);
     terracotta_get::<TerracottaMeta>(port, "/meta").await
 }
@@ -821,7 +821,7 @@ pub async fn start_terracotta(
         resolve_installed_terracotta_binary_path,
         resolve_terracotta_binary_path,
     );
-
+    
     if !is_terracotta_executable(&final_path) && auto_download {
         info!("terracotta binary not found, attempting auto-download");
         run_terracotta_download(None).await?;
@@ -830,16 +830,16 @@ pub async fn start_terracotta(
             resolve_terracotta_binary_path,
         );
     }
-
+    
     if !is_terracotta_executable(&final_path) {
         bail!(
             "valid terracotta executable not found at {} (platform: {}, expected name: {})",
-            final_path.display(),
-            terracotta_platform_key(),
-            terracotta_binary_name()
+              final_path.display(),
+              terracotta_platform_key(),
+              terracotta_binary_name()
         );
     }
-
+    
     let mut runtime = TERRACOTTA_RUNTIME.lock().await;
     if let Some(process) = runtime.process.as_mut() {
         if process
@@ -847,50 +847,51 @@ pub async fn start_terracotta(
             .try_wait()
             .wrap_err("failed to inspect existing terracotta process")?
             .is_none()
-        {
-            bail!("terracotta is already running");
-        }
-        warn!("discarding exited terracotta process before restart");
+            {
+                bail!("terracotta is already running");
+            }
+            warn!("discarding exited terracotta process before restart");
         runtime.process.take();
     }
-
+    
     let temp_dir = std::env::temp_dir();
     let port_file =
-        temp_dir.join(format!("terracotta_port_{}.json", std::process::id()));
+    temp_dir.join(format!("terracotta_port_{}.json", std::process::id()));
     let _ = std::fs::remove_file(&port_file);
-
+    
     let mut child = Command::new(&final_path)
-        .args(terracotta_startup_arguments(std::env::consts::OS))
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .wrap_err_with(|| {
-            format!("failed to start terracotta at {}", final_path.display())
-        })?;
-
+    .arg("--hmcl")
+    .arg(&port_file)
+    .stdin(Stdio::null())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true)
+    .spawn()
+    .wrap_err_with(|| {
+        format!("failed to start terracotta with --hmcl at {}", final_path.display())
+    })?;
+    
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
     let pid = child.id().unwrap_or(0);
     let output = Arc::new(Mutex::new(VecDeque::new()));
-
+    
     if let Some(stdout) = stdout {
         capture_terracotta_output(stdout, "stdout", pid, output.clone());
     }
     if let Some(stderr) = stderr {
         capture_terracotta_output(stderr, "stderr", pid, output.clone());
     }
-
+    
     let pid = child.id().unwrap_or(0);
     info!("started terracotta (pid {pid})");
-
+    
     runtime.process = Some(TerracottaProcess {
         child,
         output: output.clone(),
     });
     drop(runtime);
-
+    
     {
         let mut state = TERRACOTTA_STATE.lock().await;
         state.status = TerracottaStatus::Starting;
@@ -902,125 +903,75 @@ pub async fn start_terracotta(
         state.error_message = None;
         state.profile_index = None;
     }
-
-    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    if let Some((status, output)) = take_terminated_terracotta_process().await?
-    {
-        let message = format_terracotta_exit(status, output).await;
-        if let Some(port) = reported_terracotta_port(&message) {
-            if terracotta_get::<TerracottaMeta>(port, "/meta")
-                .await
-                .is_ok()
-            {
-                info!("connected to existing terracotta on port {port}");
-                spawn_terracotta_state_poller(port).await;
-                let mut state = TERRACOTTA_STATE.lock().await;
-                state.status = TerracottaStatus::Idle;
-                state.http_port = Some(port);
-                state.error_type = None;
-                state.error_message = None;
-                return Ok(());
-            }
-        }
-        let mut state = TERRACOTTA_STATE.lock().await;
-        state.status = TerracottaStatus::Error;
-        state.error_type = Some(TerracottaErrorType::Terracotta);
-        state.error_message = Some(message.clone());
-        bail!(message);
-    }
-    if let Err(error) =
-        request_terracotta_port(&final_path, &port_file, output.clone()).await
-    {
-        TERRACOTTA_RUNTIME.lock().await.process.take();
-        let message = format!("{error:#}");
-        let mut state = TERRACOTTA_STATE.lock().await;
-        state.status = TerracottaStatus::Error;
-        state.error_type = Some(TerracottaErrorType::Terracotta);
-        state.error_message = Some(message);
-        return Err(error);
-    }
-
-    for i in 0..30 {
+    
+    let mut attempts = 0;
+    const MAX_ATTEMPTS: u32 = 30; 
+    let port = loop {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        attempts += 1;
+        if attempts > MAX_ATTEMPTS {
+            let output = {
+                let mut runtime = TERRACOTTA_RUNTIME.lock().await;
+                runtime.process.take().map(|mut p| {
+                    let _ = p.child.start_kill();
+                    p.output.clone()
+                })
+            };
+            let details = match output {
+                Some(out) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    out.lock().await.iter().cloned().collect::<Vec<_>>().join("\n")
+                }
+                None => String::new(),
+            };
+            let msg = if details.is_empty() {
+                "timed out waiting for terracotta to start".to_string()
+            } else {
+                format!("timed out waiting for terracotta to start:\n{details}")
+            };
+            let mut state = TERRACOTTA_STATE.lock().await;
+            state.status = TerracottaStatus::Error;
+            state.error_type = Some(TerracottaErrorType::Terracotta);
+            state.error_message = Some(msg.clone());
+            bail!(msg);
+        }
+        
+        if let Some((status, output)) = take_terminated_terracotta_process().await? {
+            let message = format_terracotta_exit(status, output).await;
+            bail!("terracotta exited before writing port file: {}", message);
+        }
+        
         match std::fs::read_to_string(&port_file) {
             Ok(contents) => {
-                #[derive(Deserialize)]
+                #[derive(serde::Deserialize)]
                 struct PortInfo {
                     port: u16,
                 }
                 match serde_json::from_str::<PortInfo>(&contents) {
-                    Ok(port_info) => {
+                    Ok(info) => {
                         let _ = std::fs::remove_file(&port_file);
-
-                        info!("terracotta started on port {}", port_info.port);
-
-                        let port = port_info.port;
-                        spawn_terracotta_state_poller(port).await;
-
-                        let mut state = TERRACOTTA_STATE.lock().await;
-                        state.http_port = Some(port);
-                        return Ok(());
+                        break info.port;
                     }
                     Err(e) => {
-                        warn!("failed to parse terracotta port file: {e}");
+                        warn!("failed to parse terracotta port file: {}", e);
+                        continue;
                     }
                 }
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                if i == 0 {
-                    info!(
-                        "waiting for terracotta port file at {}",
-                        port_file.display()
-                    );
-                }
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(e) => {
-                warn!("failed to read terracotta port file: {e}");
+                warn!("failed to read terracotta port file: {}", e);
+                continue;
             }
         }
-
-        if let Some((status, output)) =
-            take_terminated_terracotta_process().await?
-        {
-            let message = format_terracotta_exit(status, output).await;
-            let mut state = TERRACOTTA_STATE.lock().await;
-            state.status = TerracottaStatus::Error;
-            state.error_type = Some(TerracottaErrorType::Terracotta);
-            state.error_message = Some(message.clone());
-            bail!(message);
-        }
-    }
-
-    let output = {
-        let mut runtime = TERRACOTTA_RUNTIME.lock().await;
-        runtime.process.take().map(|mut process| {
-            let _ = process.child.start_kill();
-            process.output.clone()
-        })
     };
-    let details = match output {
-        Some(output) => {
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            output
-                .lock()
-                .await
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n")
-        }
-        None => String::new(),
-    };
-    let message = if details.is_empty() {
-        "timed out waiting for terracotta to start".to_string()
-    } else {
-        format!("timed out waiting for terracotta to start:\n{details}")
-    };
+    
+    info!("terracotta started on port {}", port);
+    spawn_terracotta_state_poller(port).await;
     let mut state = TERRACOTTA_STATE.lock().await;
-    state.status = TerracottaStatus::Error;
-    state.error_type = Some(TerracottaErrorType::Terracotta);
-    state.error_message = Some(message.clone());
-    bail!(message);
+    state.http_port = Some(port);
+    state.status = TerracottaStatus::Idle;
+    Ok(())
 }
 
 pub async fn stop_terracotta() -> eyre::Result<()> {
@@ -1051,7 +1002,7 @@ fn build_room_url(
     let mut url = format!(
         "http://127.0.0.1:{port}{path}?room={}&player={}",
         urlencoding::encode(room),
-        urlencoding::encode(player),
+                          urlencoding::encode(player),
     );
     for node in nodes {
         url.push_str("&public_nodes=");
@@ -1071,8 +1022,8 @@ pub async fn start_hosting(
     }
     let state = TERRACOTTA_STATE.lock().await;
     let port = state
-        .http_port
-        .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
+    .http_port
+    .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
     drop(state);
 
     let room_param = room_code.as_deref().unwrap_or("");
@@ -1087,10 +1038,10 @@ pub async fn start_hosting(
         &nodes,
     );
     let resp = client
-        .get(&url)
-        .send()
-        .await
-        .wrap_err("failed to send hosting request to terracotta")?;
+    .get(&url)
+    .send()
+    .await
+    .wrap_err("failed to send hosting request to terracotta")?;
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
@@ -1114,8 +1065,8 @@ pub async fn start_joining(
     let room_code = parse_room_code(&room_code)?;
     let state = TERRACOTTA_STATE.lock().await;
     let port = state
-        .http_port
-        .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
+    .http_port
+    .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
     drop(state);
 
     let nodes: Vec<String> = Vec::new();
@@ -1129,10 +1080,10 @@ pub async fn start_joining(
         &nodes,
     );
     let resp = client
-        .get(&url)
-        .send()
-        .await
-        .wrap_err("failed to send joining request to terracotta")?;
+    .get(&url)
+    .send()
+    .await
+    .wrap_err("failed to send joining request to terracotta")?;
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
@@ -1188,11 +1139,11 @@ pub fn parse_room_code(code: &str) -> eyre::Result<String> {
             if segments.len() == 4
                 && segments.iter().all(|s| s.len() == 4)
                 && segments
-                    .iter()
-                    .all(|s| s.chars().all(|c| c.is_ascii_alphanumeric()))
-            {
-                return Ok(format!("U/{inner}"));
-            }
+                .iter()
+                .all(|s| s.chars().all(|c| c.is_ascii_alphanumeric()))
+                {
+                    return Ok(format!("U/{inner}"));
+                }
         }
     }
     bail!(
@@ -1203,32 +1154,32 @@ pub fn parse_room_code(code: &str) -> eyre::Result<String> {
 pub async fn get_logs() -> eyre::Result<String> {
     let state = TERRACOTTA_STATE.lock().await;
     let port = state
-        .http_port
-        .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
+    .http_port
+    .ok_or_else(|| eyre::eyre!("terracotta is not running"))?;
     drop(state);
 
     let client = terracotta_client();
     let url = format!("http://127.0.0.1:{port}/log?fetch=");
     let resp = client
-        .get(&url)
-        .send()
-        .await
-        .wrap_err("failed to fetch terracotta logs")?;
+    .get(&url)
+    .send()
+    .await
+    .wrap_err("failed to fetch terracotta logs")?;
     let body = resp
-        .text()
-        .await
-        .wrap_err("failed to read terracotta logs")?;
+    .text()
+    .await
+    .wrap_err("failed to read terracotta logs")?;
     Ok(body)
 }
 
 #[cfg(all(
-    test,
-    any(
-        target_os = "macos",
-        target_os = "linux",
-        target_os = "freebsd",
-        target_os = "windows"
-    )
+test,
+any(
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "windows"
+)
 ))]
 mod tests {
     use super::*;
@@ -1290,7 +1241,7 @@ mod tests {
         assert_eq!(
             find_terracotta_executable(
                 temp.path(),
-                Some("terracotta-0.4.2-test")
+                                       Some("terracotta-0.4.2-test")
             ),
             Some(preferred)
         );
@@ -1305,14 +1256,14 @@ mod tests {
         std::fs::write(&destination, b"old").unwrap();
 
         install_terracotta_binary(&candidate, &destination)
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         assert_eq!(std::fs::read(&destination).unwrap(), b"new");
         assert!(
             !destination
-                .with_file_name(format!("{}.old", terracotta_binary_name()))
-                .exists()
+            .with_file_name(format!("{}.old", terracotta_binary_name()))
+            .exists()
         );
     }
 
@@ -1325,8 +1276,8 @@ mod tests {
 
         assert!(
             install_terracotta_binary(&candidate, &destination)
-                .await
-                .is_err()
+            .await
+            .is_err()
         );
         assert_eq!(std::fs::read(&destination).unwrap(), b"old");
     }
@@ -1334,7 +1285,7 @@ mod tests {
     #[test]
     fn parses_port_reported_by_an_existing_daemon() {
         let output =
-            "stdout: [Lock]: Successfully join the global mutex, port = 57924";
+        "stdout: [Lock]: Successfully join the global mutex, port = 57924";
         assert_eq!(reported_terracotta_port(output), Some(57924));
     }
 
@@ -1351,7 +1302,7 @@ mod tests {
         let root = Path::new("launcher-data");
         assert_eq!(
             binary::terracotta_binary_path_in(root),
-            root.join("terracotta").join(terracotta_binary_name())
+                   root.join("terracotta").join(terracotta_binary_name())
         );
     }
 
@@ -1359,13 +1310,13 @@ mod tests {
     fn installed_binary_resolution_falls_back_to_the_legacy_location() {
         let temp = tempfile::tempdir().unwrap();
         let installed = temp
-            .path()
-            .join("launcher-data")
-            .join(terracotta_binary_name());
+        .path()
+        .join("launcher-data")
+        .join(terracotta_binary_name());
         let legacy = temp
-            .path()
-            .join("application")
-            .join(terracotta_binary_name());
+        .path()
+        .join("application")
+        .join(terracotta_binary_name());
         std::fs::create_dir_all(installed.parent().unwrap()).unwrap();
         std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
         std::fs::write(&legacy, executable_magic()).unwrap();
@@ -1382,13 +1333,13 @@ mod tests {
     fn installed_binary_resolution_keeps_the_writable_path_when_missing() {
         let temp = tempfile::tempdir().unwrap();
         let installed = temp
-            .path()
-            .join("launcher-data")
-            .join(terracotta_binary_name());
+        .path()
+        .join("launcher-data")
+        .join(terracotta_binary_name());
         let legacy = temp
-            .path()
-            .join("application")
-            .join(terracotta_binary_name());
+        .path()
+        .join("application")
+        .join(terracotta_binary_name());
 
         assert_eq!(
             binary::resolve_installed_terracotta_binary_path_from(
@@ -1402,7 +1353,7 @@ mod tests {
     fn parses_guest_server_port() {
         assert_eq!(
             terracotta_server_port(Some("127.0.0.1:38449")),
-            Some(38449)
+                   Some(38449)
         );
         assert_eq!(terracotta_server_port(Some("invalid")), None);
         assert_eq!(terracotta_server_port(None), None);
@@ -1429,7 +1380,7 @@ mod tests {
     fn maps_protocol_states_without_silently_accepting_unknown_values() {
         assert_eq!(
             TerracottaStatus::from_api("guest-ok"),
-            Some(TerracottaStatus::GuestReady)
+                   Some(TerracottaStatus::GuestReady)
         );
         assert_eq!(TerracottaStatus::from_api("future-state"), None);
     }
@@ -1438,7 +1389,7 @@ mod tests {
     fn validates_room_codes_at_the_backend_boundary() {
         assert_eq!(
             parse_room_code("u/ABCD-EFGH-IJKL-MNOP").unwrap(),
-            "U/ABCD-EFGH-IJKL-MNOP"
+                   "U/ABCD-EFGH-IJKL-MNOP"
         );
         assert!(parse_room_code("ABCD-EFGH-IJKL-MNOP").is_err());
         assert!(parse_room_code("U/ABCD-EFGH-IJKL-MNO!").is_err());
@@ -1448,11 +1399,11 @@ mod tests {
     fn serializes_error_types_for_the_frontend_contract() {
         assert_eq!(
             serde_json::to_string(&TerracottaErrorType::Terracotta).unwrap(),
-            "\"terracotta\""
+                   "\"terracotta\""
         );
         assert_eq!(
             serde_json::to_string(&TerracottaPlayerKind::Host).unwrap(),
-            "\"HOST\""
+                   "\"HOST\""
         );
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

在 HMCL 模式下启动 terracotta，并简化其启动/端口握手及错误处理流程。

New Features:
- 直接从启动器以 `--hmcl` 标志和端口文件参数启动 terracotta 进程。

Enhancements:
- 精简 terracotta 的启动逻辑，依赖其端口文件输出，并使用有界重试循环，提供更清晰的超时和错误报告。
- 调整与端口文件解析、进程退出和 HTTP 连接相关的日志和错误消息，以实现更一致的诊断信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Start terracotta in HMCL mode and simplify its startup/port handshake and error handling.

New Features:
- Launch the terracotta process with the --hmcl flag and port file parameter directly from the launcher.

Enhancements:
- Streamline terracotta startup logic to rely on its port file output with a bounded retry loop and clearer timeout/error reporting.
- Adjust logging and error messages around port file parsing, process exit, and HTTP connectivity for more consistent diagnostics.

</details>