### PR TITLE
fix: 终止实例按钮大小异常

### DIFF
--- a/apps/app-frontend/src/components/ui/Instance.vue
+++ b/apps/app-frontend/src/components/ui/Instance.vue
@@ -279,7 +279,7 @@ onUnmounted(() => unlisten())
 						<button
 							v-tooltip="formatMessage(commonMessages.stopButton)"
 							:class="{ 'scale-100 opacity-100': isPlaying }"
-							class="transition-all scale-75 origin-bottom opacity-0 card-shadow"
+							class="transition-all origin-bottom opacity-0 card-shadow"
 							@click="(e) => stop(e, 'InstanceCard')"
 							@mousehover="checkProcess"
 						>


### PR DESCRIPTION
<img width="238" height="190" alt="image" src="https://github.com/user-attachments/assets/b6f525a3-b4a6-4800-9e5b-0a54a5070f0d" />

## Summary by Sourcery

Bug Fixes:
- 修正停止实例按钮的缩放比例，以便在实例播放时按预期尺寸显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct stop instance button scale to display at the intended size while the instance is playing.

</details>