### PR TITLE
自动下载源：按任务进行一次并发测速探测

### DIFF
--- a/packages/app-lib/src/install/events.rs
+++ b/packages/app-lib/src/install/events.rs
@@ -88,6 +88,10 @@ impl InstallProgressReporter {
             .unwrap_or_else(CancellationToken::new)
     }
 
+    pub(crate) fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
     pub fn new(job_id: Uuid, mut state: InstallJobState) -> Self {
         state.compact_transient_download_events();
         let shared_state = match REPORTER_STATES.entry(job_id) {

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -27,12 +27,13 @@ use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::time::{self, Instant};
-use tokio::sync::{Mutex as AsyncMutex, Semaphore, SemaphorePermit};
+use tokio::sync::{Mutex as AsyncMutex, Notify, Semaphore, SemaphorePermit};
 use tokio::{
     fs::File,
     io::{AsyncReadExt, AsyncWriteExt},
 };
 use url::Url;
+use uuid::Uuid;
 
 pub const DOWNLOAD_META_HEADER: &str = "modrinth-download-meta";
 
@@ -97,8 +98,16 @@ const BMCL_RATE_RECOVERY_INTERVAL: time::Duration =
 const MAX_DOWNLOAD_ATTEMPT_HISTORY: usize = 12;
 const MAX_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const H2_FALLBACK_TTL: time::Duration = time::Duration::from_secs(600);
-const COLD_START_PROBE_MAX_ROUTES: usize = 3;
-const COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD: u32 = 2;
+const TASK_PROBE_MAX_ROUTES: usize = 3;
+const MAX_TASK_PROBE_STATES: usize = 64;
+#[cfg(not(test))]
+const TASK_PROBE_WINDOW: time::Duration = time::Duration::from_secs(60);
+#[cfg(test)]
+const TASK_PROBE_WINDOW: time::Duration = time::Duration::from_secs(5);
+#[cfg(not(test))]
+const TASK_PROBE_MAX_WAIT: time::Duration = time::Duration::from_secs(10);
+#[cfg(test)]
+const TASK_PROBE_MAX_WAIT: time::Duration = time::Duration::from_secs(2);
 
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize,
@@ -337,6 +346,36 @@ static ROUTE_HEALTH: LazyLock<Mutex<HashMap<RouteHealthKey, RouteHealth>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static ROUTE_EFFECTIVE_AUTHORITIES: LazyLock<Mutex<HashMap<String, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum TaskProbeKey {
+    Job(Uuid),
+    Anonymous,
+}
+
+#[derive(Default)]
+struct TaskProbeState {
+    families: Mutex<HashMap<ResourceFamily, FamilyProbeState>>,
+}
+
+impl TaskProbeState {
+    fn has_in_flight(&self) -> bool {
+        self.families
+            .lock()
+            .values()
+            .any(|family| family.in_flight.is_some())
+    }
+}
+
+#[derive(Default)]
+struct FamilyProbeState {
+    last_probed: Option<Instant>,
+    in_flight: Option<Arc<Notify>>,
+}
+
+static TASK_PROBE_STATES: LazyLock<
+    Mutex<HashMap<TaskProbeKey, Arc<TaskProbeState>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 fn url_authority(url: &str) -> Option<String> {
     let url = Url::parse(url).ok()?;
@@ -3999,40 +4038,38 @@ async fn probe_faster_route(
     None
 }
 
-fn route_health_is_cold(
-    route: &DownloadRoute,
-    resource: ResourceClass,
-) -> bool {
-    route_health_key(route, resource).is_none_or(|key| {
-        ROUTE_HEALTH.lock().get(&key).is_none_or(|entry| {
-            entry.success_samples < COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD
-        })
-    })
-}
-
-async fn select_cold_start_route(
+/// Ensures the download task has a fresh throughput measurement before the
+/// first file of a resource family starts downloading in Auto mode.
+/// Candidate routes are probed concurrently once per task; other files of
+/// the same family wait for that probe instead of running their own, so
+/// small files get measured route ordering without per-file probing.
+async fn ensure_task_routes_probed(
     request: &DownloadRequest,
     routes: &mut Vec<DownloadRoute>,
     semaphore: &FetchSemaphore,
     system_client: &reqwest::Client,
     direct_client: &reqwest::Client,
 ) {
-    let Some(size) = request.integrity.size else {
-        return;
-    };
-    if size < SEGMENTED_DOWNLOAD_THRESHOLD
-        || !matches!(
-            source_mode_for_resource(request.resource),
-            crate::state::DownloadSourceMode::Auto
-        )
-        || !route_health_is_cold(&routes[0], request.resource)
-    {
+    if !matches!(
+        source_mode_for_resource(request.resource),
+        crate::state::DownloadSourceMode::Auto
+    ) {
         return;
     }
+    let Some(size) = request.integrity.size.filter(|size| *size > 0) else {
+        return;
+    };
+    let Some(family) = routes
+        .first()
+        .and_then(|route| route_health_key(route, request.resource))
+        .map(|key| key.family)
+    else {
+        return;
+    };
     let candidates: Vec<&DownloadRoute> = routes
         .iter()
         .filter(|route| route.supports_range && range_splitting_allowed(route))
-        .take(COLD_START_PROBE_MAX_ROUTES)
+        .take(TASK_PROBE_MAX_ROUTES)
         .collect();
     if candidates.len() < 2 {
         return;
@@ -4040,12 +4077,63 @@ async fn select_cold_start_route(
     if semaphore.0.available_permits() < candidates.len() {
         return;
     }
-    let mut probes = futures::stream::FuturesUnordered::new();
-    for (index, route) in candidates.iter().copied().enumerate() {
-        probes.push(async move {
-            (
-                index,
-                probe_route_throughput(
+    let task_key = request
+        .install_tracking
+        .as_ref()
+        .map(|tracking| TaskProbeKey::Job(tracking.reporter.job_id()))
+        .unwrap_or(TaskProbeKey::Anonymous);
+    let state = {
+        let mut tasks = TASK_PROBE_STATES.lock();
+        if tasks.len() >= MAX_TASK_PROBE_STATES {
+            tasks.retain(|_, state| state.has_in_flight());
+        }
+        tasks.entry(task_key).or_default().clone()
+    };
+    enum TaskProbeDecision {
+        Run(Arc<Notify>),
+        Wait(Arc<Notify>),
+        Done,
+    }
+    let decision = {
+        let mut families = state.families.lock();
+        let entry = families.entry(family).or_default();
+        let recently_probed = entry.last_probed.is_some_and(|probed| {
+            matches!(task_key, TaskProbeKey::Job(_))
+                || probed.elapsed() < TASK_PROBE_WINDOW
+        });
+        if recently_probed {
+            TaskProbeDecision::Done
+        } else if let Some(notify) = entry.in_flight.clone() {
+            TaskProbeDecision::Wait(notify)
+        } else {
+            let notify = Arc::new(Notify::new());
+            entry.in_flight = Some(notify.clone());
+            TaskProbeDecision::Run(notify)
+        }
+    };
+    match decision {
+        TaskProbeDecision::Done => {}
+        TaskProbeDecision::Wait(notify) => {
+            let completed =
+                tokio::time::timeout(TASK_PROBE_MAX_WAIT, notify.notified())
+                    .await
+                    .is_ok();
+            if !completed {
+                let mut families = state.families.lock();
+                if let Some(entry) = families.get_mut(&family) {
+                    if entry.in_flight.as_ref().is_some_and(|in_flight| {
+                        Arc::ptr_eq(in_flight, &notify)
+                    }) {
+                        entry.in_flight = None;
+                        entry.last_probed = None;
+                    }
+                }
+            }
+        }
+        TaskProbeDecision::Run(notify) => {
+            let mut probes = futures::stream::FuturesUnordered::new();
+            for route in candidates.iter().copied() {
+                probes.push(probe_route_throughput(
                     route,
                     None,
                     size,
@@ -4056,46 +4144,23 @@ async fn select_cold_start_route(
                     system_client,
                     direct_client,
                     request.resource,
-                )
-                .await,
-            )
-        });
-    }
-    let mut measured = HashMap::new();
-    while let Some((index, result)) = probes.next().await {
-        if let Some(result) = result {
-            measured.insert(index, result.bytes_per_second);
+                ));
+            }
+            while probes.next().await.is_some() {}
+            {
+                let mut families = state.families.lock();
+                if let Some(entry) = families.get_mut(&family) {
+                    entry.last_probed = Some(Instant::now());
+                    entry.in_flight = None;
+                }
+            }
+            notify.notify_waiters();
+            tracing::debug!(?family, "Task download route probe completed");
         }
     }
-    drop(probes);
-    let first_bytes_per_second = match measured.get(&0) {
-        Some(bytes_per_second) => *bytes_per_second,
-        None => return,
-    };
-    let Some((best_index, best_bytes_per_second)) = measured
-        .iter()
-        .max_by_key(|(_, bytes_per_second)| **bytes_per_second)
-    else {
-        return;
-    };
-    if *best_index == 0
-        || !probe_is_meaningfully_faster(
-            *best_bytes_per_second,
-            first_bytes_per_second,
-        )
-    {
-        return;
-    }
-    tracing::debug!(
-        best_bytes_per_second,
-        first_bytes_per_second,
-        "Cold-start probe selected a faster download route"
-    );
-    let best_route = candidates[*best_index].clone();
-    if let Some(index) = routes.iter().position(|route| *route == best_route) {
-        let best_route = routes.remove(index);
-        routes.insert(0, best_route);
-    }
+    let mirror_first_loader =
+        uses_mirror_first_loader_routes(&request.url, request.resource);
+    order_auto_routes(routes, request.resource, mirror_first_loader);
 }
 
 fn segment_path(part_path: &Path, index: usize) -> PathBuf {
@@ -5273,7 +5338,7 @@ async fn download_to_path_inner(
         any_route_can_resume(&routes),
     )
     .await?;
-    select_cold_start_route(
+    ensure_task_routes_probed(
         &request,
         &mut routes,
         semaphore,


### PR DESCRIPTION
- 自动模式下，每个下载任务按资源族只测速一次：官方源与镜像源并发探测，结果写入路由健康数据
- 移除原有 4 MiB 门槛，小文件（资产/库文件等）也享受测速排序，不再按 locale 盲选镜像
- 同任务内其他文件等待该次探测完成，避免逐文件重复测速；无任务上下文时按 60 秒窗口匿名探测
- 修复冷启动时总是优先镜像、切换官方源后速度明显更快的问题

## Summary by Sourcery

在自动模式下引入按任务的并发下载路由探测，以改进初始路由选择，并在文件之间复用探测结果。

新特性：
- 跟踪每个安装任务的下载探测状态，使每个资源家族在每个任务中最多只被探测一次；在没有任务上下文时进行匿名探测。

缺陷修复：
- 解决冷启动行为问题：即使官方源更快，镜像路由仍被持续优先选用的情况。

改进：
- 通过移除之前的最小文件大小阈值，并根据记录的健康状况重新排序自动路由，将基于吞吐量的路由排序应用于所有文件大小。
- 在同一任务中以及匿名下载的短时间窗口内，在同一资源家族的文件之间共享探测结果，以避免对单个文件进行重复探测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce per-task concurrent download route probing in auto mode to improve initial route selection and reuse probe results across files.

New Features:
- Track per-install-job download probing state so that each resource family is probed at most once per task, with anonymous probing when no job context is available.

Bug Fixes:
- Resolve cold-start behavior where mirror routes were consistently preferred over official sources even when the latter are faster.

Enhancements:
- Apply throughput-based route ordering to all file sizes by removing the previous minimum size threshold and reordering auto routes based on recorded health.
- Share probe results among files of the same resource family within a task and within a short time window for anonymous downloads to avoid redundant per-file probing.

</details>