### PR TITLE
fix(app): 修复在MacOS上无法显示窗口透明背景

### DIFF
--- a/apps/app/tauri.macos.conf.json
+++ b/apps/app/tauri.macos.conf.json
@@ -14,6 +14,7 @@
 				"visible": false,
 				"zoomHotkeysEnabled": false,
 				"decorations": true,
+				"transparent": true,
 				"trafficLightPosition": {
 					"x": 15.0,
 					"y": 22.0


### PR DESCRIPTION
为MacOS窗口添加`"transparent": true`
<img width="1325" height="834" alt="截屏2026-08-17 下午3 59 42" src="https://github.com/user-attachments/assets/53c459aa-cbd8-4b79-a47e-f32ff416adb2" />

## Summary by Sourcery

Bug Fixes:
- 修复 macOS 窗口透明度问题，使应用能够正确显示透明背景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix macOS window transparency so the app can correctly display a transparent background.

</details>