### PR TITLE
feat(fetch): Allow h2 download using Modrinth mirrors

### DIFF
--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -9,7 +9,10 @@
 
 use super::h2_pool::SharedH2Connection;
 use crate::util::fetch;
-use crate::util::fetch::{DownloadRequest, DownloadResult, Integrity};
+use crate::util::fetch::{
+    DownloadRequest, DownloadResult, DownloadRoute, DownloadRouteSource,
+    Integrity,
+};
 use http::header::{ACCEPT_ENCODING, RANGE, USER_AGENT};
 use http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use std::path::Path;
@@ -17,6 +20,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use url::Url;
 
 const SEGMENTED_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 const MIN_SEGMENT_SIZE: u64 = 256 * 1024;
@@ -38,15 +42,16 @@ pub(crate) enum H2DownloadOutcome {
 /// connection, multiplexing range streams for large files.
 pub(crate) async fn try_download_via_h2(
     request: &DownloadRequest,
+    route: &DownloadRoute,
     destination: &Path,
     part_path: &Path,
 ) -> H2DownloadOutcome {
-    let Some(connection) = connect_authority(&request.url).await else {
+    let Some(connection) = connect_authority(&route.url).await else {
         return H2DownloadOutcome::Fallback {
             reason: "no shared HTTP/2 connection",
         };
     };
-    let Ok(uri) = request.url.parse::<Uri>() else {
+    let Ok(uri) = route.url.parse::<Uri>() else {
         return H2DownloadOutcome::Fallback {
             reason: "unparsable URL",
         };
@@ -55,20 +60,7 @@ pub(crate) async fn try_download_via_h2(
     let integrity = request.integrity.clone();
     let expected_size = integrity.size;
 
-    fetch::record_install_download_started(
-        request,
-        &fetch::DownloadRoute {
-            url: request.url.clone(),
-            source: fetch::DownloadRouteSource::Official,
-            is_mirror: false,
-            allow_sensitive_headers: false,
-            supports_range: true,
-            proxy: fetch::ProxyPolicy::System,
-        },
-        0,
-        1,
-    )
-    .await;
+    fetch::record_install_download_started(request, route, 0, 1).await;
 
     // When the size is known (Modrinth metadata provides it) skip the probe
     // entirely: small files fetch the body directly, large files split into
@@ -77,7 +69,7 @@ pub(crate) async fn try_download_via_h2(
     let total_size = if let Some(size) = expected_size {
         size
     } else {
-        let mut probe_headers = request_headers(request);
+        let mut probe_headers = request_headers(request, route);
         probe_headers.insert(RANGE, HeaderValue::from_static("bytes=0-0"));
         probe_headers
             .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
@@ -129,6 +121,7 @@ pub(crate) async fn try_download_via_h2(
             Arc::clone(&connection),
             &uri,
             request,
+            route,
             destination,
             part_path,
             &integrity,
@@ -140,6 +133,7 @@ pub(crate) async fn try_download_via_h2(
             &connection,
             &uri,
             request,
+            route,
             destination,
             part_path,
             &integrity,
@@ -177,21 +171,34 @@ async fn connect_authority(url: &str) -> Option<Arc<SharedH2Connection>> {
     }
 }
 
-fn request_headers(request: &DownloadRequest) -> HeaderMap {
+fn request_headers(
+    request: &DownloadRequest,
+    route: &DownloadRoute,
+) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         USER_AGENT,
         HeaderValue::from_str(&crate::launcher_user_agent())
             .unwrap_or_else(|_| HeaderValue::from_static("Axolotl Launcher")),
     );
-    if let Some((name, value)) = &request.header {
+    let original_host = Url::parse(&request.url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string));
+    if let Some((name, value)) = &request.header
+        && (route.allow_sensitive_headers || !fetch::is_sensitive_header(name))
+        && (!name.eq_ignore_ascii_case("x-api-key")
+            || original_host.as_deref() == Some("api.curseforge.com"))
+    {
         if let Ok(name) = http::header::HeaderName::from_str(name) {
             if let Ok(value) = HeaderValue::from_str(value) {
                 headers.insert(name, value);
             }
         }
     }
-    if let Some(download_meta) = &request.download_meta {
+    if route.source == DownloadRouteSource::Official
+        && fetch::is_official_modrinth_download_url(&request.url)
+        && let Some(download_meta) = &request.download_meta
+    {
         if let Ok(value) =
             HeaderValue::from_str(&download_meta.to_header_value())
         {
@@ -278,12 +285,13 @@ async fn single_stream(
     connection: &SharedH2Connection,
     uri: &Uri,
     request: &DownloadRequest,
+    route: &DownloadRoute,
     destination: &Path,
     part_path: &Path,
     integrity: &Integrity,
     total_size: u64,
 ) -> crate::Result<DownloadResult> {
-    let mut headers = request_headers(request);
+    let mut headers = request_headers(request, route);
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
 
     let (response, mut stream) = open_stream(connection, uri, headers).await?;
@@ -338,7 +346,7 @@ async fn single_stream(
     Ok(DownloadResult {
         path: destination.to_path_buf(),
         url: uri.to_string(),
-        source: fetch::DownloadRouteSource::Official,
+        source: route.source,
         size: downloaded,
         attempts: 0,
         fallback_count: 0,
@@ -351,6 +359,7 @@ async fn multiplexed_ranges(
     connection: Arc<SharedH2Connection>,
     uri: &Uri,
     request: &DownloadRequest,
+    route: &DownloadRoute,
     destination: &Path,
     part_path: &Path,
     integrity: &Integrity,
@@ -376,7 +385,7 @@ async fn multiplexed_ranges(
     for (index, (start, end)) in segments.into_iter().enumerate() {
         let connection = connection.clone();
         let uri = uri.clone();
-        let headers = request_headers(request);
+        let headers = request_headers(request, route);
         let segment_path = segment_path(part_path, index);
         handles.push(tokio::spawn(async move {
             let result = download_segment(
@@ -448,7 +457,7 @@ async fn multiplexed_ranges(
     Ok(DownloadResult {
         path: destination.to_path_buf(),
         url: uri.to_string(),
-        source: fetch::DownloadRouteSource::Official,
+        source: route.source,
         size: downloaded,
         attempts: 0,
         fallback_count: 0,

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -35,7 +35,10 @@ pub(crate) enum H2DownloadOutcome {
     Completed(DownloadResult),
     /// The multiplexed path cannot be used; the caller should fall back to
     /// the legacy path.
-    Fallback { reason: &'static str },
+    Fallback {
+        reason: &'static str,
+        integrity_failure: bool,
+    },
 }
 
 /// Attempts to download `request` to `destination` over a shared HTTP/2
@@ -49,11 +52,13 @@ pub(crate) async fn try_download_via_h2(
     let Some(connection) = connect_authority(&route.url).await else {
         return H2DownloadOutcome::Fallback {
             reason: "no shared HTTP/2 connection",
+            integrity_failure: false,
         };
     };
     let Ok(uri) = route.url.parse::<Uri>() else {
         return H2DownloadOutcome::Fallback {
             reason: "unparsable URL",
+            integrity_failure: false,
         };
     };
 
@@ -85,6 +90,7 @@ pub(crate) async fn try_download_via_h2(
                     );
                     return H2DownloadOutcome::Fallback {
                         reason: "probe failed",
+                        integrity_failure: false,
                     };
                 }
             };
@@ -100,16 +106,19 @@ pub(crate) async fn try_download_via_h2(
         let Some(total_size) = total_size else {
             return H2DownloadOutcome::Fallback {
                 reason: "unknown content size",
+                integrity_failure: false,
             };
         };
         if total_size == 0 {
             return H2DownloadOutcome::Fallback {
                 reason: "empty content",
+                integrity_failure: false,
             };
         }
         if status != StatusCode::PARTIAL_CONTENT {
             return H2DownloadOutcome::Fallback {
                 reason: "range requests unsupported",
+                integrity_failure: false,
             };
         }
         total_size
@@ -151,6 +160,7 @@ pub(crate) async fn try_download_via_h2(
             );
             H2DownloadOutcome::Fallback {
                 reason: "multiplexed download failed",
+                integrity_failure: fetch::is_integrity_error(&error),
             }
         }
     }

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -191,13 +191,13 @@ fn request_headers(
         HeaderValue::from_str(&crate::launcher_user_agent())
             .unwrap_or_else(|_| HeaderValue::from_static("Axolotl Launcher")),
     );
-    let original_host = Url::parse(&request.url)
+    let route_host = Url::parse(&route.url)
         .ok()
         .and_then(|url| url.host_str().map(str::to_string));
     if let Some((name, value)) = &request.header
         && (route.allow_sensitive_headers || !fetch::is_sensitive_header(name))
         && (!name.eq_ignore_ascii_case("x-api-key")
-            || original_host.as_deref() == Some("api.curseforge.com"))
+            || route_host.as_deref() == Some("api.curseforge.com"))
     {
         if let Ok(name) = http::header::HeaderName::from_str(name) {
             if let Ok(value) = HeaderValue::from_str(value) {

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -1066,7 +1066,7 @@ fn route_host(route: &DownloadRoute) -> Option<String> {
         .and_then(|url| url.host_str().map(str::to_string))
 }
 
-fn is_official_modrinth_download_url(url: &str) -> bool {
+pub(crate) fn is_official_modrinth_download_url(url: &str) -> bool {
     Url::parse(url).is_ok_and(|url| {
         matches!(
             url.host_str(),
@@ -1468,7 +1468,7 @@ fn retry_after(response: &reqwest::Response) -> Option<time::Duration> {
     Some(time::Duration::from_secs(seconds.clamp(0, 60) as u64))
 }
 
-fn is_sensitive_header(name: &str) -> bool {
+pub(crate) fn is_sensitive_header(name: &str) -> bool {
     name.eq_ignore_ascii_case("authorization")
         || name.eq_ignore_ascii_case("proxy-authorization")
         || name.eq_ignore_ascii_case("cookie")
@@ -5375,9 +5375,11 @@ async fn download_to_path_inner(
     if request.allow_segmented_download
         && !part_resume_expected(&part_path).await
         && !request.url.starts_with("http://")
+        && let Some(h2_route) = routes.first().cloned()
     {
         match crate::util::download::h2_download::try_download_via_h2(
             &request,
+            &h2_route,
             destination,
             &part_path,
         )
@@ -5405,11 +5407,12 @@ async fn download_to_path_inner(
             crate::util::download::h2_download::H2DownloadOutcome::Fallback {
                 reason,
             } => {
-                if let Some(authority) = url_authority(&request.url) {
+                if let Some(authority) = url_authority(&h2_route.url) {
                     record_authority_h2_failure(&authority);
                 }
                 tracing::debug!(
                     url = %sanitize_url_for_log(&request.url),
+                    source = h2_route.source.as_str(),
                     reason,
                     "Multiplexed download unavailable; using legacy path"
                 );

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -5433,7 +5433,7 @@ async fn download_to_path_inner(
                     record_authority_h2_failure(&authority);
                 }
                 tracing::debug!(
-                    url = %sanitize_url_for_log(&request.url),
+                    url = %sanitize_url_for_log(&h2_route.url),
                     source = h2_route.source.as_str(),
                     reason,
                     "Multiplexed download unavailable; using legacy path"

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -3038,6 +3038,17 @@ pub(crate) fn verify_computed_integrity(
     Ok(())
 }
 
+pub(crate) fn is_integrity_error(error: &crate::Error) -> bool {
+    match error.raw.as_ref() {
+        ErrorKind::HashError(..) => true,
+        ErrorKind::OtherError(message) => {
+            message.starts_with("Incorrect ")
+                && message.contains(" hash for download")
+        }
+        _ => false,
+    }
+}
+
 pub(crate) async fn validate_file_content(
     path: &Path,
     validation: ContentValidation,
@@ -5372,6 +5383,7 @@ async fn download_to_path_inner(
     // Prefer a multiplexed HTTP/2 download over a shared per-authority
     // connection: one handshake per CDN instead of one per file, and range
     // streams for large files. Any failure falls through to the legacy path.
+    let mut h2_failed_mirror = None;
     if request.allow_segmented_download
         && !part_resume_expected(&part_path).await
         && !request.url.starts_with("http://")
@@ -5406,8 +5418,18 @@ async fn download_to_path_inner(
             }
             crate::util::download::h2_download::H2DownloadOutcome::Fallback {
                 reason,
+                integrity_failure,
             } => {
-                if let Some(authority) = url_authority(&h2_route.url) {
+                if integrity_failure {
+                    if h2_route.is_mirror {
+                        h2_failed_mirror = Some(h2_route.url.clone());
+                        tracing::warn!(
+                            url = %sanitize_url_for_log(&h2_route.url),
+                            source = h2_route.source.as_str(),
+                            "Mirror hash validation failed; falling back to the official source"
+                        );
+                    }
+                } else if let Some(authority) = url_authority(&h2_route.url) {
                     record_authority_h2_failure(&authority);
                 }
                 tracing::debug!(
@@ -5425,6 +5447,9 @@ async fn download_to_path_inner(
         }
     }
 
+    if let Some(failed_route) = h2_failed_mirror.take() {
+        routes.retain(|route| route.url != failed_route);
+    }
     ensure_task_routes_probed(
         &request,
         &mut routes,
@@ -7123,6 +7148,27 @@ mod tests {
             verify_computed_integrity(&size_only, &matching).is_err(),
             "without a hash the size claim is still enforced"
         );
+    }
+
+    #[test]
+    fn identifies_hash_integrity_failures_without_treating_size_errors_as_hash_failures()
+     {
+        let hash_error: crate::Error = ErrorKind::OtherError(
+            "Incorrect sha1 hash for download: expected != actual".to_string(),
+        )
+        .into();
+        assert!(is_integrity_error(&hash_error));
+
+        let typed_hash_error: crate::Error =
+            ErrorKind::HashError("expected".to_string(), "actual".to_string())
+                .into();
+        assert!(is_integrity_error(&typed_hash_error));
+
+        let size_error: crate::Error = ErrorKind::OtherError(
+            "Incorrect size for download: 10 != 20".to_string(),
+        )
+        .into();
+        assert!(!is_integrity_error(&size_error));
     }
 
     #[test]


### PR DESCRIPTION
添加 H2 原生下载引擎对镜像源的支持

Draft & To-do：镜像源 hash 错误时回退官方源

## 由 Sourcery 提供的总结

允许本机 HTTP/2 下载在遵循 Modrinth 镜像路由的同时，应用合适的请求头和来源处理。

新功能：
- 使本机 HTTP/2 下载引擎能够使用所选的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 保留基于路由的请求头处理逻辑，避免将敏感凭据和 Modrinth 元数据发送到镜像。

增强：
- 复用共享的下载路由逻辑，用于 HTTP/2 下载和回退诊断。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

</details>

新功能：
- 使原生 HTTP/2 下载能够使用已选择的 Modrinth 镜像路由，并上报实际下载来源。

缺陷修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像站点。
- 当 HTTP/2 下载的完整性校验失败时，从镜像回退到官方源。

增强改进：
- 在原生 HTTP/2 与传统下载路径之间复用共享的下载路由和校验逻辑。

测试：
- 增加区分哈希完整性失败与文件大小校验错误的测试覆盖率。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

</details>

新功能：
- 使原生 HTTP/2 下载能够使用已选择的 Modrinth 镜像路由，并上报实际下载来源。

缺陷修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像站点。
- 当 HTTP/2 下载的完整性校验失败时，从镜像回退到官方源。

增强改进：
- 在原生 HTTP/2 与传统下载路径之间复用共享的下载路由和校验逻辑。

测试：
- 增加区分哈希完整性失败与文件大小校验错误的测试覆盖率。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在保持安全请求处理和可靠回退行为的前提下，为原生 HTTP/2 下载增加对 Modrinth 镜像路由的支持。

新功能：
- 允许原生 HTTP/2 下载使用选定的 Modrinth 镜像路由，并报告实际的下载来源。

错误修复：
- 防止敏感请求头和 Modrinth 元数据被发送到镜像主机。
- 当 HTTP/2 下载的哈希校验失败时，从镜像回退到官方源。

改进：
- 在原生 HTTP/2 和旧版下载路径之间共享下载路由和校验逻辑。

测试：
- 新增测试覆盖，用于区分哈希完整性失败与文件大小校验错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Modrinth mirror routing in native HTTP/2 downloads while preserving secure request handling and reliable fallback behavior.

New Features:
- Enable native HTTP/2 downloads to use selected Modrinth mirror routes and report the actual download source.

Bug Fixes:
- Prevent sensitive headers and Modrinth metadata from being sent to mirror hosts.
- Fall back from a mirror to the official source when HTTP/2 download hash validation fails.

Enhancements:
- Share download route and validation logic between native HTTP/2 and legacy download paths.

Tests:
- Add coverage distinguishing hash integrity failures from file-size validation errors.

</details>

</details>

</details>

</details>

</details>