### PR TITLE
feat(app): Add theme color for modal overlay.

### DIFF
--- a/packages/ui/src/components/modal/NewModal.vue
+++ b/packages/ui/src/components/modal/NewModal.vue
@@ -418,7 +418,11 @@ defineOptions({
 
 	// Fade variants
 	&.standard {
-		background: linear-gradient(to bottom, rgba(29, 48, 43, 0.52) 0%, rgba(14, 21, 26, 0.95) 100%);
+		background: linear-gradient(
+			to bottom,
+			color-mix(in srgb, var(--color-brand-shadow) 10%, rgba(0, 0, 0, 0.52)) 0%,
+			color-mix(in srgb, var(--color-brand-shadow) 2%, rgba(0, 0, 0, 0.95)) 100%
+		);
 	}
 
 	&.warning {


### PR DESCRIPTION
Add theme color for `NewModal` standard overlay. #203 

<img width="1128" height="318" alt="Kooha-2026-08-09-20-18-41" src="https://github.com/user-attachments/assets/5826707d-290d-4180-8b55-a022e1519f06" />

## Summary by Sourcery

增强功能：
- 调整标准模态覆盖层的背景渐变效果，将品牌阴影颜色与现有深色调融合，以实现更好的主题融合效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust the standard modal overlay background gradient to blend the brand shadow color with existing dark tones for better theme integration.

</details>