### PR TITLE
下载加速：HTTP/2 文件传输 + 多线路冷启动探测 + 高速下载防卡死

### DIFF
--- a/apps/app-frontend/src/components/ui/AppActionBar.vue
+++ b/apps/app-frontend/src/components/ui/AppActionBar.vue
@@ -546,14 +546,27 @@ const installJobNotifications = await useInstallJobNotifications({
 
 await refreshLoadingBars()
 
+let newBarDuringWindow = false
+let loadingNotificationTimer: ReturnType<typeof setTimeout> | null = null
+
 const unlistenLoading = await loading_listener((payload: LoadingEventPayload) => {
 	const isNewBar = applyLoadingEvent(payload)
 	if (isNewBar) {
-		removeNotification()
-		updateNotification(true)
-	} else {
-		updateNotification()
+		newBarDuringWindow = true
 	}
+	if (loadingNotificationTimer !== null) {
+		return
+	}
+	loadingNotificationTimer = setTimeout(() => {
+		loadingNotificationTimer = null
+		if (newBarDuringWindow) {
+			newBarDuringWindow = false
+			removeNotification()
+			updateNotification(true)
+		} else {
+			updateNotification()
+		}
+	}, 250)
 })
 
 function goToDownloads() {
@@ -570,6 +583,10 @@ function selectProcess(process: RunningProcess) {
 }
 
 onBeforeUnmount(() => {
+	if (loadingNotificationTimer !== null) {
+		clearTimeout(loadingNotificationTimer)
+		loadingNotificationTimer = null
+	}
 	removeNotification()
 	dismissed.value = false
 	unlistenProcess()

--- a/apps/app-frontend/src/composables/browse/install-job-notifications.ts
+++ b/apps/app-frontend/src/composables/browse/install-job-notifications.ts
@@ -805,6 +805,10 @@ export async function useInstallJobNotifications(opts: {
 		}
 	}
 
+	let lastCompositionSignature: string | null = null
+	let lastMetadataRefreshAt = 0
+	let lastEnteredPackDownload = false
+
 	setJobs(opts.manager.jobs.value)
 	await refreshMetadata(false)
 	const stopJobsWatch = watch(
@@ -816,9 +820,18 @@ export async function useInstallJobNotifications(opts: {
 					job.phase === 'downloading_pack_file' &&
 					previousPhases.get(job.job_id) !== 'downloading_pack_file',
 			)
+			const signature = nextJobs.map((job) => `${job.job_id}:${job.status}:${job.phase}`).join('|')
+			const compositionChanged = signature !== lastCompositionSignature
+			lastCompositionSignature = signature
 			setJobs(nextJobs)
-			opts.onChange(enteredPackDownload)
-			void refreshMetadata()
+			if (enteredPackDownload !== lastEnteredPackDownload) {
+				lastEnteredPackDownload = enteredPackDownload
+				opts.onChange(enteredPackDownload)
+			}
+			if (compositionChanged || Date.now() - lastMetadataRefreshAt >= 2000) {
+				lastMetadataRefreshAt = Date.now()
+				void refreshMetadata()
+			}
 		},
 	)
 

--- a/apps/app-frontend/src/providers/download-manager.ts
+++ b/apps/app-frontend/src/providers/download-manager.ts
@@ -29,6 +29,9 @@ export const downloadBarTypes = new Set([
 	'launcher_update',
 ])
 
+const pendingRequestUpdates: DownloadRequestUpdate[] = []
+let requestFlushTimer: ReturnType<typeof setTimeout> | null = null
+
 export interface DownloadManager {
 	jobs: Ref<InstallJobSnapshot[]>
 	legacyDownloads: Ref<LoadingBar[]>
@@ -59,7 +62,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 	const pendingInitialUpdates: Array<
 		{ kind: 'job'; job: InstallJobSnapshot } | { kind: 'request'; update: DownloadRequestUpdate }
 	> = []
-	const pendingRequestUpdates = new Map<string, DownloadRequestUpdate[]>()
+	const pendingRequestUpdatesByJob = new Map<string, DownloadRequestUpdate[]>()
 
 	function persistManualDownloadsFromJob(job: InstallJobSnapshot) {
 		if (job.status !== 'waiting_for_user' && job.status !== 'succeeded') return
@@ -90,9 +93,9 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 		jobs.value = [job, ...jobs.value.filter((candidate) => candidate.job_id !== job.job_id)].sort(
 			(a, b) => b.created.localeCompare(a.created),
 		)
-		const pending = pendingRequestUpdates.get(job.job_id)
+		const pending = pendingRequestUpdatesByJob.get(job.job_id)
 		if (pending) {
-			pendingRequestUpdates.delete(job.job_id)
+			pendingRequestUpdatesByJob.delete(job.job_id)
 			for (const update of pending) updateRequest(update)
 		}
 		persistManualDownloadsFromJob(job)
@@ -103,15 +106,41 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			pendingInitialUpdates.push({ kind: 'request', update })
 			return
 		}
-		const jobIndex = jobs.value.findIndex((job) => job.job_id === update.job_id)
+		pendingRequestUpdates.push(update)
+		scheduleRequestFlush()
+	}
+
+	function scheduleRequestFlush() {
+		if (requestFlushTimer !== null) return
+		requestFlushTimer = setTimeout(() => {
+			requestFlushTimer = null
+			flushRequestUpdates()
+		}, 120)
+	}
+
+	function flushRequestUpdates() {
+		if (pendingRequestUpdates.length === 0) return
+		const updates = pendingRequestUpdates.splice(0)
+		let next = jobs.value
+		for (const update of updates) {
+			next = applyRequestUpdate(update, next)
+		}
+		jobs.value = next
+	}
+
+	function applyRequestUpdate(
+		update: DownloadRequestUpdate,
+		jobs: InstallJobSnapshot[],
+	): InstallJobSnapshot[] {
+		const jobIndex = jobs.findIndex((job) => job.job_id === update.job_id)
 		if (jobIndex === -1) {
-			const pending = pendingRequestUpdates.get(update.job_id) ?? []
+			const pending = pendingRequestUpdatesByJob.get(update.job_id) ?? []
 			pending.push(update)
-			pendingRequestUpdates.set(update.job_id, pending)
-			return
+			pendingRequestUpdatesByJob.set(update.job_id, pending)
+			return jobs
 		}
 
-		const job = jobs.value[jobIndex]
+		const job = jobs[jobIndex]
 		const itemIndex = job.items.findIndex((item) => item.id === update.id)
 		const current = itemIndex === -1 ? null : job.items[itemIndex]
 		let item: InstallJobSnapshot['items'][number]
@@ -134,7 +163,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 				}
 				break
 			case 'progress':
-				if (!current) return
+				if (!current) return jobs
 				item = {
 					...current,
 					status: update.status,
@@ -142,7 +171,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 				}
 				break
 			case 'finished':
-				if (!current) return
+				if (!current) return jobs
 				item = {
 					...current,
 					status: 'completed',
@@ -151,7 +180,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 				}
 				break
 			case 'failed':
-				if (!current) return
+				if (!current) return jobs
 				item = { ...current, status: 'failed' }
 				break
 		}
@@ -159,7 +188,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 		const items = [...job.items]
 		if (itemIndex === -1) items.push(item)
 		else items[itemIndex] = item
-		const nextJobs = [...jobs.value]
+		const nextJobs = [...jobs]
 		nextJobs[jobIndex] = {
 			...job,
 			items,
@@ -172,7 +201,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 						}
 					: job.summary,
 		}
-		jobs.value = nextJobs
+		return nextJobs
 	}
 
 	async function refresh() {
@@ -193,6 +222,8 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 		}
 	}
 
+	let legacyRefreshTimer: ReturnType<typeof setTimeout> | null = null
+
 	async function refreshLegacyDownloads() {
 		const bars = await progress_bars_list().catch((error) => {
 			handleError(error)
@@ -206,6 +237,14 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			}))
 	}
 
