### PR TITLE
fix: 小窗口下复制地图链接按钮异常

### DIFF
--- a/apps/app-frontend/src/pages/LabSeedMap.vue
+++ b/apps/app-frontend/src/pages/LabSeedMap.vue
@@ -3840,7 +3840,12 @@ function clampWorldCoordinate(value: number) {
 	}
 
 	.toolbar-secondary {
-		flex-wrap: wrap;
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.share-button {
+		grid-column: 1 / -1;
+		justify-self: end;
 	}
 
 	.coordinate-group {


### PR DESCRIPTION
<img width="1066" height="152" alt="image" src="https://github.com/user-attachments/assets/fbea7c17-faaa-466b-bb20-00dd5bc46f06" />

## Summary by Sourcery

调整工具栏布局，以确保在小窗口中共享/复制地图链接按钮正确显示。

Bug Fixes:
- 通过将工具栏更改为网格布局，修复在较小视口宽度下共享/复制地图链接按钮的布局问题。

Enhancements:
- 优化次级工具栏的对齐方式，使共享按钮在更好响应式表现的同时跨越整个宽度并右对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust toolbar layout to ensure the share/copy map link button displays correctly in small windows.

Bug Fixes:
- Fix share/copy map link button layout issues on small viewport widths by changing the toolbar to a grid layout.

Enhancements:
- Refine secondary toolbar alignment so the share button spans the full width and is right-aligned for better responsiveness.

</details>