### PR TITLE
feat(app): Add offline uuid support.

### DIFF
--- a/apps/app-frontend/src/components/ui/AccountsCard.vue
+++ b/apps/app-frontend/src/components/ui/AccountsCard.vue
@@ -163,6 +163,21 @@
 			>
 				{{ formatMessage(messages.chineseUsernameWarning) }}
 			</p>
+
+			<label class="flex flex-col gap-2 font-semibold">
+				{{ formatMessage(messages.uuidLabel) }}
+				<StyledInput
+					v-model="offlineUUID"
+					:disabled="loginDisabled"
+					placeholder="a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8"
+					autocomplete="off"
+					maxlength="36"
+				/>
+			</label>
+			<p v-if="offlineUUID.length > 0 && !offlineUUIDValid" class="m-0 text-sm text-red">
+				{{ formatMessage(messages.uuidValidation) }}
+			</p>
+
 			<div class="input-group push-right">
 				<ButtonStyled>
 					<button :disabled="loginDisabled" @click="offlineAccountModal?.hide()">
@@ -170,7 +185,14 @@
 					</button>
 				</ButtonStyled>
 				<ButtonStyled color="brand">
-					<button :disabled="loginDisabled || !offlineUsernameValid" @click="addOfflineAccount()">
+					<button
+						:disabled="
+							loginDisabled ||
+							!offlineUsernameValid ||
+							(offlineUUID.length > 0 && !offlineUUIDValid)
+						"
+						@click="addOfflineAccount()"
+					>
 						<SpinnerIcon v-if="loginDisabled" class="animate-spin" />
 						<PlusIcon v-else />
 						{{ formatMessage(messages.createOfflineAccount) }}