+	function scheduleLegacyRefresh() {
+		if (legacyRefreshTimer !== null) return
+		legacyRefreshTimer = setTimeout(() => {
+			legacyRefreshTimer = null
+			void refreshLegacyDownloads()
+		}, 300)
+	}
+
 	async function start() {
 		if (started || disposed) return
 		started = true
@@ -214,7 +253,7 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			updateRequest(update),
 		)
 		unlistenJobs = await install_job_listener((job: InstallJobSnapshot) => setJob(job))
-		unlistenLoading = await loading_listener(() => void refreshLegacyDownloads())
+		unlistenLoading = await loading_listener(() => scheduleLegacyRefresh())
 		await Promise.all([refresh(), refreshLegacyDownloads()])
 		initializing = false
 		for (const update of pendingInitialUpdates.splice(0)) {
@@ -290,7 +329,16 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			disposed = true
 			initializing = false
 			pendingInitialUpdates.length = 0
-			pendingRequestUpdates.clear()
+			pendingRequestUpdatesByJob.clear()
+			if (requestFlushTimer !== null) {
+				clearTimeout(requestFlushTimer)
+				requestFlushTimer = null
+			}
+			if (legacyRefreshTimer !== null) {
+				clearTimeout(legacyRefreshTimer)
+				legacyRefreshTimer = null
+			}
+			pendingRequestUpdates.length = 0
 			unlistenJobs?.()
 			unlistenRequests?.()
 			unlistenLoading?.()

--- a/apps/app-frontend/src/providers/download-manager.ts
+++ b/apps/app-frontend/src/providers/download-manager.ts
@@ -29,9 +29,6 @@ export const downloadBarTypes = new Set([
 	'launcher_update',
 ])
 
-const pendingRequestUpdates: DownloadRequestUpdate[] = []
-let requestFlushTimer: ReturnType<typeof setTimeout> | null = null
-
 export interface DownloadManager {
 	jobs: Ref<InstallJobSnapshot[]>
 	legacyDownloads: Ref<LoadingBar[]>
@@ -63,6 +60,9 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 		{ kind: 'job'; job: InstallJobSnapshot } | { kind: 'request'; update: DownloadRequestUpdate }
 	> = []
 	const pendingRequestUpdatesByJob = new Map<string, DownloadRequestUpdate[]>()
+	const pendingRequestUpdates: DownloadRequestUpdate[] = []
+	let requestFlushTimer: ReturnType<typeof setTimeout> | null = null
+	let legacyRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 	function persistManualDownloadsFromJob(job: InstallJobSnapshot) {
 		if (job.status !== 'waiting_for_user' && job.status !== 'succeeded') return
@@ -221,8 +221,6 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			}
 		}
 	}
