### PR TITLE
faet(lab): Add input for schematic display layers.

### DIFF
--- a/apps/app-frontend/src/pages/LabSchematicPreview.vue
+++ b/apps/app-frontend/src/pages/LabSchematicPreview.vue
@@ -1760,7 +1760,14 @@ onBeforeUnmount(() => {
 							<LayersIcon />
 							<span>Y</span>
 						</span>
-						<strong class="schematic-layer-current">{{ layerMaximum }}</strong>
+						<input
+							class="schematic-layer-current"
+							type="number"
+							v-model.number="layerMaximum"
+							:min="layerFloor"
+							:max="layerCeiling"
+							step="1"
+						/>
 						<span class="schematic-layer-limit">{{ layerCeiling }}</span>
 						<input
 							v-model.number="layerMaximum"
@@ -2528,9 +2535,15 @@ onBeforeUnmount(() => {
 }
 
 .schematic-layer-current {
+	min-height: 0.5rem;
+	height: 1.4em;
+	border-radius: 0.2rem;
+	padding: 0.2rem;
 	color: var(--color-text-dark);
-	font-size: 0.9rem;
+	font-size: 0.7rem;
+	font-weight: bold;
 	font-variant-numeric: tabular-nums;
+	text-align: center;
 }
 
 .schematic-layer-limit,


### PR DESCRIPTION
将投影层显示的最高层信息改为输入框
<img width="111" height="93" alt="image" src="https://github.com/user-attachments/assets/3693d4c0-feb6-4ac6-9169-40a0f86e9d3e" />

## Summary by Sourcery

允许通过输入字段直接编辑示意图的最大显示层，并调整其样式以与整个 UI 保持一致。

新功能：
- 添加一个数字输入字段，用于设置最大可见示意图层级，替代之前使用的静态标签。

改进：
- 更新当前层级显示的样式，使其在外观和行为上正确表现为一个输入控件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow editing the maximum schematic display layer directly via an input field and adjust its styling for consistency with the UI.

New Features:
- Add a numeric input field to set the maximum visible schematic layer instead of using a static label.

Enhancements:
- Update styling of the current-layer display to look and behave correctly as an input control.

</details>