@@ -411,6 +433,10 @@ const offlineUsernameValid = computed(() =>
 const offlineUsernameContainsChinese = computed(() =>
 	/\p{Script=Han}/u.test(offlineUsername.value.trim()),
 )
+const offlineUUID = ref('')
+const offlineUUIDValid = computed(() =>
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(offlineUUID.value.trim()),
+)
 const yggdrasilAccountModal = ref<InstanceType<typeof ModalWrapper> | null>(null)
 const yggdrasilProfileModal = ref<InstanceType<typeof ModalWrapper> | null>(null)
 const yggdrasilApiRoot = ref(LITTLE_SKIN_API_ROOT)
@@ -453,8 +479,8 @@ function hasResolvedAccountHead(account: MinecraftCredential) {
 	const skin = getAccountSkin(account)
 	return Boolean(
 		skin &&
-			accountHeadUrlCache.value.has(account.profile.id) &&
-			accountHeadTextureKeyCache.value.get(account.profile.id) === skin.texture_key,
+		accountHeadUrlCache.value.has(account.profile.id) &&
+		accountHeadTextureKeyCache.value.get(account.profile.id) === skin.texture_key,
 	)
 }
 
@@ -702,6 +728,7 @@ async function login() {
 
 function showOfflineAccountModal() {
 	offlineUsername.value = ''
+	offlineUUID.value = ''
 	offlineAccountModal.value?.show()
 }
 
@@ -886,7 +913,7 @@ async function addOfflineAccount() {
 
 	loginDisabled.value = true
 	try {
-		const account = await add_offline_user(offlineUsername.value.trim())
+		const account = await add_offline_user(offlineUsername.value.trim(), offlineUUID.value.trim())
 		offlineAccountModal.value?.hide()
 		await setAccount(account)
 		trackEvent('OfflineAccountAdd')
@@ -1029,6 +1056,14 @@ const messages = defineMessages({
 		id: 'minecraft-account.offline-modal.description',
 		defaultMessage:
 			'Choose the username used in offline games. This account can only join servers that allow offline players.',
+	},
+	uuidLabel: {
+		id: 'minecraft-account.offline-modal.uuid-label.message',
+		defaultMessage: 'UUID (Optional)',
+	},
+	uuidValidation: {
+		id: 'minecraft-account.offline-modal.uuid-validation.message',
+		defaultMessage: 'Invalid UUID',
 	},
 	usernameLabel: {
 		id: 'minecraft-account.offline-modal.username-label',

--- a/apps/app-frontend/src/helpers/auth.js
+++ b/apps/app-frontend/src/helpers/auth.js
@@ -62,8 +62,8 @@ export async function delete_yggdrasil_password(apiRoot, login) {
  * @param {string} username
  * @returns {Promise<Credential>}
  */
-export async function add_offline_user(username) {
-	return await invoke('plugin:auth|add_offline_user', { username })
+export async function add_offline_user(username, uuid = '') {
+	return await invoke('plugin:auth|add_offline_user', { username, uuid })
 }
 
 /**

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6215,6 +6215,12 @@
 	"minecraft-account.offline-modal.title": {
 		"message": "Add offline account"
 	},
+	"minecraft-account.offline-modal.uuid-label": {
+		"message": "UUID (Optional)"
+	},
+	"minecraft-account.offline-modal.uuid-validation": {
+		"message": "Invalid UUID"
+	},
 	"minecraft-account.offline-modal.username-label": {
 		"message": "Minecraft username"
 	},

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -3446,6 +3446,12 @@
 	"minecraft-account.offline-modal.description": {
 		"message": "选择离线游戏中使用的用户名。此账户只能加入允许离线玩家的服务器。"
 	},
+	"minecraft-account.offline-modal.uuid-label": {
+		"message": "UUID (选填)"
+	},
+	"minecraft-account.offline-modal.uuid-validation": {
+		"message": "不符合格式的UUID"
+	},
 	"minecraft-account.offline-modal.title": {
 		"message": "添加离线账户"
 	},

--- a/apps/app/src/api/auth.rs
+++ b/apps/app/src/api/auth.rs
@@ -288,8 +288,11 @@ fn keyring_error(
 }
 
 #[tauri::command]
-pub async fn add_offline_user(username: String) -> Result<Credentials> {
-    Ok(minecraft_auth::add_offline_user(&username).await?)
+pub async fn add_offline_user(
+    username: String,
+    uuid: String,
+) -> Result<Credentials> {
+    Ok(minecraft_auth::add_offline_user(&username, &uuid).await?)
 }
 
 #[tauri::command]

--- a/packages/app-lib/src/api/minecraft_auth.rs
+++ b/packages/app-lib/src/api/minecraft_auth.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 use serde::Serialize;
 use std::time::Duration;
+use uuid::Uuid;
 
 use crate::State;
 pub use crate::state::YggdrasilLoginResult;
@@ -45,9 +46,21 @@ pub async fn finish_login(
 }
 
 #[tracing::instrument]
-pub async fn add_offline_user(username: &str) -> crate::Result<Credentials> {
+pub async fn add_offline_user(
+    username: &str,
+    uuid: &str,
+) -> crate::Result<Credentials> {
     let state = State::get().await?;
-    let credentials = Credentials::offline(username)?;
+    let credentials = Credentials::offline(
+        username,
+        if uuid.len() == 0 {
+            None
+        } else if let Ok(uuid) = Uuid::parse_str(uuid) {
+            Some(uuid)
+        } else {
+            None
+        },
+    )?;
     credentials.upsert(&state.pool).await?;
     Ok(credentials)
 }

--- a/packages/app-lib/src/state/minecraft_auth.rs
+++ b/packages/app-lib/src/state/minecraft_auth.rs
@@ -298,7 +298,7 @@ impl OnlineProfileCacheIntent {
 }
 
 impl Credentials {
-    pub fn offline(username: &str) -> crate::Result<Self> {
+    pub fn offline(username: &str, uuid: Option<Uuid>) -> crate::Result<Self> {
         let username = username.trim();
         if !(1..=16).contains(&username.chars().count())
             || !username.chars().all(|character| {
@@ -312,14 +312,20 @@ impl Credentials {
             .as_error());
         }
 
-        let mut uuid_bytes =
-            md5::compute(format!("OfflinePlayer:{username}")).0;
-        uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x30;
-        uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80;
+        let id = match uuid {
+            Some(id) => id,
+            None => {
+                let mut uuid_bytes =
+                    md5::compute(format!("OfflinePlayer:{username}")).0;
+                uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x30;
+                uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80;
+                Uuid::from_bytes(uuid_bytes)
+            }
+        };
 
         Ok(Self {
             offline_profile: MinecraftProfile {
-                id: Uuid::from_bytes(uuid_bytes),
+                id,
                 name: username.to_string(),
                 ..MinecraftProfile::default()
             },


### PR DESCRIPTION
User can specify UUID while adding offline account.
- Change backend api: `plugin:auth|add_offline_player`. If parameter `uuid` is `""`, generate a default UUID for username.
- Add UUID input at `OfflineAccountModal`. #96 
- If UUID inputed, will validate UUID.
- UUID can be empty to use default UUID generator.

<img width="737" height="483" alt="image" src="https://github.com/user-attachments/assets/8fd94603-d0a6-4bc6-a569-a602d5c6ae76" />

## Summary by Sourcery

为前端和后端的离线 Minecraft 账号添加可选的用户自定义 UUID 支持。

New Features:
- 允许用户在 UI 中创建离线账号时提供一个可选的 UUID，并在客户端进行校验，如果无效则禁用表单。
- 支持在创建离线凭据时使用用户提供的 UUID，或者在未提供时使用确定性生成的 UUID。

Enhancements:
- 扩展认证 API、Tauri 命令和辅助函数，以在创建离线账号时传递一个可选的 UUID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional user-specified UUID support for offline Minecraft accounts across frontend and backend.

New Features:
- Allow users to provide an optional UUID when creating offline accounts in the UI, with client-side validation and form disabling if invalid.
- Support creating offline credentials with either a provided UUID or a deterministically generated UUID when none is supplied.

Enhancements:
- Extend auth API, Tauri command, and helper functions to pass an optional UUID for offline account creation.

</details>