-
-	let legacyRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 	async function refreshLegacyDownloads() {
 		const bars = await progress_bars_list().catch((error) => {

--- a/packages/app-lib/src/install/model.rs
+++ b/packages/app-lib/src/install/model.rs
@@ -1664,6 +1664,7 @@ impl InstallJobState {
 
     pub fn download_items(&self) -> Vec<DownloadItemSnapshot> {
         let mut items = Vec::<DownloadItemSnapshot>::new();
+        let mut indices = HashMap::<String, usize>::new();
         for event in &self.events {
             match &event.kind {
                 InstallJobEventKind::ContentFileQueued {
@@ -1671,8 +1672,9 @@ impl InstallJobState {
                     bytes_total,
                     max_attempts,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Queued;
                         item.bytes_downloaded = 0;
@@ -1683,6 +1685,7 @@ impl InstallJobState {
                         item.request_url = None;
                         item.source = None;
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: path.clone(),
@@ -1698,14 +1701,16 @@ impl InstallJobState {
                             request_url: None,
                             source: None,
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::ContentFileBrowserOptions {
                     path,
                     urls,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.manual_url = urls.first().cloned();
                     }
@@ -1713,24 +1718,27 @@ impl InstallJobState {
                 InstallJobEventKind::ContentFileVerificationStarted {
                     path,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Verifying;
                         item.error = None;
                     }
                 }
                 InstallJobEventKind::ContentFileWritingStarted { path } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Writing;
                         item.error = None;
                     }
                 }
                 InstallJobEventKind::ContentFileRecovered { path, bytes } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Completed;
                         item.bytes_downloaded = *bytes;
@@ -1744,8 +1752,9 @@ impl InstallJobState {
                     attempt,
                     max_attempts,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Queued;
                         item.bytes_downloaded = 0;
@@ -1756,6 +1765,7 @@ impl InstallJobState {
                         item.request_url = None;
                         item.source = None;
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: path.clone(),
@@ -1771,6 +1781,7 @@ impl InstallJobState {
                             request_url: None,
                             source: None,
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::DownloadRequestStarted {
@@ -1782,8 +1793,9 @@ impl InstallJobState {
                     attempt,
                     max_attempts,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Downloading;
                         item.bytes_total = item.bytes_total.or(*bytes_total);
@@ -1793,6 +1805,7 @@ impl InstallJobState {
                         item.request_url = Some(url.clone());
                         item.source = Some(source.clone());
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: name.clone(),
@@ -1808,14 +1821,16 @@ impl InstallJobState {
                             request_url: Some(url.clone()),
                             source: Some(source.clone()),
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::DownloadRequestFinished {
                     path,
                     bytes,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Completed;
                         item.bytes_downloaded = *bytes;
@@ -1823,21 +1838,24 @@ impl InstallJobState {
                     }
                 }
                 InstallJobEventKind::DownloadRequestFailed { path } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Failed;
                     }
                 }
                 InstallJobEventKind::ContentFileCompleted { path, bytes } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Completed;
                         item.bytes_downloaded = *bytes;
                         item.bytes_total = Some(*bytes);
                         item.error = None;
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: path.clone(),
@@ -1853,6 +1871,7 @@ impl InstallJobState {
                             request_url: None,
                             source: None,
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::ContentFileSkipped {
@@ -1862,8 +1881,9 @@ impl InstallJobState {
                     version_id,
                     manual_url,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Skipped;
                         item.bytes_downloaded = 0;
@@ -1872,6 +1892,7 @@ impl InstallJobState {
                         item.error = Some(reason.clone());
                         item.manual_url = manual_url.clone();
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: path.clone(),
@@ -1887,6 +1908,7 @@ impl InstallJobState {
                             request_url: None,
                             source: None,
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::ContentFileFailed {
@@ -1895,8 +1917,9 @@ impl InstallJobState {
                     project_id,
                     version_id,
                 } => {
-                    if let Some(item) =
-                        items.iter_mut().find(|item| item.id == *path)
+                    if let Some(item) = indices
+                        .get(path)
+                        .and_then(|&index| items.get_mut(index))
                     {
                         item.status = DownloadItemStatus::Failed;
                         item.bytes_downloaded = 0;
@@ -1904,6 +1927,7 @@ impl InstallJobState {
                         item.version_id = version_id.clone();
                         item.error = Some(reason.clone());
                     } else {
+                        let index = items.len();
                         items.push(DownloadItemSnapshot {
                             id: path.clone(),
                             name: path.clone(),
@@ -1919,6 +1943,7 @@ impl InstallJobState {
                             request_url: None,
                             source: None,
                         });
+                        indices.insert(path.clone(), index);
                     }
                 }
                 InstallJobEventKind::JobCanceled { .. } => {
@@ -1946,7 +1971,8 @@ impl InstallJobState {
         });
         if !terminal {
             for (id, active) in &self.active_downloads {
-                if let Some(item) = items.iter_mut().find(|item| item.id == *id)
+                if let Some(item) =
+                    indices.get(id).and_then(|&index| items.get_mut(index))
                 {
                     item.name = active.name.clone();
                     item.status = active.status;

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -17,6 +17,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256, Sha512};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::error::Error;
 use std::ffi::OsStr;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -95,6 +96,9 @@ const BMCL_RATE_RECOVERY_INTERVAL: time::Duration =
     time::Duration::from_millis(100);
 const MAX_DOWNLOAD_ATTEMPT_HISTORY: usize = 12;
 const MAX_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
+const H2_FALLBACK_TTL: time::Duration = time::Duration::from_secs(600);
+const COLD_START_PROBE_MAX_ROUTES: usize = 3;
+const COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD: u32 = 2;
 
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize,
@@ -1272,6 +1276,51 @@ static MIRROR_REQUEST_LIMITERS: LazyLock<
 static TAIL_HEDGE_SEMAPHORE: LazyLock<Semaphore> =
     LazyLock::new(|| Semaphore::new(MAX_GLOBAL_TAIL_HEDGES));
 
+static H2_FALLBACK_AUTHORITIES: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn authority_uses_http1_fallback(authority: &str) -> bool {
+    let mut fallbacks = H2_FALLBACK_AUTHORITIES.lock();
+    match fallbacks.get(authority) {
+        Some(until) if *until > Instant::now() => true,
+        Some(_) => {
+            fallbacks.remove(authority);
+            false
+        }
+        None => false,
+    }
+}
+
+fn record_authority_h2_failure(authority: &str) {
+    let now = Instant::now();
+    let mut fallbacks = H2_FALLBACK_AUTHORITIES.lock();
+    fallbacks.retain(|_, until| *until > now);
+    fallbacks.insert(authority.to_string(), now + H2_FALLBACK_TTL);
+}
+
+fn is_h2_protocol_failure(error: &reqwest::Error) -> bool {
+    let mut chain = String::new();
+    let mut source = error.source();
+    while let Some(next) = source {
+        if !chain.is_empty() {
+            chain.push(' ');
+        }
+        chain.push_str(&next.to_string());
+        source = next.source();
+    }
+    let chain = chain.to_ascii_lowercase();
+    [
+        "http2",
+        "http/2",
+        "goaway",
+        "stream error",
+        "protocol error",
+        "refused stream",
+    ]
+    .iter()
+    .any(|marker| chain.contains(marker))
+}
+
 fn reqwest_client_builder() -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .connect_timeout(FILE_TRANSFER_CONNECT_TIMEOUT)
@@ -1284,6 +1333,12 @@ fn reqwest_client_builder() -> reqwest::ClientBuilder {
 }
 
 fn file_reqwest_client_builder() -> reqwest::ClientBuilder {
+    reqwest_client_builder()
+        .http2_adaptive_window(true)
+        .http2_keep_alive_interval(Some(time::Duration::from_secs(15)))
+}
+
+fn http1_file_reqwest_client_builder() -> reqwest::ClientBuilder {
     reqwest_client_builder().http1_only()
 }
 
@@ -1320,6 +1375,29 @@ static DIRECT_REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .build()
         .expect("client configuration should be valid")
 });
+
+static HTTP1_NO_REDIRECT_REQWEST_CLIENT: LazyLock<reqwest::Client> =
+    LazyLock::new(|| {
+        let builder = http1_file_reqwest_client_builder()
+            .redirect(reqwest::redirect::Policy::none());
+        #[cfg(not(test))]
+        let builder = builder.https_only(true);
+        builder
+            .build()
+            .expect("client configuration should be valid")
+    });
+
+static HTTP1_DIRECT_REQWEST_CLIENT: LazyLock<reqwest::Client> =
+    LazyLock::new(|| {
+        let builder = http1_file_reqwest_client_builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none());
+        #[cfg(not(test))]
+        let builder = builder.https_only(true);
+        builder
+            .build()
+            .expect("client configuration should be valid")
+    });
 
 static DIRECT_FETCH_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     let builder = reqwest_client_builder().no_proxy();
@@ -3231,10 +3309,23 @@ async fn send_path_request_with_clients(
     };
     let mut reused_redirect_target = current != original;
     for redirect_count in 0..=5 {
-        let client = if route.proxy == ProxyPolicy::Direct {
-            direct_client
+        let fallback_to_http1 = url_authority(current.as_str())
+            .is_some_and(|authority| authority_uses_http1_fallback(&authority));
+        let (system_client_for_hop, direct_client_for_hop): (
+            &reqwest::Client,
+            &reqwest::Client,
+        ) = if fallback_to_http1 {
+            (
+                &HTTP1_NO_REDIRECT_REQWEST_CLIENT,
+                &HTTP1_DIRECT_REQWEST_CLIENT,
+            )
         } else {
-            system_client
+            (system_client, direct_client)
+        };
+        let client = if route.proxy == ProxyPolicy::Direct {
+            direct_client_for_hop
+        } else {
+            system_client_for_hop
         };
         let same_as_original = same_origin(&original, &current);
         let allow_sensitive = route.allow_sensitive_headers && same_as_original;
@@ -3263,7 +3354,25 @@ async fn send_path_request_with_clients(
                 .header(header::ACCEPT_ENCODING, "identity");
         }
 
-        let response = request.send().await?;
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                if !fallback_to_http1
+                    && redirect_count < 5
+                    && is_h2_protocol_failure(&error)
+                    && let Some(authority) = url_authority(current.as_str())
+                {
+                    tracing::warn!(
+                        authority,
+                        error = %error.without_url(),
+                        "HTTP/2 download request failed; retrying over HTTP/1.1"
+                    );
+                    record_authority_h2_failure(&authority);
+                    continue;
+                }
+                return Err(error.into());
+            }
+        };
         if matches!(
             response.status(),
             StatusCode::TOO_MANY_REQUESTS | StatusCode::SERVICE_UNAVAILABLE
@@ -3300,6 +3409,7 @@ async fn send_path_request_with_clients(
                 original_url = %sanitize_url_for_log(&route.url),
                 final_host = current.host_str().unwrap_or_default(),
                 reused_redirect_target,
+                http1_fallback = fallback_to_http1,
                 "Resolved file download route"
             );
             return Ok((response, current.into()));
@@ -3889,6 +3999,105 @@ async fn probe_faster_route(
     None
 }
 
+fn route_health_is_cold(
+    route: &DownloadRoute,
+    resource: ResourceClass,
+) -> bool {
+    route_health_key(route, resource).is_none_or(|key| {
+        ROUTE_HEALTH.lock().get(&key).is_none_or(|entry| {
+            entry.success_samples < COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD
+        })
+    })
+}
+
+async fn select_cold_start_route(
+    request: &DownloadRequest,
+    routes: &mut Vec<DownloadRoute>,
+    semaphore: &FetchSemaphore,
+    system_client: &reqwest::Client,
+    direct_client: &reqwest::Client,
+) {
+    let Some(size) = request.integrity.size else {
+        return;
+    };
+    if size < SEGMENTED_DOWNLOAD_THRESHOLD
+        || !matches!(
+            source_mode_for_resource(request.resource),
+            crate::state::DownloadSourceMode::Auto
+        )
+        || !route_health_is_cold(&routes[0], request.resource)
+    {
+        return;
+    }
+    let candidates: Vec<&DownloadRoute> = routes
+        .iter()
+        .filter(|route| route.supports_range && range_splitting_allowed(route))
+        .take(COLD_START_PROBE_MAX_ROUTES)
+        .collect();
+    if candidates.len() < 2 {
+        return;
+    }
+    if semaphore.0.available_permits() < candidates.len() {
+        return;
+    }
+    let mut probes = futures::stream::FuturesUnordered::new();
+    for (index, route) in candidates.iter().copied().enumerate() {
+        probes.push(async move {
+            (
+                index,
+                probe_route_throughput(
+                    route,
+                    None,
+                    size,
+                    request.header.as_ref(),
+                    None,
+                    request.download_meta.as_ref(),
+                    semaphore,
+                    system_client,
+                    direct_client,
+                    request.resource,
+                )
+                .await,
+            )
+        });
+    }
+    let mut measured = HashMap::new();
+    while let Some((index, result)) = probes.next().await {
+        if let Some(result) = result {
+            measured.insert(index, result.bytes_per_second);
+        }
+    }
+    drop(probes);
+    let first_bytes_per_second = match measured.get(&0) {
+        Some(bytes_per_second) => *bytes_per_second,
+        None => return,
+    };
+    let Some((best_index, best_bytes_per_second)) = measured
+        .iter()
+        .max_by_key(|(_, bytes_per_second)| **bytes_per_second)
+    else {
+        return;
+    };
+    if *best_index == 0
+        || !probe_is_meaningfully_faster(
+            *best_bytes_per_second,
+            first_bytes_per_second,
+        )
+    {
+        return;
+    }
+    tracing::debug!(
+        best_bytes_per_second,
+        first_bytes_per_second,
+        "Cold-start probe selected a faster download route"
+    );
+    let best_route = candidates[*best_index].clone();
+    if let Some(index) = routes.iter().position(|route| *route == best_route) {
+        let best_route = routes.remove(index);
+        routes.insert(0, best_route);
+    }
+}
+
 fn segment_path(part_path: &Path, index: usize) -> PathBuf {
     suffixed_path(part_path, &format!(".segment-{index}"))
 }
@@ -4028,7 +4237,17 @@ async fn download_tail_candidate(
         let Some(chunk) = chunk else {
             break;
         };
-        let chunk = chunk.map_err(|_| SegmentDownloadError::Transport)?;
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                if is_h2_protocol_failure(&error)
+                    && let Some(authority) = url_authority(&final_url)
+                {
+                    record_authority_h2_failure(&authority);
+                }
+                return Err(SegmentDownloadError::Transport);
+            }
+        };
         let accepted = usize::try_from(expected.saturating_sub(received))
             .unwrap_or(usize::MAX)
             .min(chunk.len());
@@ -4410,6 +4629,11 @@ async fn download_segment(
             let chunk = match chunk {
                 Ok(chunk) => chunk,
                 Err(error) => {
+                    if is_h2_protocol_failure(&error)
+                        && let Some(authority) = url_authority(&final_url)
+                    {
+                        record_authority_h2_failure(&authority);
+                    }
                     stream_end_reason = Some(error.to_string());
                     break;
                 }
@@ -5049,6 +5273,14 @@ async fn download_to_path_inner(
         any_route_can_resume(&routes),
     )
     .await?;
+    select_cold_start_route(
+        &request,
+        &mut routes,
+        semaphore,
+        &NO_REDIRECT_REQWEST_CLIENT,
+        &DIRECT_REQWEST_CLIENT,
+    )
+    .await;
 
     let mut attempts = 0;
     let mut last_error = None;
@@ -5617,6 +5849,12 @@ async fn download_to_path_inner(
                             let chunk = match item {
                                 Ok(chunk) => chunk,
                                 Err(error) => {
+                                    if is_h2_protocol_failure(&error)
+                                        && let Some(authority) =
+                                            url_authority(&final_url)
+                                    {
+                                        record_authority_h2_failure(&authority);
+                                    }
                                     transfer_error = Some(error.into());
                                     break;
                                 }
@@ -8322,5 +8560,13 @@ mod tests {
         assert!(values.is_empty());
         assert_eq!(requests.load(Ordering::Relaxed), 1);
         server.abort();
+    }
+
+    #[test]
+    fn h2_fallback_authority_marking() {
+        record_authority_h2_failure("example.com:443");
+        assert!(authority_uses_http1_fallback("example.com:443"));
+        assert!(!authority_uses_http1_fallback("other.com:443"));
+        H2_FALLBACK_AUTHORITIES.lock().clear();
     }
 }


### PR DESCRIPTION
## 背景
- 文件下载此前被钉死在 HTTP/1.1，多分段各占一条 TCP 连接，速度上不去
- 提速到 20MB/s 后，下载进度事件风暴导致启动器界面卡死（每个事件全量重建响应式数组 + 多次 IPC）

## 改动
### 下载引擎（packages/app-lib/src/util/fetch.rs）
1. 文件下载启用 HTTP/2（ALPN 协商、自适应流控窗口、15s keep-alive PING）
2. 按域名自动回退 HTTP/1.1：检测到 h2 协议错误（请求发送或流中）即记录该权威 10 分钟并即时以 http1 重试，不影响健康线路
3. 多线路冷启动并行探测：Auto 模式、≥4MiB、线路健康度冷、有 ≥2 条可分段线路且信号量余量足够时，下载前并行探测最多 3 条线路（256KiB Range），快 ≥25% 才换线；已缓存文件走免网络快速路径不受影响

### 前端（apps/app-frontend）
4. download_request 事件 120ms 尾随缓冲，合并后单次重建状态（保留全部状态转换顺序）
5. 进度事件不再每次触发 getInstances() IPC（任务构成变化或 ≥2s 才刷新）；loading 通知合并为 250ms 窗口

### 其他（packages/app-lib/src/install/model.rs）
6. download_items() 快照构建 O(n²) → O(n)，大整合包每 3 秒不再做千万级字符串比较

## 验证
- cargo check -p theseus 通过，fetch::tests 63/63 通过
- 实际 20MB/s 下载场景界面无卡死

## Summary by Sourcery

通过支持 HTTP/2、在冷启动时进行自适应路由选择，以及减少下载相关事件对 UI 的负载，实现更快速、更健壮的文件下载。

New Features:
- 支持用于文件传输的 HTTP/2，并提供自适应流控以及下载请求的长连接（keep-alive）。
- 在下载过程中检测到协议错误时，为每个 authority 提供从 HTTP/2 回退到 HTTP/1.1 的机制。
- 在大型自动模式（Auto-mode）下载的冷启动阶段并行探测多条路由，在开始传输前选择更快的分段路由。

Bug Fixes:
- 通过缓存条目索引来减少构建 `download_items` 快照时的二次复杂度行为，避免对大型事件列表的重复扫描。

Enhancements:
- 当某个 authority 被标记为与 HTTP/2 不兼容时，记录并复用仅支持 HTTP/1.1 的客户端用于文件下载。
- 通过对下载进度和请求更新进行批量处理，并在缓冲窗口中应用这些更新，优化前端的处理流程以避免 UI 卡顿。
- 根据组合变化和时间窗口对传统加载条刷新以及包元数据刷新进行节流，以降低 IPC 次数和重新计算开销。
- 通过在探测替代路由前基于样本数量检测冷路由，改进下载路由健康状态的处理。
- 添加单元测试以验证 HTTP/2 回退时 authority 标记行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable faster and more robust file downloads with HTTP/2 support, adaptive route selection on cold start, and reduced UI load from download-related events.

New Features:
- Support HTTP/2 for file transfer with adaptive flow control and keep-alive for download requests.
- Introduce per-authority fallback from HTTP/2 to HTTP/1.1 when protocol errors are detected during downloads.
- Add cold-start parallel route probing for large Auto-mode downloads to select a faster segmented route before starting the transfer.

Bug Fixes:
- Reduce quadratic behavior in download_items snapshot construction by caching item indices, preventing repeated scans over large event lists.

Enhancements:
- Record and reuse HTTP/1.1-only clients for file downloads when an authority is marked as incompatible with HTTP/2.
- Optimize handling of download progress and request updates in the frontend by batching updates and applying them in buffered windows to avoid UI stalls.
- Throttle legacy loading bar refreshes and pack metadata refreshes based on composition changes and time windows to limit IPC and recomputation.
- Improve download route health handling by detecting cold routes via sample counts before probing alternatives.
- Add a unit test to validate HTTP/2 fallback authority marking behavior.

</details>