### PR TITLE
feat(minecraft): Parallel downloading for Minecraft files

### DIFF
--- a/apps/app-frontend/src/helpers/install-progress.test.ts
+++ b/apps/app-frontend/src/helpers/install-progress.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
 	effectiveInstallProgress,
+	effectiveParallelProgress,
 	hasDeterminateInstallProgress,
 	installProgressFraction,
 	installProgressTextSource,
@@ -37,6 +38,23 @@ test('clears completed content progress when the next phase has no progress', ()
 	}
 	assert.equal(effectiveInstallProgress(nextPhase), null)
 	assert.equal(installProgressFraction(nextPhase), null)
+})
+
+test('parallel track exposes its own progress', () => {
+	const job = {
+		phase: 'downloading_content',
+		progress: { current: 2, total: 3, secondary: { current: 220, total: 300 } },
+		parallel: {
+			phase: 'downloading_minecraft',
+			current: 120,
+			total: 300,
+		},
+	}
+	assert.deepEqual(effectiveInstallProgress(job), { current: 220, total: 300 })
+	assert.deepEqual(effectiveParallelProgress(job), { current: 120, total: 300 })
+	assert.equal(installProgressFraction(job), 220 / 300)
+
+	assert.equal(effectiveParallelProgress({ phase: 'downloading_minecraft', progress: null }), null)
 })
 
 test('treats zero and non-finite totals as indeterminate', () => {

--- a/apps/app-frontend/src/helpers/install-progress.ts
+++ b/apps/app-frontend/src/helpers/install-progress.ts
@@ -7,6 +7,11 @@ export interface ProgressValue {
 export interface ProgressSnapshot {
 	phase: string
 	progress?: ProgressValue | null
+	parallel?: {
+		phase: string
+		current: number
+		total: number
+	} | null
 }
 
 export interface ProgressTextSnapshot extends ProgressSnapshot {
@@ -32,6 +37,16 @@ export function effectiveInstallProgress(
 	}
 
 	return snapshot.progress
+}
+
+export function effectiveParallelProgress(
+	snapshot: ProgressSnapshot,
+): ProgressValue | null | undefined {
+	if (!snapshot.parallel) return null
+	return {
+		current: snapshot.parallel.current,
+		total: snapshot.parallel.total,
+	}
 }
 
 export function hasDeterminateInstallProgress(

--- a/apps/app-frontend/src/helpers/install.ts
+++ b/apps/app-frontend/src/helpers/install.ts
@@ -80,6 +80,13 @@ export interface InstallProgressSecondary {
 	total: number
 }
 
+export interface InstallParallelProgress {
+	phase: InstallPhaseId
+	current: number
+	total: number
+	details: InstallJobSnapshot['details']
+}
+
 export type InstallJavaStep =
 	| 'resolving'
 	| 'fetching_metadata'
@@ -158,6 +165,7 @@ export interface InstallJobSnapshot {
 				title?: string | null
 		  }
 		| { type: 'import'; launcher_type: string; instance_folder: string }
+	parallel?: InstallParallelProgress | null
 	display?: { title: string; icon?: string | null } | null
 	error?: InstallErrorView | null
 	rollback_error?: InstallErrorView | null

--- a/apps/app-frontend/src/pages/Downloads.vue
+++ b/apps/app-frontend/src/pages/Downloads.vue
@@ -238,6 +238,16 @@
 						:waiting="job.status === 'queued' || !hasDeterminateProgress(job)"
 						show-progress
 					/>
+					<div v-if="job.parallel" class="mt-2">
+						<ProgressBar
+							full-width
+							:progress="parallelPercent(job)"
+							:max="100"
+							:label="parallelProgressText(job)"
+							:waiting="job.status === 'queued' || !hasDeterminateParallelProgress(job)"
+							show-progress
+						/>
+					</div>
 				</div>
 
 				<div v-if="job.status === 'waiting_for_user'" class="px-4 pb-4">
@@ -410,6 +420,7 @@ import {
 } from '@/helpers/install'
 import {
 	effectiveInstallProgress,
+	effectiveParallelProgress,
 	hasDeterminateInstallProgress,
 	installProgressTextSource,
 } from '@/helpers/install-progress'
@@ -807,6 +818,24 @@ function jobPercent(job: InstallJobSnapshot) {
 
 function hasDeterminateProgress(job: InstallJobSnapshot) {
 	return hasDeterminateInstallProgress(effectiveInstallProgress(job))
+}
+
+function parallelPercent(job: InstallJobSnapshot) {
+	const progress = effectiveParallelProgress(job)
+	if (!hasDeterminateInstallProgress(progress)) return 0
+	return Math.min(100, Math.max(0, (progress.current / progress.total) * 100))
+}
+
+function hasDeterminateParallelProgress(job: InstallJobSnapshot) {
+	return hasDeterminateInstallProgress(effectiveParallelProgress(job))
+}
+
+function parallelProgressText(job: InstallJobSnapshot) {
+	const progress = effectiveParallelProgress(job)
+	if (!hasDeterminateInstallProgress(progress)) {
+		return job.parallel ? phaseLabel(job.parallel.phase) : ''
+	}
+	return `${phaseLabel(job.parallel!.phase)}: ${formatBytes(progress.current)} / ${formatBytes(progress.total)}`
 }
 
 function progressText(job: InstallJobSnapshot) {

--- a/apps/app-frontend/src/pages/instance/Mods.vue
+++ b/apps/app-frontend/src/pages/instance/Mods.vue
@@ -232,7 +232,7 @@ import { trackEvent } from '@/helpers/analytics'
 import { get_project_versions, get_version, get_version_many } from '@/helpers/cache.js'
 import { applyContentItemUpdates, matchesContentItem } from '@/helpers/content-item-state'
 import { translateContentItemTitles } from '@/helpers/content-search'
-import { getCurseForgeChangelog, type CurseForgeFile } from '@/helpers/curseforge'
+import { type CurseForgeFile,getCurseForgeChangelog } from '@/helpers/curseforge'
 import {
 	type CurseForgeManualDownloadItem,
 	getCurseForgeManualDownloadUrl,
@@ -241,10 +241,10 @@ import { getMissingContentScannerSettings } from '@/helpers/downloads-scanner'
 import { instance_listener } from '@/helpers/events.js'
 import { install_duplicate_instance, installJobInstanceId } from '@/helpers/install'
 import {
-	get_content_items_by_paths,
 	add_project_from_path,
 	apply_content_update_plan,
 	edit,
+	get_content_items_by_paths,
 	type InstanceContentSnapshotItem,
 	list,
 	plan_content_updates,
@@ -258,8 +258,8 @@ import {
 } from '@/helpers/instance'
 import { readInstanceCache, writeInstanceCache } from '@/helpers/instance-cache'
 import {
-	isWorldSaveContentItem,
 	type InstanceContentData,
+	isWorldSaveContentItem,
 	loadInstanceContentData,
 } from '@/helpers/instance-content'
 import type { CacheBehaviour, GameInstance } from '@/helpers/types'

--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -49,6 +49,7 @@ use std::io::{Cursor, ErrorKind};
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 type ExtractProgressFn<'a> = dyn FnMut(u64) -> Pin<Box<dyn Future<Output = crate::Result<()>> + Send + 'a>>
     + Send
@@ -67,6 +68,41 @@ pub(crate) enum MrpackInstallOutcome {
     #[allow(dead_code)]
     Completed(String),
     WaitingForUser(InstallPauseReason),
+}
+
+/// Owns the concurrent Minecraft core install that runs while modpack content
+/// downloads. Cancels the background task on drop, so error exits never leak
+/// it; the happy path joins it explicitly and the user-pause path aborts and
+/// waits for a clean stop before returning.
+struct ParallelMinecraftInstall {
+    cancel: CancellationToken,
+    task: Option<tokio::task::JoinHandle<crate::Result<()>>>,
+}
+
+impl ParallelMinecraftInstall {
+    async fn abort(mut self) {
+        self.cancel.cancel();
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+
+    /// Waits for the parallel Minecraft install to finish naturally. Unlike
+    /// [`Self::abort`] this never cancels: when the modpack content has
+    /// already finished, the Minecraft core download must still run to
+    /// completion before the job is reported done.
+    async fn join(mut self) -> crate::Result<()> {
+        if let Some(task) = self.task.take() {
+            task.await??;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ParallelMinecraftInstall {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1003,6 +1039,35 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
         "api.modrinth.com",
     ])
     .await;
+    // Start the Minecraft core install concurrently with the content
+    // download so both progress bars advance at once. The Minecraft install
+    // reports on the parallel track (phase + bytes); content stays the main
+    // phase. It is aborted if the content flow pauses for the user or fails.
+    let minecraft_cancel = CancellationToken::new();
+    let task_cancel = minecraft_cancel.clone();
+    let minecraft_parallel_reporter = reporter.clone().with_parallel_output();
+    let minecraft_instance_id = instance_id.clone();
+    let minecraft_task = tokio::spawn(async move {
+        tokio::select! {
+            _ = task_cancel.cancelled() => {
+                tracing::debug!(
+                    instance_id = %minecraft_instance_id,
+                    "Parallel Minecraft install aborted before completion"
+                );
+                Ok(())
+            }
+            result = crate::launcher::install_minecraft_for_instance_id_with_reporter(
+                &minecraft_instance_id,
+                false,
+                Some(minecraft_parallel_reporter),
+                crate::launcher::InstanceCompletionPolicy::DeferToInstallJob,
+            ) => result,
+        }
+    });
+    let minecraft_install = ParallelMinecraftInstall {
+        cancel: minecraft_cancel,
+        task: Some(minecraft_task),
+    };
     let pack_files = pack.files;
     let mut retry_indices = (0..pack_files.len()).collect::<Vec<_>>();
     let mut required_file_failures = Vec::new();
@@ -1400,6 +1465,7 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
     if let Some(reason) =
         missing_required_content_pause(&required_file_failures)
     {
+        minecraft_install.abort().await;
         return Ok(MrpackInstallOutcome::WaitingForUser(reason));
     }
 
@@ -1573,13 +1639,10 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
             .await?;
     }
 
-    crate::launcher::install_minecraft_for_instance_id_with_reporter(
-        &instance_id,
-        false,
-        Some(reporter.clone()),
-        crate::launcher::InstanceCompletionPolicy::DeferToInstallJob,
-    )
-    .await?;
+    // Join the parallel Minecraft core install: if content finished first,
+    // this waits for the Minecraft download to complete so the instance is
+    // fully installed; if Minecraft finished first, this returns at once.
+    minecraft_install.join().await?;
     reporter.clear_context().await?;
 
     Ok(MrpackInstallOutcome::Completed(instance_id.clone()))

--- a/packages/app-lib/src/install/events.rs
+++ b/packages/app-lib/src/install/events.rs
@@ -1,8 +1,9 @@
 use super::model::{
     ActiveDownloadState, DownloadItemStatus, InstallContinuationState,
     InstallErrorContext, InstallJobEventKind, InstallJobSnapshot,
-    InstallJobState, InstallPauseReason, InstallPhaseDetails, InstallPhaseId,
-    InstallProgress, InstallRollbackState, MissingModpackContentState,
+    InstallJobState, InstallPauseReason, InstallParallelProgress,
+    InstallPhaseDetails, InstallPhaseId, InstallProgress, InstallRollbackState,
+    MissingModpackContentState,
 };
 use super::store;
 use chrono::Utc;
@@ -27,6 +28,11 @@ static REPORTER_STATES: LazyLock<
 pub struct InstallProgressReporter {
     job_id: Uuid,
     state: Arc<Mutex<InstallProgressReporterState>>,
+    /// When set, `update`/`update_with_events` write to the parallel track
+    /// (`InstallProgressState.parallel`) instead of the main phase. Used by
+    /// the modpack installer to report the concurrent Minecraft core download
+    /// while content installation remains the main phase.
+    parallel_output: bool,
 }
 
 #[derive(Debug)]
@@ -136,7 +142,16 @@ impl InstallProgressReporter {
         Self {
             job_id,
             state: shared_state,
+            parallel_output: false,
         }
+    }
+
+    /// Returns a reporter clone whose phase updates are routed to the
+    /// parallel track, leaving the main phase untouched. The underlying job
+    /// state is shared, so both tracks still persist to the same job.
+    pub fn with_parallel_output(mut self) -> Self {
+        self.parallel_output = true;
+        self
     }
 
     pub async fn update(
@@ -145,8 +160,109 @@ impl InstallProgressReporter {
         progress: Option<InstallProgress>,
         details: InstallPhaseDetails,
     ) -> crate::Result<()> {
+        if self.parallel_output {
+            self.update_parallel(phase, progress, details).await
+        } else {
+            self.update_main(phase, progress, details).await
+        }
+    }
+
+    async fn update_main(
+        &self,
+        phase: InstallPhaseId,
+        progress: Option<InstallProgress>,
+        details: InstallPhaseDetails,
+    ) -> crate::Result<()> {
         self.update_with_events(phase, progress, details, Vec::new())
             .await
+    }
+
+    /// Updates the parallel track while the main phase keeps its own
+    /// progress. The parallel track lives on `InstallProgressState` and is
+    /// preserved across main-phase progress updates.
+    async fn update_parallel(
+        &self,
+        phase: InstallPhaseId,
+        progress: Option<InstallProgress>,
+        details: InstallPhaseDetails,
+    ) -> crate::Result<()> {
+        let app_state = match crate::State::get().await {
+            Ok(app_state) => app_state,
+            Err(error) => {
+                tracing::warn!(%error, "Failed to access install progress store");
+                return Ok(());
+            }
+        };
+        let mut state = self.state.lock().await;
+        if let Err(error) = self.sync_latest(&mut state, &app_state).await {
+            tracing::warn!(%error, "Failed to load install progress state");
+            return Ok(());
+        }
+        let (current, total) = match &progress {
+            Some(progress) => (progress.current, progress.total),
+            None => state
+                .job
+                .progress
+                .parallel
+                .as_ref()
+                .map(|parallel| (parallel.current, parallel.total))
+                .unwrap_or((0, 0)),
+        };
+        let previous = &state.job.progress.parallel;
+        let phase_changed =
+            previous.as_ref().is_none_or(|parallel| parallel.phase != phase);
+        let total_changed = previous
+            .as_ref()
+            .is_none_or(|parallel| parallel.total != total);
+        let enough_progress = previous
+            .as_ref()
+            .map(|parallel| {
+                current.saturating_sub(parallel.current)
+                    >= (parallel.total / 200).max(CONTENT_PROGRESS_PERSIST_STEPS)
+            })
+            .unwrap_or(true);
+        state.job.progress.parallel = Some(InstallParallelProgress {
+            phase,
+            current,
+            total,
+            details,
+        });
+        if !(phase_changed || total_changed || enough_progress)
+            && state.last_persisted_at.elapsed() < PROGRESS_PERSIST_INTERVAL
+        {
+            return Ok(());
+        }
+
+        let json = serde_json::to_string(&state.job)?;
+        let provider = state.job.provider().as_str().to_string();
+        let summary = state.job.download_summary();
+        drop(state);
+        let record = match store::update_progress_state(
+            self.job_id,
+            &json,
+            &provider,
+            &summary,
+            &app_state,
+        )
+        .await
+        {
+            Ok(()) => store::get_required(self.job_id, &app_state).await,
+            Err(error) => Err(error),
+        };
+        let record = match record {
+            Ok(record) => record,
+            Err(error) => {
+                tracing::warn!(%error, "Failed to persist parallel install progress");
+                return Ok(());
+            }
+        };
+        if let Ok(mut state) = self.state.try_lock() {
+            state.mark_persisted();
+        }
+        if let Err(error) = emit_install_job(&record.snapshot()).await {
+            tracing::warn!(%error, "Failed to emit parallel install progress");
+        }
+        Ok(())
     }
 
     pub async fn set_context(

--- a/packages/app-lib/src/install/events.rs
+++ b/packages/app-lib/src/install/events.rs
@@ -1,7 +1,7 @@
 use super::model::{
     ActiveDownloadState, DownloadItemStatus, InstallContinuationState,
     InstallErrorContext, InstallJobEventKind, InstallJobSnapshot,
-    InstallJobState, InstallPauseReason, InstallParallelProgress,
+    InstallJobState, InstallParallelProgress, InstallPauseReason,
     InstallPhaseDetails, InstallPhaseId, InstallProgress, InstallRollbackState,
     MissingModpackContentState,
 };
@@ -209,8 +209,9 @@ impl InstallProgressReporter {
                 .unwrap_or((0, 0)),
         };
         let previous = &state.job.progress.parallel;
-        let phase_changed =
-            previous.as_ref().is_none_or(|parallel| parallel.phase != phase);
+        let phase_changed = previous
+            .as_ref()
+            .is_none_or(|parallel| parallel.phase != phase);
         let total_changed = previous
             .as_ref()
             .is_none_or(|parallel| parallel.total != total);
@@ -218,7 +219,8 @@ impl InstallProgressReporter {
             .as_ref()
             .map(|parallel| {
                 current.saturating_sub(parallel.current)
-                    >= (parallel.total / 200).max(CONTENT_PROGRESS_PERSIST_STEPS)
+                    >= (parallel.total / 200)
+                        .max(CONTENT_PROGRESS_PERSIST_STEPS)
             })
             .unwrap_or(true);
         state.job.progress.parallel = Some(InstallParallelProgress {

--- a/packages/app-lib/src/install/model.rs
+++ b/packages/app-lib/src/install/model.rs
@@ -112,6 +112,7 @@ impl InstallJobState {
                 phase,
                 progress: None,
                 details: InstallPhaseDetails::Empty,
+                parallel: None,
             },
             paths: InstallJobPaths::default(),
             context: None,
@@ -1474,6 +1475,21 @@ pub struct InstallProgressState {
     pub phase: InstallPhaseId,
     pub progress: Option<InstallProgress>,
     pub details: InstallPhaseDetails,
+    /// A concurrently running secondary track (e.g. the Minecraft core
+    /// download while modpack content is being installed). The frontend
+    /// renders it as a separate progress bar alongside the main phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<InstallParallelProgress>,
+}
+
+/// Progress of a parallel install track that runs while the main phase
+/// advances. Self-contained so the UI can render an independent bar.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct InstallParallelProgress {
+    pub phase: InstallPhaseId,
+    pub current: u64,
+    pub total: u64,
+    pub details: InstallPhaseDetails,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
@@ -1766,6 +1782,7 @@ pub struct InstallJobSnapshot {
     pub phase: InstallPhaseId,
     pub progress: Option<InstallProgress>,
     pub details: InstallPhaseDetails,
+    pub parallel: Option<InstallParallelProgress>,
     pub display: Option<InstallJobDisplay>,
     pub error: Option<InstallErrorView>,
     pub rollback_error: Option<InstallErrorView>,

--- a/packages/app-lib/src/install/recovery.rs
+++ b/packages/app-lib/src/install/recovery.rs
@@ -32,6 +32,7 @@ pub async fn recover_interrupted_jobs(state: &State) -> crate::Result<()> {
         job.state.progress.phase = InstallPhaseId::RollingBack;
         job.state.progress.progress = None;
         job.state.progress.details = InstallPhaseDetails::Empty;
+        job.state.progress.parallel = None;
         job.state.error = Some(InstallErrorView::from_message(
             "app_closed",
             interrupted_phase,

--- a/packages/app-lib/src/install/runner.rs
+++ b/packages/app-lib/src/install/runner.rs
@@ -267,6 +267,7 @@ pub async fn retry_job(job_id: Uuid) -> crate::Result<InstallJobSnapshot> {
     job.state.progress.phase = InstallPhaseId::PreparingInstance;
     job.state.progress.progress = None;
     job.state.progress.details = InstallPhaseDetails::Empty;
+    job.state.progress.parallel = None;
     prepare_initial_instance(&mut job.state, &state).await?;
     job.state.record_event(InstallJobEventKind::JobQueued {
         kind: job.state.request.kind(),
@@ -623,6 +624,7 @@ fn begin_canceling_job(job_state: &mut InstallJobState) {
     job_state.progress.phase = InstallPhaseId::RollingBack;
     job_state.progress.progress = None;
     job_state.progress.details = InstallPhaseDetails::Empty;
+    job_state.progress.parallel = None;
     job_state.record_event(InstallJobEventKind::RollbackStarted {
         cleanup: job_state.cleanup.clone(),
     });
@@ -888,6 +890,7 @@ fn begin_failed_job_rollback(
     job_state.progress.phase = InstallPhaseId::RollingBack;
     job_state.progress.progress = None;
     job_state.progress.details = InstallPhaseDetails::Empty;
+    job_state.progress.parallel = None;
     job_state.record_event(InstallJobEventKind::RollbackStarted {
         cleanup: job_state.cleanup.clone(),
     });
@@ -901,6 +904,7 @@ fn begin_waiting_for_user(
     job_state.error = None;
     job_state.rollback_error = None;
     job_state.context = None;
+    job_state.progress.parallel = None;
     job_state.record_event(InstallJobEventKind::WaitingForUser { reason });
 }
 
@@ -974,6 +978,7 @@ async fn run_job(job_id: Uuid) -> crate::Result<()> {
             job_state.progress.phase = InstallPhaseId::Finalizing;
             job_state.progress.progress = None;
             job_state.progress.details = InstallPhaseDetails::Empty;
+            job_state.progress.parallel = None;
             job_state.error = None;
             job_state.rollback_error = None;
             job_state.pause_reason = None;

--- a/packages/app-lib/src/install/store.rs
+++ b/packages/app-lib/src/install/store.rs
@@ -53,6 +53,7 @@ impl InstallJobRecord {
             phase: self.state.progress.phase,
             progress: self.state.progress.progress.clone(),
             details: self.state.progress.details.clone(),
+            parallel: self.state.progress.parallel.clone(),
             display: self.state.display.clone(),
             error: self.state.error.clone(),
             rollback_error: self.state.rollback_error.clone(),

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -22,7 +22,8 @@ use daedalus::minecraft::{LibraryDownload, LoggingConfiguration, LoggingSide};
 use daedalus::{
     self as d,
     minecraft::{
-        AssetsIndex, Library, Version as GameVersion, VersionInfo as GameVersionInfo,
+        AssetsIndex, Library, Version as GameVersion,
+        VersionInfo as GameVersionInfo,
     },
     modded::LoaderVersion,
 };
@@ -1414,8 +1415,11 @@ pub async fn download_assets(
     let st = State::get().await?;
     let local_source = local_source.cloned();
     let num_futs = index.objects.len();
-    let per_file_fraction =
-        if num_futs > 0 { loading_amount / num_futs as f64 } else { 0.0 };
+    let per_file_fraction = if num_futs > 0 {
+        loading_amount / num_futs as f64
+    } else {
+        0.0
+    };
 
     // Partition assets: batch downloads (object missing), legacy-only copies
     // (object present, legacy missing), and per-file fallbacks (local reuse,
@@ -1427,9 +1431,10 @@ pub async fn download_assets(
     for (name, asset) in index.objects.iter() {
         let hash = &asset.hash;
         let resource_path = st.directories.object_dir(hash);
-        let legacy_resource_path = st.directories.legacy_assets_dir().join(
-            name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
-        );
+        let legacy_resource_path = st
+            .directories
+            .legacy_assets_dir()
+            .join(name.replace('/', &String::from(std::path::MAIN_SEPARATOR)));
         let should_fetch_object = !resource_path.exists() || force;
         let should_fetch_legacy =
             (with_legacy && !legacy_resource_path.exists()) || force;
@@ -1475,10 +1480,13 @@ pub async fn download_assets(
     if !batch_items.is_empty() {
         let source_mode = st.minecraft_file_source();
         let first_url = batch_items[0].url.clone();
-        let route =
-            resolve_download_routes_for(&first_url, ResourceClass::MinecraftAsset, source_mode)
-                .into_iter()
-                .next();
+        let route = resolve_download_routes_for(
+            &first_url,
+            ResourceClass::MinecraftAsset,
+            source_mode,
+        )
+        .into_iter()
+        .next();
         if let Some(route) = route {
             // Resolve each item's URL onto the chosen route (official or
             // mirror) so the batch reuses one connection to that authority.
@@ -1513,9 +1521,13 @@ pub async fn download_assets(
                     })
                 }
             };
-            let failed =
-                download_asset_batch_via_h2(&route, batch_items, ASSET_BATCH_CONCURRENCY, callback)
-                    .await;
+            let failed = download_asset_batch_via_h2(
+                &route,
+                batch_items,
+                ASSET_BATCH_CONCURRENCY,
+                callback,
+            )
+            .await;
             if !failed.is_empty() {
                 let failed_hashes = failed
                     .iter()
@@ -1534,9 +1546,13 @@ pub async fn download_assets(
                             size: asset.size as u64,
                             url,
                             resource_path: st.directories.object_dir(hash),
-                            legacy_resource_path: st.directories.legacy_assets_dir().join(
-                                name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
-                            ),
+                            legacy_resource_path: st
+                                .directories
+                                .legacy_assets_dir()
+                                .join(name.replace(
+                                    '/',
+                                    &String::from(std::path::MAIN_SEPARATOR),
+                                )),
                         });
                     }
                 }
@@ -1555,9 +1571,13 @@ pub async fn download_assets(
                     size: asset.size as u64,
                     url,
                     resource_path: st.directories.object_dir(hash),
-                    legacy_resource_path: st.directories.legacy_assets_dir().join(
-                        name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
-                    ),
+                    legacy_resource_path: st
+                        .directories
+                        .legacy_assets_dir()
+                        .join(name.replace(
+                            '/',
+                            &String::from(std::path::MAIN_SEPARATOR),
+                        )),
                 });
             }
         }
@@ -1567,9 +1587,10 @@ pub async fn download_assets(
     for (name, asset) in legacy_copies {
         let hash = &asset.hash;
         let resource_path = st.directories.object_dir(hash);
-        let legacy_resource_path = st.directories.legacy_assets_dir().join(
-            name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
-        );
+        let legacy_resource_path = st
+            .directories
+            .legacy_assets_dir()
+            .join(name.replace('/', &String::from(std::path::MAIN_SEPARATOR)));
         crate::util::fetch::copy(
             &resource_path,
             &legacy_resource_path,

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -13,14 +13,16 @@ use crate::{
         emit::{emit_loading, loading_try_for_each_concurrent},
     },
     state::State,
+    util::download::h2_download::{
+        ASSET_BATCH_CONCURRENCY, H2BatchAsset, download_asset_batch_via_h2,
+    },
     util::{fetch::*, io},
 };
 use daedalus::minecraft::{LibraryDownload, LoggingConfiguration, LoggingSide};
 use daedalus::{
     self as d,
     minecraft::{
-        Asset, AssetsIndex, Library, Version as GameVersion,
-        VersionInfo as GameVersionInfo,
+        AssetsIndex, Library, Version as GameVersion, VersionInfo as GameVersionInfo,
     },
     modded::LoaderVersion,
 };
@@ -1382,10 +1384,22 @@ pub async fn download_assets_index(
     Ok(res)
 }
 
+/// Owned per-asset work item for the per-file fallback path of
+/// `download_assets`. Owning the data keeps the concurrent futures 'static so
+/// `buffer_unordered` can be used without lifetime-restricted captures.
+struct FallbackAsset {
+    name: String,
+    hash: String,
+    size: u64,
+    url: String,
+    resource_path: PathBuf,
+    legacy_resource_path: PathBuf,
+}
+
 #[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub async fn download_assets(
-    st: &State,
+    _st: &State,
     local_source: Option<&LocalRuntimeSource>,
     with_legacy: bool,
     index: &AssetsIndex,
@@ -1395,113 +1409,302 @@ pub async fn download_assets(
     progress: Option<MinecraftDownloadProgress>,
 ) -> crate::Result<()> {
     tracing::debug!("Loading assets");
+    // Own the shared state and local source so the concurrent fallback
+    // futures below are 'static + Send (buffer_unordered requires this).
+    let st = State::get().await?;
+    let local_source = local_source.cloned();
     let num_futs = index.objects.len();
-    let assets = stream::iter(index.objects.iter())
-        .map(Ok::<(&String, &Asset), crate::Error>);
+    let per_file_fraction =
+        if num_futs > 0 { loading_amount / num_futs as f64 } else { 0.0 };
 
-    loading_try_for_each_concurrent(assets,
-			crate::util::download::task_concurrency_limit(&st).map(|limit| limit.saturating_mul(2)),
-            loading_bar,
-            loading_amount,
-            num_futs,
-			None,
-            |(name, asset)| {
-                let progress = progress.clone();
-                async move {
-                let hash = &asset.hash;
-                let resource_path = st.directories.object_dir(hash);
-                let legacy_resource_path = st.directories.legacy_assets_dir().join(
-                    name.replace('/', &String::from(std::path::MAIN_SEPARATOR))
-                );
-                let should_fetch_object = !resource_path.exists() || force;
-                let should_fetch_legacy =
-                    (with_legacy && !legacy_resource_path.exists()) || force;
-                let fetch_progress = if should_fetch_object || should_fetch_legacy {
-                    progress.clone()
-                } else {
-                    None
-                };
-                let object_progress = fetch_progress.clone();
-                let legacy_progress = if should_fetch_object {
-                    None
-                } else {
-                    fetch_progress
-                };
+    // Partition assets: batch downloads (object missing), legacy-only copies
+    // (object present, legacy missing), and per-file fallbacks (local reuse,
+    // no batch route, or failed batch items).
+    let mut batch_items = Vec::new();
+    let mut legacy_copies = Vec::new();
+    let mut fallback_assets = Vec::new();
+    let mut skipped_count = 0_u64;
+    for (name, asset) in index.objects.iter() {
+        let hash = &asset.hash;
+        let resource_path = st.directories.object_dir(hash);
+        let legacy_resource_path = st.directories.legacy_assets_dir().join(
+            name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
+        );
+        let should_fetch_object = !resource_path.exists() || force;
+        let should_fetch_legacy =
+            (with_legacy && !legacy_resource_path.exists()) || force;
+
+        if should_fetch_object {
+            if local_source.is_some() {
                 let url = format!(
                     "https://resources.download.minecraft.net/{sub_hash}/{hash}",
                     sub_hash = &hash[..2]
                 );
+                fallback_assets.push(FallbackAsset {
+                    name: name.clone(),
+                    hash: hash.clone(),
+                    size: asset.size as u64,
+                    url,
+                    resource_path,
+                    legacy_resource_path,
+                });
+            } else {
+                let url = format!(
+                    "https://resources.download.minecraft.net/{sub_hash}/{hash}",
+                    sub_hash = &hash[..2]
+                );
+                batch_items.push(H2BatchAsset {
+                    url,
+                    destination: resource_path,
+                    legacy_destination: should_fetch_legacy
+                        .then_some(legacy_resource_path),
+                    sha1: hash.clone(),
+                    size: asset.size as u64,
+                });
+            }
+        } else if should_fetch_legacy {
+            legacy_copies.push((name, asset));
+        } else {
+            skipped_count += 1;
+        }
+    }
 
-                tokio::try_join! {
-                    async {
-                        if should_fetch_object {
-                            let context =
-                                InstallErrorContext::new("download Minecraft asset")
-                                    .file_path(name.clone())
-                                    .target_path(resource_path.display().to_string())
-                                    .build();
-                            let reused = download_or_reuse_local(
-                                st,
-                                local_source,
-                                &local_asset_object_path(hash),
-                                &resource_path,
-                                Some(hash),
-                                Some(asset.size as u64),
-                                object_progress.as_ref(),
-                                context.clone(),
-                                force,
-                                || {
-                                    download_minecraft_file(
-                                        st,
-                                        &url,
-                                        Some(hash),
-                                        Some(asset.size as u64),
-                                        &resource_path,
-                                        ResourceClass::MinecraftAsset,
-                                        ContentValidation::None,
-                                        force,
-                                        object_progress.clone(),
-                                        context,
-                                    )
-                                },
-                            )
-                            .await?;
-                            if reused {
-                                tracing::trace!("Reused asset with hash {hash}");
-                            } else {
-                                tracing::trace!("Fetched asset with hash {hash}");
+    // Batch-download the object files over a single shared HTTP/2 connection:
+    // hundreds of concurrent multiplexed streams, one connection per
+    // authority — never one connection per file.
+    if !batch_items.is_empty() {
+        let source_mode = st.minecraft_file_source();
+        let first_url = batch_items[0].url.clone();
+        let route =
+            resolve_download_routes_for(&first_url, ResourceClass::MinecraftAsset, source_mode)
+                .into_iter()
+                .next();
+        if let Some(route) = route {
+            // Resolve each item's URL onto the chosen route (official or
+            // mirror) so the batch reuses one connection to that authority.
+            for item in &mut batch_items {
+                item.url = resolve_download_routes_for(
+                    &item.url,
+                    ResourceClass::MinecraftAsset,
+                    source_mode,
+                )
+                .first()
+                .map(|route| route.url.clone())
+                .unwrap_or_else(|| item.url.clone());
+            }
+            let callback = {
+                let progress = progress.clone();
+                let loading_bar = loading_bar.cloned();
+                move |item: H2BatchAsset| -> Pin<Box<dyn Future<Output = ()> + Send>> {
+                    let progress = progress.clone();
+                    let loading_bar = loading_bar.clone();
+                    Box::pin(async move {
+                        if let Some(progress) = progress {
+                            if let Err(error) = progress.add_bytes(item.size).await {
+                                tracing::warn!(
+                                    error = %error,
+                                    "Failed to record batch asset bytes"
+                                );
                             }
                         }
-                        Ok::<_, crate::Error>(())
-                    },
-                    async {
-                        if should_fetch_legacy {
-                            download_minecraft_file(
-                                st,
-                                &url,
-                                Some(hash),
-                                Some(asset.size as u64),
-                                &legacy_resource_path,
-                                ResourceClass::MinecraftAsset,
-                                ContentValidation::None,
-                                force,
-                                legacy_progress,
-                                InstallErrorContext::new("download Minecraft asset")
-                                    .file_path(name.clone())
-                                    .target_path(legacy_resource_path.display().to_string())
-                                    .build(),
-                            )
-                            .await?;
-                            tracing::trace!("Fetched legacy asset with hash {hash}");
+                        if let Some(loading_bar) = loading_bar {
+                            let _ = emit_loading(&loading_bar, per_file_fraction, None);
                         }
-                        Ok::<_, crate::Error>(())
-                    },
-                }?;
-
-                tracing::trace!("Loaded asset with hash {hash}");
-                Ok(())
+                    })
                 }
-            }).await?;
+            };
+            let failed =
+                download_asset_batch_via_h2(&route, batch_items, ASSET_BATCH_CONCURRENCY, callback)
+                    .await;
+            if !failed.is_empty() {
+                let failed_hashes = failed
+                    .iter()
+                    .map(|item| item.sha1.as_str())
+                    .collect::<std::collections::HashSet<_>>();
+                for (name, asset) in index.objects.iter() {
+                    if failed_hashes.contains(asset.hash.as_str()) {
+                        let hash = &asset.hash;
+                        let url = format!(
+                            "https://resources.download.minecraft.net/{sub_hash}/{hash}",
+                            sub_hash = &hash[..2]
+                        );
+                        fallback_assets.push(FallbackAsset {
+                            name: name.clone(),
+                            hash: hash.clone(),
+                            size: asset.size as u64,
+                            url,
+                            resource_path: st.directories.object_dir(hash),
+                            legacy_resource_path: st.directories.legacy_assets_dir().join(
+                                name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
+                            ),
+                        });
+                    }
+                }
+            }
+        } else {
+            // No route could be resolved; fall back to per-file for all.
+            for (name, asset) in index.objects.iter() {
+                let hash = &asset.hash;
+                let url = format!(
+                    "https://resources.download.minecraft.net/{sub_hash}/{hash}",
+                    sub_hash = &hash[..2]
+                );
+                fallback_assets.push(FallbackAsset {
+                    name: name.clone(),
+                    hash: hash.clone(),
+                    size: asset.size as u64,
+                    url,
+                    resource_path: st.directories.object_dir(hash),
+                    legacy_resource_path: st.directories.legacy_assets_dir().join(
+                        name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
+                    ),
+                });
+            }
+        }
+    }
+
+    // Legacy copies for assets whose object is already on disk.
+    for (name, asset) in legacy_copies {
+        let hash = &asset.hash;
+        let resource_path = st.directories.object_dir(hash);
+        let legacy_resource_path = st.directories.legacy_assets_dir().join(
+            name.replace('/', &String::from(std::path::MAIN_SEPARATOR)),
+        );
+        crate::util::fetch::copy(
+            &resource_path,
+            &legacy_resource_path,
+            &st.io_semaphore,
+        )
+        .await?;
+        if let Some(progress) = &progress {
+            progress.add_bytes(asset.size as u64).await?;
+        }
+        if let Some(loading_bar) = loading_bar {
+            emit_loading(loading_bar, per_file_fraction, None)?;
+        }
+    }
+
+    // Per-file fallback path: local runtime reuse, no batch route, or batch
+    // failures. Runs concurrently (same budget as the original scheduler) so
+    // import flows are not serialised.
+    if !fallback_assets.is_empty() {
+        let limit = crate::util::download::task_concurrency_limit(&st)
+            .map(|limit| limit.saturating_mul(2))
+            .unwrap_or(ASSET_BATCH_CONCURRENCY);
+        let results = futures::stream::iter(fallback_assets)
+            .map(|item| {
+                let progress = progress.clone();
+                let st = st.clone();
+                let local_source = local_source.clone();
+                async move {
+                    let resource_path = &item.resource_path;
+                    let legacy_resource_path = &item.legacy_resource_path;
+                    let hash = &item.hash;
+                    let name = &item.name;
+                    let should_fetch_object = !resource_path.exists() || force;
+                    let should_fetch_legacy =
+                        (with_legacy && !legacy_resource_path.exists()) || force;
+                    let fetch_progress = if should_fetch_object || should_fetch_legacy {
+                        progress.clone()
+                    } else {
+                        None
+                    };
+                    let object_progress = fetch_progress.clone();
+                    let legacy_progress = if should_fetch_object {
+                        None
+                    } else {
+                        fetch_progress
+                    };
+
+                    tokio::try_join! {
+                        async {
+                            if should_fetch_object {
+                                let context =
+                                    InstallErrorContext::new("download Minecraft asset")
+                                        .file_path(name.clone())
+                                        .target_path(resource_path.display().to_string())
+                                        .build();
+                                let reused = download_or_reuse_local(
+                                    &st,
+                                    local_source.as_ref(),
+                                    &local_asset_object_path(hash),
+                                    resource_path,
+                                    Some(hash),
+                                    Some(item.size),
+                                    object_progress.as_ref(),
+                                    context.clone(),
+                                    force,
+                                    || {
+                                        download_minecraft_file(
+                                            &st,
+                                            &item.url,
+                                            Some(hash),
+                                            Some(item.size),
+                                            resource_path,
+                                            ResourceClass::MinecraftAsset,
+                                            ContentValidation::None,
+                                            force,
+                                            object_progress.clone(),
+                                            context,
+                                        )
+                                    },
+                                )
+                                .await?;
+                                if reused {
+                                    tracing::trace!("Reused asset with hash {hash}");
+                                } else {
+                                    tracing::trace!("Fetched asset with hash {hash}");
+                                }
+                            }
+                            Ok::<_, crate::Error>(())
+                        },
+                        async {
+                            if should_fetch_legacy {
+                                download_minecraft_file(
+                                    &st,
+                                    &item.url,
+                                    Some(hash),
+                                    Some(item.size),
+                                    legacy_resource_path,
+                                    ResourceClass::MinecraftAsset,
+                                    ContentValidation::None,
+                                    force,
+                                    legacy_progress,
+                                    InstallErrorContext::new("download Minecraft asset")
+                                        .file_path(name.clone())
+                                        .target_path(legacy_resource_path.display().to_string())
+                                        .build(),
+                                )
+                                .await?;
+                                tracing::trace!("Fetched legacy asset with hash {hash}");
+                            }
+                            Ok::<_, crate::Error>(())
+                        },
+                    }?;
+
+                    if let Some(loading_bar) = loading_bar {
+                        emit_loading(loading_bar, per_file_fraction, None)?;
+                    }
+                    tracing::trace!("Loaded asset with hash {hash}");
+                    Ok::<_, crate::Error>(())
+                }
+            })
+            .buffer_unordered(limit)
+            .collect::<Vec<crate::Result<()>>>()
+            .await;
+        for result in results {
+            result?;
+        }
+    }
+
+    // Account for assets that were already on disk so the loading bar still
+    // reaches its total.
+    for _ in 0..skipped_count {
+        if let Some(loading_bar) = loading_bar {
+            emit_loading(loading_bar, per_file_fraction, None)?;
+        }
+    }
+
     tracing::debug!("Done loading assets!");
     Ok(())
 }

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -22,7 +22,7 @@ use daedalus::minecraft::{LibraryDownload, LoggingConfiguration, LoggingSide};
 use daedalus::{
     self as d,
     minecraft::{
-        AssetsIndex, Library, Version as GameVersion,
+        Asset, AssetsIndex, Library, Version as GameVersion,
         VersionInfo as GameVersionInfo,
     },
     modded::LoaderVersion,
@@ -1386,8 +1386,8 @@ pub async fn download_assets_index(
 }
 
 /// Owned per-asset work item for the per-file fallback path of
-/// `download_assets`. Owning the data keeps the concurrent futures 'static so
-/// `buffer_unordered` can be used without lifetime-restricted captures.
+/// `download_assets`. Owned so the concurrent fallback futures do not borrow
+/// from the assets index.
 struct FallbackAsset {
     name: String,
     hash: String,
@@ -1397,10 +1397,33 @@ struct FallbackAsset {
     legacy_resource_path: PathBuf,
 }
 
+fn build_fallback_asset(
+    st: &State,
+    name: &str,
+    asset: &Asset,
+) -> FallbackAsset {
+    let hash = &asset.hash;
+    let url = format!(
+        "https://resources.download.minecraft.net/{sub_hash}/{hash}",
+        sub_hash = &hash[..2]
+    );
+    FallbackAsset {
+        name: name.to_string(),
+        hash: hash.clone(),
+        size: asset.size as u64,
+        url,
+        resource_path: st.directories.object_dir(hash),
+        legacy_resource_path: st
+            .directories
+            .legacy_assets_dir()
+            .join(name.replace('/', &String::from(std::path::MAIN_SEPARATOR))),
+    }
+}
+
 #[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub async fn download_assets(
-    _st: &State,
+    st: &State,
     local_source: Option<&LocalRuntimeSource>,
     with_legacy: bool,
     index: &AssetsIndex,
@@ -1410,10 +1433,6 @@ pub async fn download_assets(
     progress: Option<MinecraftDownloadProgress>,
 ) -> crate::Result<()> {
     tracing::debug!("Loading assets");
-    // Own the shared state and local source so the concurrent fallback
-    // futures below are 'static + Send (buffer_unordered requires this).
-    let st = State::get().await?;
-    let local_source = local_source.cloned();
     let num_futs = index.objects.len();
     let per_file_fraction = if num_futs > 0 {
         loading_amount / num_futs as f64
@@ -1441,18 +1460,7 @@ pub async fn download_assets(
 
         if should_fetch_object {
             if local_source.is_some() {
-                let url = format!(
-                    "https://resources.download.minecraft.net/{sub_hash}/{hash}",
-                    sub_hash = &hash[..2]
-                );
-                fallback_assets.push(FallbackAsset {
-                    name: name.clone(),
-                    hash: hash.clone(),
-                    size: asset.size as u64,
-                    url,
-                    resource_path,
-                    legacy_resource_path,
-                });
+                fallback_assets.push(build_fallback_asset(st, name, asset));
             } else {
                 let url = format!(
                     "https://resources.download.minecraft.net/{sub_hash}/{hash}",
@@ -1490,6 +1498,10 @@ pub async fn download_assets(
         if let Some(route) = route {
             // Resolve each item's URL onto the chosen route (official or
             // mirror) so the batch reuses one connection to that authority.
+            // Items whose resolved URL targets a different authority cannot
+            // share the batch connection and go through the per-file path.
+            let route_authority = url_authority(&route.url);
+            let mut reroute = Vec::new();
             for item in &mut batch_items {
                 item.url = resolve_download_routes_for(
                     &item.url,
@@ -1499,6 +1511,21 @@ pub async fn download_assets(
                 .first()
                 .map(|route| route.url.clone())
                 .unwrap_or_else(|| item.url.clone());
+                if url_authority(&item.url) != route_authority {
+                    reroute.push(item.sha1.clone());
+                }
+            }
+            if !reroute.is_empty() {
+                let reroute_hashes = reroute
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<std::collections::HashSet<_>>();
+                for (name, asset) in index.objects.iter() {
+                    if reroute_hashes.contains(asset.hash.as_str()) {
+                        fallback_assets
+                            .push(build_fallback_asset(st, name, asset));
+                    }
+                }
             }
             let callback = {
                 let progress = progress.clone();
@@ -1529,56 +1556,28 @@ pub async fn download_assets(
             )
             .await;
             if !failed.is_empty() {
+                tracing::warn!(
+                    items = failed.len(),
+                    source = route.source.as_str(),
+                    "Falling back to per-file downloads for {} batch-failed Minecraft assets on route {}",
+                    failed.len(),
+                    route.source.as_str(),
+                );
                 let failed_hashes = failed
                     .iter()
                     .map(|item| item.sha1.as_str())
                     .collect::<std::collections::HashSet<_>>();
                 for (name, asset) in index.objects.iter() {
                     if failed_hashes.contains(asset.hash.as_str()) {
-                        let hash = &asset.hash;
-                        let url = format!(
-                            "https://resources.download.minecraft.net/{sub_hash}/{hash}",
-                            sub_hash = &hash[..2]
-                        );
-                        fallback_assets.push(FallbackAsset {
-                            name: name.clone(),
-                            hash: hash.clone(),
-                            size: asset.size as u64,
-                            url,
-                            resource_path: st.directories.object_dir(hash),
-                            legacy_resource_path: st
-                                .directories
-                                .legacy_assets_dir()
-                                .join(name.replace(
-                                    '/',
-                                    &String::from(std::path::MAIN_SEPARATOR),
-                                )),
-                        });
+                        fallback_assets
+                            .push(build_fallback_asset(st, name, asset));
                     }
                 }
             }
         } else {
             // No route could be resolved; fall back to per-file for all.
             for (name, asset) in index.objects.iter() {
-                let hash = &asset.hash;
-                let url = format!(
-                    "https://resources.download.minecraft.net/{sub_hash}/{hash}",
-                    sub_hash = &hash[..2]
-                );
-                fallback_assets.push(FallbackAsset {
-                    name: name.clone(),
-                    hash: hash.clone(),
-                    size: asset.size as u64,
-                    url,
-                    resource_path: st.directories.object_dir(hash),
-                    legacy_resource_path: st
-                        .directories
-                        .legacy_assets_dir()
-                        .join(name.replace(
-                            '/',
-                            &String::from(std::path::MAIN_SEPARATOR),
-                        )),
-                });
+                fallback_assets.push(build_fallback_asset(st, name, asset));
             }
         }
     }
@@ -1609,14 +1608,13 @@ pub async fn download_assets(
     // failures. Runs concurrently (same budget as the original scheduler) so
     // import flows are not serialised.
     if !fallback_assets.is_empty() {
-        let limit = crate::util::download::task_concurrency_limit(&st)
+        let limit = crate::util::download::task_concurrency_limit(st)
             .map(|limit| limit.saturating_mul(2))
             .unwrap_or(ASSET_BATCH_CONCURRENCY);
-        let results = futures::stream::iter(fallback_assets)
-            .map(|item| {
+        futures::stream::iter(fallback_assets)
+            .map(Ok::<FallbackAsset, crate::Error>)
+            .try_for_each_concurrent(limit, |item| {
                 let progress = progress.clone();
-                let st = st.clone();
-                let local_source = local_source.clone();
                 async move {
                     let resource_path = &item.resource_path;
                     let legacy_resource_path = &item.legacy_resource_path;
@@ -1646,8 +1644,8 @@ pub async fn download_assets(
                                         .target_path(resource_path.display().to_string())
                                         .build();
                                 let reused = download_or_reuse_local(
-                                    &st,
-                                    local_source.as_ref(),
+                                    st,
+                                    local_source,
                                     &local_asset_object_path(hash),
                                     resource_path,
                                     Some(hash),
@@ -1657,7 +1655,7 @@ pub async fn download_assets(
                                     force,
                                     || {
                                         download_minecraft_file(
-                                            &st,
+                                            st,
                                             &item.url,
                                             Some(hash),
                                             Some(item.size),
@@ -1682,7 +1680,7 @@ pub async fn download_assets(
                         async {
                             if should_fetch_legacy {
                                 download_minecraft_file(
-                                    &st,
+                                    st,
                                     &item.url,
                                     Some(hash),
                                     Some(item.size),
@@ -1710,12 +1708,7 @@ pub async fn download_assets(
                     Ok::<_, crate::Error>(())
                 }
             })
-            .buffer_unordered(limit)
-            .collect::<Vec<crate::Result<()>>>()
-            .await;
-        for result in results {
-            result?;
-        }
+            .await?;
     }
 
     // Account for assets that were already on disk so the loading bar still

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -660,7 +660,8 @@ pub(crate) async fn download_asset_batch_via_h2<F>(
     on_completed: F,
 ) -> Vec<H2BatchAsset>
 where
-    F: FnMut(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send
+    F: FnMut(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>>
+        + Send
         + 'static,
 {
     let Some(connection) = connect_authority(&route.url).await else {
@@ -679,16 +680,14 @@ where
                 let callback = callback.clone();
                 async move {
                     let Ok(uri) = item.url.parse::<Uri>() else {
-                        let error = crate::Error::from(
-                            crate::ErrorKind::InputError(format!(
-                                "invalid asset URL: {}",
-                                item.url
-                            )),
-                        );
+                        let error =
+                            crate::Error::from(crate::ErrorKind::InputError(
+                                format!("invalid asset URL: {}", item.url),
+                            ));
                         return (item, Err(error));
                     };
-                    let result = download_asset_item(&connection, &uri, &item)
-                        .await;
+                    let result =
+                        download_asset_item(&connection, &uri, &item).await;
                     if result.is_ok() {
                         let mut callback = callback.lock().await;
                         callback(item.clone()).await;
@@ -749,7 +748,8 @@ async fn download_asset_item(
         sha1: Some(item.sha1.clone()),
         ..Integrity::default()
     };
-    let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(&integrity);
+    let mut hashers =
+        fetch::IntegrityHashers::new_integrity_hashers(&integrity);
     let part_path = fetch::suffixed_path(&item.destination, ".part");
     if let Some(parent) = part_path.parent() {
         crate::util::io::create_dir_all(parent).await?;
@@ -787,8 +787,7 @@ async fn download_asset_item(
         .into());
     }
     let computed = hashers.finish(downloaded);
-    if let Err(error) =
-        fetch::verify_computed_integrity(&integrity, &computed)
+    if let Err(error) = fetch::verify_computed_integrity(&integrity, &computed)
     {
         let _ = tokio::fs::remove_file(&part_path).await;
         return Err(error);

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -653,9 +653,11 @@ impl Clone for H2BatchAsset {
 /// opens an independent stream on that single connection. Items that cannot be
 /// downloaded after internal retries are returned so the caller can retry them
 /// through the regular per-file path (which performs route fallback).
+/// Returned items have exhausted every batch pass, so downstream can treat
+/// them as persistently failing against the chosen route.
 pub(crate) async fn download_asset_batch_via_h2<F>(
     route: &DownloadRoute,
-    mut items: Vec<H2BatchAsset>,
+    items: Vec<H2BatchAsset>,
     concurrency: usize,
     on_completed: F,
 ) -> Vec<H2BatchAsset>
@@ -667,9 +669,23 @@ where
     let Some(connection) = connect_authority(&route.url).await else {
         return items;
     };
+    let route_authority = fetch::url_authority(&route.url);
+
+    // Items whose URL targets a different authority cannot be multiplexed on
+    // this connection; hand them straight back without wasting batch passes.
+    let (mut items, mut failed): (Vec<_>, Vec<_>) = items
+        .into_iter()
+        .partition(|item| fetch::url_authority(&item.url) == route_authority);
+    if !failed.is_empty() {
+        tracing::warn!(
+            items = failed.len(),
+            route = %fetch::sanitize_url_for_log(&route.url),
+            "Skipping {} assets whose resolved URL does not match the batch authority",
+            failed.len(),
+        );
+    }
 
     let callback = Arc::new(tokio::sync::Mutex::new(on_completed));
-    let mut failed = Vec::new();
     for pass in 0..ASSET_BATCH_RETRY_PASSES {
         if items.is_empty() {
             break;
@@ -703,9 +719,9 @@ where
             match result {
                 Ok(()) => {}
                 Err(error) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         url = %fetch::sanitize_url_for_log(&item.url),
-                        pass,
+                        pass = pass + 1,
                         error = %error,
                         "Batch asset download failed"
                     );
@@ -717,6 +733,16 @@ where
                 }
             }
         }
+    }
+    if !failed.is_empty() {
+        tracing::warn!(
+            items = failed.len(),
+            retry_passes = ASSET_BATCH_RETRY_PASSES,
+            source = route.source.as_str(),
+            "{} assets exhausted all {ASSET_BATCH_RETRY_PASSES} batch retry passes on route {}",
+            failed.len(),
+            route.source.as_str(),
+        );
     }
     failed
 }
@@ -754,51 +780,56 @@ async fn download_asset_item(
     if let Some(parent) = part_path.parent() {
         crate::util::io::create_dir_all(parent).await?;
     }
-    let mut file = tokio::fs::File::create(&part_path).await?;
-    let mut downloaded = 0_u64;
-    loop {
-        let chunk = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.data())
-            .await
-            .map_err(|_| {
-                crate::ErrorKind::NetworkError(
-                    "HTTP/2 asset stream receive timed out".into(),
-                )
-            })?
-            .transpose()
-            .map_err(|error| {
-                crate::ErrorKind::NetworkError(format!(
-                    "HTTP/2 asset stream error: {error}"
-                ))
-            })?;
-        let Some(chunk) = chunk else {
-            break;
-        };
-        file.write_all(&chunk).await?;
-        hashers.update(&chunk);
-        downloaded += chunk.len() as u64;
-    }
-    file.flush().await?;
-    drop(file);
-    if downloaded == 0 {
-        let _ = tokio::fs::remove_file(&part_path).await;
-        return Err(crate::ErrorKind::OtherError(
-            "downloaded asset is empty".to_string(),
-        )
-        .into());
-    }
-    let computed = hashers.finish(downloaded);
-    if let Err(error) = fetch::verify_computed_integrity(&integrity, &computed)
-    {
-        let _ = tokio::fs::remove_file(&part_path).await;
-        return Err(error);
-    }
-    fetch::finalize_download(&part_path, &item.destination).await?;
-
-    if let Some(legacy) = &item.legacy_destination {
-        if let Some(parent) = legacy.parent() {
-            tokio::fs::create_dir_all(parent).await?;
+    // Any failure below leaves a partial file behind; clean it up so retries
+    // start from a clean slate and no orphaned `.part` files accumulate.
+    let result: crate::Result<()> = async {
+        let mut file = tokio::fs::File::create(&part_path).await?;
+        let mut downloaded = 0_u64;
+        loop {
+            let chunk =
+                tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.data())
+                    .await
+                    .map_err(|_| {
+                        crate::ErrorKind::NetworkError(
+                            "HTTP/2 asset stream receive timed out".into(),
+                        )
+                    })?
+                    .transpose()
+                    .map_err(|error| {
+                        crate::ErrorKind::NetworkError(format!(
+                            "HTTP/2 asset stream error: {error}"
+                        ))
+                    })?;
+            let Some(chunk) = chunk else {
+                break;
+            };
+            file.write_all(&chunk).await?;
+            hashers.update(&chunk);
+            downloaded += chunk.len() as u64;
         }
-        tokio::fs::copy(&item.destination, legacy).await?;
+        file.flush().await?;
+        drop(file);
+        if downloaded == 0 {
+            return Err(crate::ErrorKind::OtherError(
+                "downloaded asset is empty".to_string(),
+            )
+            .into());
+        }
+        let computed = hashers.finish(downloaded);
+        fetch::verify_computed_integrity(&integrity, &computed)?;
+        fetch::finalize_download(&part_path, &item.destination).await?;
+
+        if let Some(legacy) = &item.legacy_destination {
+            if let Some(parent) = legacy.parent() {
+                crate::util::io::create_dir_all(parent).await?;
+            }
+            tokio::fs::copy(&item.destination, legacy).await?;
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&part_path).await;
+    }
+    result
 }

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -13,9 +13,11 @@ use crate::util::fetch::{
     DownloadRequest, DownloadResult, DownloadRoute, DownloadRouteSource,
     Integrity,
 };
+use futures::StreamExt;
 use http::header::{ACCEPT_ENCODING, RANGE, USER_AGENT};
 use http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use std::path::Path;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,6 +30,14 @@ const MAX_SEGMENT_CONCURRENCY: usize = 8;
 const INITIAL_SEGMENT_CONCURRENCY: usize = 4;
 const RANGE_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 const STREAM_RECV_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Client-side concurrency target for the batch asset downloader. All
+/// concurrent streams are multiplexed over one shared HTTP/2 connection per
+/// authority, so this is the number of streams, not connections.
+pub(crate) const ASSET_BATCH_CONCURRENCY: usize = 512;
+/// Internal retry passes for failed batch items before they are handed back
+/// to the caller for the regular per-file download path.
+const ASSET_BATCH_RETRY_PASSES: usize = 2;
 
 /// Outcome of attempting a multiplexed download.
 pub(crate) enum H2DownloadOutcome {
@@ -607,5 +617,189 @@ async fn verify_and_finalize(
         .into());
     }
     fetch::finalize_download(part_path, destination).await?;
+    Ok(())
+}
+
+/// A single small file (a Minecraft asset object) to download over a shared
+/// HTTP/2 connection. All items in one batch must share the same authority.
+pub(crate) struct H2BatchAsset {
+    /// Route-resolved URL for the asset.
+    pub url: String,
+    /// Destination for the object (`assets/objects/<hh>/<hash>`).
+    pub destination: std::path::PathBuf,
+    /// Optional legacy `resources/` copy destination.
+    pub legacy_destination: Option<std::path::PathBuf>,
+    /// Expected SHA-1 hash of the asset (also its file name).
+    pub sha1: String,
+    /// Expected size in bytes.
+    pub size: u64,
+}
+
+impl Clone for H2BatchAsset {
+    fn clone(&self) -> Self {
+        Self {
+            url: self.url.clone(),
+            destination: self.destination.clone(),
+            legacy_destination: self.legacy_destination.clone(),
+            sha1: self.sha1.clone(),
+            size: self.size,
+        }
+    }
+}
+
+/// Downloads a batch of small files over one shared HTTP/2 connection,
+/// multiplexing up to `concurrency` streams. This is deliberately NOT one
+/// connection per file: the caller groups items by authority and every item
+/// opens an independent stream on that single connection. Items that cannot be
+/// downloaded after internal retries are returned so the caller can retry them
+/// through the regular per-file path (which performs route fallback).
+pub(crate) async fn download_asset_batch_via_h2<F>(
+    route: &DownloadRoute,
+    mut items: Vec<H2BatchAsset>,
+    concurrency: usize,
+    on_completed: F,
+) -> Vec<H2BatchAsset>
+where
+    F: FnMut(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send
+        + 'static,
+{
+    let Some(connection) = connect_authority(&route.url).await else {
+        return items;
+    };
+
+    let callback = Arc::new(tokio::sync::Mutex::new(on_completed));
+    let mut failed = Vec::new();
+    for pass in 0..ASSET_BATCH_RETRY_PASSES {
+        if items.is_empty() {
+            break;
+        }
+        let results = futures::stream::iter(items)
+            .map(|item| {
+                let connection = connection.clone();
+                let callback = callback.clone();
+                async move {
+                    let Ok(uri) = item.url.parse::<Uri>() else {
+                        let error = crate::Error::from(
+                            crate::ErrorKind::InputError(format!(
+                                "invalid asset URL: {}",
+                                item.url
+                            )),
+                        );
+                        return (item, Err(error));
+                    };
+                    let result = download_asset_item(&connection, &uri, &item)
+                        .await;
+                    if result.is_ok() {
+                        let mut callback = callback.lock().await;
+                        callback(item.clone()).await;
+                    }
+                    (item, result)
+                }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+        items = Vec::new();
+        for (item, result) in results {
+            match result {
+                Ok(()) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        url = %fetch::sanitize_url_for_log(&item.url),
+                        pass,
+                        error = %error,
+                        "Batch asset download failed"
+                    );
+                    if pass + 1 < ASSET_BATCH_RETRY_PASSES {
+                        items.push(item);
+                    } else {
+                        failed.push(item);
+                    }
+                }
+            }
+        }
+    }
+    failed
+}
+
+async fn download_asset_item(
+    connection: &SharedH2Connection,
+    uri: &Uri,
+    item: &H2BatchAsset,
+) -> crate::Result<()> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_str(&crate::launcher_user_agent())
+            .unwrap_or_else(|_| HeaderValue::from_static("Axolotl Launcher")),
+    );
+    headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
+
+    let (response, mut stream) = open_stream(connection, uri, headers).await?;
+    if !response.status().is_success() {
+        return Err(crate::ErrorKind::OtherError(format!(
+            "HTTP/2 GET failed with status {}",
+            response.status()
+        ))
+        .into());
+    }
+
+    let integrity = Integrity {
+        size: Some(item.size),
+        sha1: Some(item.sha1.clone()),
+        ..Integrity::default()
+    };
+    let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(&integrity);
+    let part_path = fetch::suffixed_path(&item.destination, ".part");
+    if let Some(parent) = part_path.parent() {
+        crate::util::io::create_dir_all(parent).await?;
+    }
+    let mut file = tokio::fs::File::create(&part_path).await?;
+    let mut downloaded = 0_u64;
+    loop {
+        let chunk = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.data())
+            .await
+            .map_err(|_| {
+                crate::ErrorKind::NetworkError(
+                    "HTTP/2 asset stream receive timed out".into(),
+                )
+            })?
+            .transpose()
+            .map_err(|error| {
+                crate::ErrorKind::NetworkError(format!(
+                    "HTTP/2 asset stream error: {error}"
+                ))
+            })?;
+        let Some(chunk) = chunk else {
+            break;
+        };
+        file.write_all(&chunk).await?;
+        hashers.update(&chunk);
+        downloaded += chunk.len() as u64;
+    }
+    file.flush().await?;
+    drop(file);
+    if downloaded == 0 {
+        let _ = tokio::fs::remove_file(&part_path).await;
+        return Err(crate::ErrorKind::OtherError(
+            "downloaded asset is empty".to_string(),
+        )
+        .into());
+    }
+    let computed = hashers.finish(downloaded);
+    if let Err(error) =
+        fetch::verify_computed_integrity(&integrity, &computed)
+    {
+        let _ = tokio::fs::remove_file(&part_path).await;
+        return Err(error);
+    }
+    fetch::finalize_download(&part_path, &item.destination).await?;
+
+    if let Some(legacy) = &item.legacy_destination {
+        if let Some(parent) = legacy.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::copy(&item.destination, legacy).await?;
+    }
     Ok(())
 }

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -210,10 +210,10 @@ async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
     let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
         .await
         .map_err(|error| {
-            crate::ErrorKind::NetworkError(format!(
-                "HTTP/2 handshake with {authority} failed: {error}"
-            ))
-        })?;
+        crate::ErrorKind::NetworkError(format!(
+            "HTTP/2 handshake with {authority} failed: {error}"
+        ))
+    })?;
 
     // Tune flow-control windows for high-stream multiplexing (e.g. hundreds
     // of concurrent asset downloads over one connection). With the default

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -220,6 +220,8 @@ async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
     // 64 KiB connection window, concurrent streams would stall waiting for
     // connection-level window updates; a larger per-stream window also lets
     // the peer send a whole small file without round trips.
+    // `set_target_window_size` returns `()`, while `set_initial_window_size`
+    // returns a `Result`, so only the latter needs its error captured.
     connection.set_target_window_size(64 * 1024 * 1024);
     let _ = connection.set_initial_window_size(1024 * 1024);
 

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -207,13 +207,21 @@ async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
         ))
     })?;
 
-    let (sender, connection) = h2::client::handshake(Box::pin(tls))
+    let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
         .await
         .map_err(|error| {
             crate::ErrorKind::NetworkError(format!(
                 "HTTP/2 handshake with {authority} failed: {error}"
             ))
         })?;
+
+    // Tune flow-control windows for high-stream multiplexing (e.g. hundreds
+    // of concurrent asset downloads over one connection). With the default
+    // 64 KiB connection window, concurrent streams would stall waiting for
+    // connection-level window updates; a larger per-stream window also lets
+    // the peer send a whole small file without round trips.
+    connection.set_target_window_size(64 * 1024 * 1024);
+    let _ = connection.set_initial_window_size(1024 * 1024);
 
     let shared = Arc::new(SharedH2Connection::new(sender));
 

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -2810,7 +2810,7 @@ impl IntegrityHashers {
     }
 }
 
-fn suffixed_path(path: &Path, suffix: &str) -> PathBuf {
+pub(crate) fn suffixed_path(path: &Path, suffix: &str) -> PathBuf {
     let mut value = path.as_os_str().to_os_string();
     value.push(suffix);
     PathBuf::from(value)


### PR DESCRIPTION
优化 Minecraft 下载，使用多线程激进下载 hashed assets，并在下载 Modpack 的同时进行 Minecraft 文件下载。

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

新功能：
- 通过共享的 HTTP/2 连接，以高度并发的批处理方式下载 Minecraft 资源对象，并对每个文件进行重试和回退处理。
- 将 Minecraft 核心安装与整合包内容安装并行执行，并在下载 UI 中提供独立的进度跟踪。

改进：
- 为并行安装任务增加安装进度状态、持久化、清理逻辑以及前端渲染支持。
- 调整 HTTP/2 流控，以优化大规模多路复用资源下载。

测试：
- 增加对独立并行安装进度显示与选择的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

新功能：
- 通过共享的 HTTP/2 连接，以高度并发的批处理方式下载 Minecraft 资源对象，并对每个文件进行重试和回退处理。
- 将 Minecraft 核心安装与整合包内容安装并行执行，并在下载 UI 中提供独立的进度跟踪。

改进：
- 为并行安装任务增加安装进度状态、持久化、清理逻辑以及前端渲染支持。
- 调整 HTTP/2 流控，以优化大规模多路复用资源下载。

测试：
- 增加对独立并行安装进度显示与选择的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

新功能：
- 通过共享的 HTTP/2 连接，以高度并发的批处理方式下载 Minecraft 资源对象，并对每个文件进行重试和回退处理。
- 将 Minecraft 核心安装与整合包内容安装并行执行，并在下载 UI 中提供独立的进度跟踪。

改进：
- 为并行安装任务增加安装进度状态、持久化、清理逻辑以及前端渲染支持。
- 调整 HTTP/2 流控，以优化大规模多路复用资源下载。

测试：
- 增加对独立并行安装进度显示与选择的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

新功能：
- 通过共享的 HTTP/2 连接，以高度并发的批处理方式下载 Minecraft 资源对象，并对每个文件进行重试和回退处理。
- 将 Minecraft 核心安装与整合包内容安装并行执行，并在下载 UI 中提供独立的进度跟踪。

改进：
- 为并行安装任务增加安装进度状态、持久化、清理逻辑以及前端渲染支持。
- 调整 HTTP/2 流控，以优化大规模多路复用资源下载。

测试：
- 增加对独立并行安装进度显示与选择的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在共享 HTTP/2 连接上复用资源下载，并在下载整合包内容的同时并行执行核心安装，加速 Minecraft 及整合包的安装过程。

New Features:
- 通过共享的 HTTP/2 连接，以高度并发的批次方式下载 Minecraft 资源对象，并提供完整性校验、重试机制以及按文件粒度的降级回退处理。
- 在下载整合包内容的同时并发安装 Minecraft 核心文件，并在下载界面中暴露独立的进度跟踪。

Bug Fixes:
- 清理失败的部分资源下载文件，并在整合包安装被中断或暂停时停止并行的 Minecraft 安装任务。

Enhancements:
- 持久化、恢复、清空并渲染独立的并行安装进度轨迹。
- 为大规模多路复用的资源下载调优 HTTP/2 流控窗口。

Tests:
- 为独立的并行安装进度添加前端测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accelerate Minecraft and modpack installation by multiplexing asset downloads over shared HTTP/2 connections and running core installation alongside modpack content downloads.

New Features:
- Download Minecraft asset objects in highly concurrent batches over shared HTTP/2 connections with integrity validation, retries, and per-file fallback handling.
- Install Minecraft core files concurrently with modpack content and expose separate progress tracking in the download interface.

Bug Fixes:
- Clean up failed partial asset downloads and stop parallel Minecraft installation tasks during interrupted or paused modpack installations.

Enhancements:
- Persist, restore, clear, and render an independent parallel installation progress track.
- Tune HTTP/2 flow-control windows for large multiplexed asset downloads.

Tests:
- Add frontend coverage for independent parallel installation progress.

</details>

</details>

</details>

</details>

</details>