### PR TITLE
refactor: 继续重构原生下载引擎，借鉴 XMCL 下载优点

### DIFF
--- a/apps/app-frontend/src/data/about/contributors.json
+++ b/apps/app-frontend/src/data/about/contributors.json
@@ -12,22 +12,22 @@
 		"contributions": 776
 	},
 	{
+		"name": "addre98",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/111131309?v=4&s=96",
+		"url": "https://github.com/addre98",
+		"contributions": 378
+	},
+	{
 		"name": "IMB11",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/93472213?v=4&s=96",
 		"url": "https://github.com/IMB11",
 		"contributions": 363
 	},
 	{
-		"name": "addre98",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/111131309?v=4&s=96",
-		"url": "https://github.com/addre98",
-		"contributions": 334
-	},
-	{
 		"name": "Mystic-Stars",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/97295993?v=4&s=96",
 		"url": "https://github.com/Mystic-Stars",
-		"contributions": 199
+		"contributions": 223
 	},
 	{
 		"name": "triphora",
@@ -45,7 +45,7 @@
 		"name": "ItzJerry317",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/85010676?v=4&s=96",
 		"url": "https://github.com/ItzJerry317",
-		"contributions": 146
+		"contributions": 153
 	},
 	{
 		"name": "venashial",
@@ -78,16 +78,16 @@
 		"contributions": 91
 	},
 	{
+		"name": "Lintern",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/100106683?v=4&s=96",
+		"url": "https://github.com/Lintern",
+		"contributions": 90
+	},
+	{
 		"name": "AlexTMjugador",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/7822554?v=4&s=96",
 		"url": "https://github.com/AlexTMjugador",
 		"contributions": 85
-	},
-	{
-		"name": "Lintern",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/100106683?v=4&s=96",
-		"url": "https://github.com/Lintern",
-		"contributions": 81
 	},
 	{
 		"name": "github-actions[bot]",
@@ -142,6 +142,12 @@
 		"avatarUrl": "https://avatars.githubusercontent.com/u/106493074?v=4&s=96",
 		"url": "https://github.com/modrinth-bot",
 		"contributions": 39
+	},
+	{
+		"name": "CodeZhangBorui",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/61909157?v=4&s=96",
+		"url": "https://github.com/CodeZhangBorui",
+		"contributions": 33
 	},
 	{
 		"name": "Aeledfyr",
@@ -306,6 +312,12 @@
 		"contributions": 5
 	},
 	{
+		"name": "bcmRayCrazy-coder",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/65066644?v=4&s=96",
+		"url": "https://github.com/bcmRayCrazy-coder",
+		"contributions": 5
+	},
+	{
 		"name": "he3als",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/65787561?v=4&s=96",
 		"url": "https://github.com/he3als",
@@ -354,15 +366,9 @@
 		"contributions": 4
 	},
 	{
-		"name": "bcmRayCrazy-coder",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/65066644?v=4&s=96",
-		"url": "https://github.com/bcmRayCrazy-coder",
-		"contributions": 4
-	},
-	{
-		"name": "CodeZhangBorui",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/61909157?v=4&s=96",
-		"url": "https://github.com/CodeZhangBorui",
+		"name": "CiiLu",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/109708109?v=4&s=96",
+		"url": "https://github.com/CiiLu",
 		"contributions": 4
 	},
 	{
@@ -417,12 +423,6 @@
 		"name": "cfanoulis",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/38255093?v=4&s=96",
 		"url": "https://github.com/cfanoulis",
-		"contributions": 3
-	},
-	{
-		"name": "CiiLu",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/109708109?v=4&s=96",
-		"url": "https://github.com/CiiLu",
 		"contributions": 3
 	},
 	{
@@ -1383,6 +1383,12 @@
 		"name": "Weredime",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/100447465?v=4&s=96",
 		"url": "https://github.com/Weredime",
+		"contributions": 1
+	},
+	{
+		"name": "xjuunn",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/145442547?v=4&s=96",
+		"url": "https://github.com/xjuunn",
 		"contributions": 1
 	}
 ]

--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -63,6 +63,7 @@ const ITEM_FAILURE_REASON_CHAR_LIMIT: usize = 1_024;
 /// over a single connection (no range segmentation) and only after every pass
 /// is exhausted does the install ask the user about missing content.
 const AUTO_RETRY_PASSES: usize = 2;
+const NATIVE_CONTENT_TASK_CONCURRENCY: usize = 32;
 
 pub(crate) enum MrpackInstallOutcome {
     #[allow(dead_code)]
@@ -1082,7 +1083,15 @@ pub(crate) async fn install_zipped_mrpack_files_with_reporter(
         let pass_failures =
             collect_required_file_failures_concurrently(
         tasks,
-        Some(state.download_concurrency()),
+        Some(if crate::util::download::active_engine()
+            == crate::util::download::DownloadEngine::XmclCompat
+        {
+            state.download_concurrency()
+        } else {
+            state
+                .download_concurrency()
+                .min(NATIVE_CONTENT_TASK_CONCURRENCY)
+        }),
         |(manifest_index, project)| {
             let content_context = content_context.clone();
             let skipped_missing_content_paths =

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -1577,6 +1577,7 @@ pub async fn download_assets(
                 batch_items,
                 ASSET_BATCH_CONCURRENCY,
 				apply_native_policy,
+				apply_native_policy.then_some(&st.fetch_semaphore),
                 callback,
             )
             .await;

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -1488,13 +1488,30 @@ pub async fn download_assets(
     if !batch_items.is_empty() {
         let source_mode = st.minecraft_file_source();
         let first_url = batch_items[0].url.clone();
-        let route = resolve_download_routes_for(
+        let mut routes = resolve_download_routes_for(
             &first_url,
             ResourceClass::MinecraftAsset,
             source_mode,
-        )
-        .into_iter()
-        .next();
+        );
+		let apply_native_policy = crate::util::download::active_engine()
+			!= crate::util::download::DownloadEngine::XmclCompat;
+		if apply_native_policy {
+			let probe_request = DownloadRequest::new(
+				&first_url,
+				ResourceClass::MinecraftAsset,
+			)
+			.with_integrity(
+				Integrity::sha1(&batch_items[0].sha1)
+					.with_size(batch_items[0].size),
+			);
+			prepare_native_download_routes(
+				&probe_request,
+				&mut routes,
+				&st.fetch_semaphore,
+			)
+			.await;
+		}
+        let route = routes.into_iter().next();
         if let Some(route) = route {
             // Resolve each item's URL onto the chosen route (official or
             // mirror) so the batch reuses one connection to that authority.
@@ -1503,12 +1520,19 @@ pub async fn download_assets(
             let route_authority = url_authority(&route.url);
             let mut reroute = Vec::new();
             for item in &mut batch_items {
-                item.url = resolve_download_routes_for(
+				let item_routes = resolve_download_routes_for(
                     &item.url,
                     ResourceClass::MinecraftAsset,
                     source_mode,
-                )
-                .first()
+                );
+				item.url = item_routes
+					.iter()
+					.find(|candidate| {
+						apply_native_policy
+							&& candidate.source == route.source
+							&& candidate.proxy == route.proxy
+					})
+					.or_else(|| item_routes.first())
                 .map(|route| route.url.clone())
                 .unwrap_or_else(|| item.url.clone());
                 if url_authority(&item.url) != route_authority {
@@ -1552,6 +1576,7 @@ pub async fn download_assets(
                 &route,
                 batch_items,
                 ASSET_BATCH_CONCURRENCY,
+				apply_native_policy,
                 callback,
             )
             .await;

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -1493,24 +1493,22 @@ pub async fn download_assets(
             ResourceClass::MinecraftAsset,
             source_mode,
         );
-		let apply_native_policy = crate::util::download::active_engine()
-			!= crate::util::download::DownloadEngine::XmclCompat;
-		if apply_native_policy {
-			let probe_request = DownloadRequest::new(
-				&first_url,
-				ResourceClass::MinecraftAsset,
-			)
-			.with_integrity(
-				Integrity::sha1(&batch_items[0].sha1)
-					.with_size(batch_items[0].size),
-			);
-			prepare_native_download_routes(
-				&probe_request,
-				&mut routes,
-				&st.fetch_semaphore,
-			)
-			.await;
-		}
+        let apply_native_policy = crate::util::download::active_engine()
+            != crate::util::download::DownloadEngine::XmclCompat;
+        if apply_native_policy {
+            let probe_request =
+                DownloadRequest::new(&first_url, ResourceClass::MinecraftAsset)
+                    .with_integrity(
+                        Integrity::sha1(&batch_items[0].sha1)
+                            .with_size(batch_items[0].size),
+                    );
+            prepare_native_download_routes(
+                &probe_request,
+                &mut routes,
+                &st.fetch_semaphore,
+            )
+            .await;
+        }
         let route = routes.into_iter().next();
         if let Some(route) = route {
             // Resolve each item's URL onto the chosen route (official or
@@ -1520,21 +1518,21 @@ pub async fn download_assets(
             let route_authority = url_authority(&route.url);
             let mut reroute = Vec::new();
             for item in &mut batch_items {
-				let item_routes = resolve_download_routes_for(
+                let item_routes = resolve_download_routes_for(
                     &item.url,
                     ResourceClass::MinecraftAsset,
                     source_mode,
                 );
-				item.url = item_routes
-					.iter()
-					.find(|candidate| {
-						apply_native_policy
-							&& candidate.source == route.source
-							&& candidate.proxy == route.proxy
-					})
-					.or_else(|| item_routes.first())
-                .map(|route| route.url.clone())
-                .unwrap_or_else(|| item.url.clone());
+                item.url = item_routes
+                    .iter()
+                    .find(|candidate| {
+                        apply_native_policy
+                            && candidate.source == route.source
+                            && candidate.proxy == route.proxy
+                    })
+                    .or_else(|| item_routes.first())
+                    .map(|route| route.url.clone())
+                    .unwrap_or_else(|| item.url.clone());
                 if url_authority(&item.url) != route_authority {
                     reroute.push(item.sha1.clone());
                 }
@@ -1576,8 +1574,8 @@ pub async fn download_assets(
                 &route,
                 batch_items,
                 ASSET_BATCH_CONCURRENCY,
-				apply_native_policy,
-				apply_native_policy.then_some(&st.fetch_semaphore),
+                apply_native_policy,
+                apply_native_policy.then_some(&st.fetch_semaphore),
                 callback,
             )
             .await;

--- a/packages/app-lib/src/logger.rs
+++ b/packages/app-lib/src/logger.rs
@@ -639,7 +639,11 @@ pub fn start_logger(app_identifier: &str) -> Option<()> {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| {
             tracing_subscriber::EnvFilter::new("theseus=info,theseus_gui=info")
-        });
+        })
+        .add_directive("h2=info".parse().ok()?)
+        .add_directive("hyper=info".parse().ok()?)
+        .add_directive("hyper_util=info".parse().ok()?)
+        .add_directive("sqlx=warn".parse().ok()?);
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_writer(|| {
             TruncatedConsoleWriter {
@@ -895,7 +899,11 @@ pub fn start_logger(app_identifier: &str) -> Option<()> {
     };
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("theseus=info"));
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("theseus=info"))
+        .add_directive("h2=info".parse().ok()?)
+        .add_directive("hyper=info".parse().ok()?)
+        .add_directive("hyper_util=info".parse().ok()?)
+        .add_directive("sqlx=warn".parse().ok()?);
 
     tracing_subscriber::registry()
         .with(

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -83,6 +83,10 @@ impl H2DownloadFailure {
 		matches!(self, Self::Protocol)
 	}
 
+	pub(crate) const fn is_transfer_failure(self) -> bool {
+		matches!(self, Self::Connect | Self::Tls | Self::Protocol)
+	}
+
 	pub(crate) const fn integrity_failure(self) -> bool {
 		matches!(self, Self::Integrity | Self::Content)
 	}
@@ -740,11 +744,12 @@ impl Clone for H2BatchAsset {
 /// Returned items have exhausted every batch pass, so downstream can treat
 /// them as persistently failing against the chosen route.
 pub(crate) async fn download_asset_batch_via_h2<F>(
-	route: &DownloadRoute,
-	items: Vec<H2BatchAsset>,
-	concurrency: usize,
-	apply_native_policy: bool,
-	on_completed: F,
+    route: &DownloadRoute,
+    items: Vec<H2BatchAsset>,
+    concurrency: usize,
+    apply_native_policy: bool,
+	native_semaphore: Option<&fetch::FetchSemaphore>,
+    on_completed: F,
 ) -> Vec<H2BatchAsset>
 where
     F: FnMut(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>>
@@ -756,6 +761,22 @@ where
 	{
 		return items;
 	}
+	let _global_permit = if let Some(semaphore) = native_semaphore {
+		match semaphore.0.acquire().await {
+			Ok(permit) => Some(permit),
+			Err(_) => return items,
+		}
+	} else {
+		None
+	};
+	let _authority_permit = if apply_native_policy {
+		match super::native_budget::acquire(route).await {
+			Ok(permit) => permit,
+			Err(_) => return items,
+		}
+	} else {
+		None
+	};
 	let connection = match connect_authority(&route.url).await {
 		Ok(connection) => connection,
 		Err(failure) => {
@@ -765,9 +786,15 @@ where
 			{
 				fetch::record_authority_h2_failure(&authority);
 			}
+			if apply_native_policy && failure.is_transfer_failure() {
+				super::native_breaker::record_failure(route);
+			}
 			return items;
 		}
 	};
+	if apply_native_policy {
+		super::native_breaker::record_success(route);
+	}
     let route_authority = fetch::url_authority(&route.url);
 
     // Items whose URL targets a different authority cannot be multiplexed on

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -5,9 +5,7 @@
 //! switch to independent HTTP/1.1 range connections when that is faster;
 //! Minecraft assets use the dedicated batch multiplexer below.
 
-use super::h2_pool::{
-	H2ConnectFailureKind, SharedH2Connection,
-};
+use super::h2_pool::{H2ConnectFailureKind, SharedH2Connection};
 use crate::util::fetch;
 use crate::util::fetch::{
     DownloadRequest, DownloadResult, DownloadRoute, DownloadRouteSource,
@@ -40,51 +38,51 @@ pub(crate) enum H2DownloadOutcome {
     Completed(DownloadResult),
     /// The multiplexed path cannot be used; the caller should fall back to
     /// the legacy path.
-	Fallback {
-		failure: H2DownloadFailure,
-		preserve_partial: bool,
-	},
+    Fallback {
+        failure: H2DownloadFailure,
+        preserve_partial: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum H2DownloadFailure {
-	Ineligible(&'static str),
-	Connect,
-	Tls,
-	Protocol,
-	Http,
-	Integrity,
-	Content,
-	Io,
-	Slow,
+    Ineligible(&'static str),
+    Connect,
+    Tls,
+    Protocol,
+    Http,
+    Integrity,
+    Content,
+    Io,
+    Slow,
 }
 
 impl H2DownloadFailure {
-	pub(crate) const fn as_str(self) -> &'static str {
-		match self {
-			Self::Ineligible(reason) => reason,
-			Self::Connect => "HTTP/2 TCP connection failed",
-			Self::Tls => "HTTP/2 TLS connection failed",
-			Self::Protocol => "HTTP/2 protocol failed",
-			Self::Http => "HTTP/2 response was unsuccessful",
-			Self::Integrity => "HTTP/2 integrity validation failed",
-			Self::Content => "HTTP/2 content validation failed",
-			Self::Io => "HTTP/2 local I/O failed",
-			Self::Slow => "HTTP/2 single stream stayed below expectation",
-		}
-	}
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ineligible(reason) => reason,
+            Self::Connect => "HTTP/2 TCP connection failed",
+            Self::Tls => "HTTP/2 TLS connection failed",
+            Self::Protocol => "HTTP/2 protocol failed",
+            Self::Http => "HTTP/2 response was unsuccessful",
+            Self::Integrity => "HTTP/2 integrity validation failed",
+            Self::Content => "HTTP/2 content validation failed",
+            Self::Io => "HTTP/2 local I/O failed",
+            Self::Slow => "HTTP/2 single stream stayed below expectation",
+        }
+    }
 
-	pub(crate) const fn should_cooldown_authority(self) -> bool {
-		matches!(self, Self::Protocol)
-	}
+    pub(crate) const fn should_cooldown_authority(self) -> bool {
+        matches!(self, Self::Protocol)
+    }
 
-	pub(crate) const fn is_transfer_failure(self) -> bool {
-		matches!(self, Self::Connect | Self::Tls | Self::Protocol)
-	}
+    pub(crate) const fn is_transfer_failure(self) -> bool {
+        matches!(self, Self::Connect | Self::Tls | Self::Protocol)
+    }
 
-	pub(crate) const fn integrity_failure(self) -> bool {
-		matches!(self, Self::Integrity | Self::Content)
-	}
+    pub(crate) const fn integrity_failure(self) -> bool {
+        matches!(self, Self::Integrity | Self::Content)
+    }
 }
 
 /// Attempts to download `request` as one stream on a shared HTTP/2 connection.
@@ -93,28 +91,28 @@ pub(crate) async fn try_download_via_h2(
     route: &DownloadRoute,
     destination: &Path,
     part_path: &Path,
-	policy: super::native::NativeH2Policy,
+    policy: super::native::NativeH2Policy,
 ) -> H2DownloadOutcome {
-	if let Some(reason) = super::native::h2_ineligible_reason(route) {
-		return H2DownloadOutcome::Fallback {
-			failure: H2DownloadFailure::Ineligible(reason.as_str()),
-			preserve_partial: false,
-		};
-	}
-	let connection = match connect_authority(&route.url).await {
-		Ok(connection) => connection,
-		Err(failure) => {
-			return H2DownloadOutcome::Fallback {
-				failure,
-				preserve_partial: false,
-			};
-		}
-	};
-	let Ok(uri) = route.url.parse::<Uri>() else {
-		return H2DownloadOutcome::Fallback {
-			failure: H2DownloadFailure::Http,
-			preserve_partial: false,
-		};
+    if let Some(reason) = super::native::h2_ineligible_reason(route) {
+        return H2DownloadOutcome::Fallback {
+            failure: H2DownloadFailure::Ineligible(reason.as_str()),
+            preserve_partial: false,
+        };
+    }
+    let connection = match connect_authority(&route.url).await {
+        Ok(connection) => connection,
+        Err(failure) => {
+            return H2DownloadOutcome::Fallback {
+                failure,
+                preserve_partial: false,
+            };
+        }
+    };
+    let Ok(uri) = route.url.parse::<Uri>() else {
+        return H2DownloadOutcome::Fallback {
+            failure: H2DownloadFailure::Http,
+            preserve_partial: false,
+        };
     };
 
     let integrity = request.integrity.clone();
@@ -143,10 +141,10 @@ pub(crate) async fn try_download_via_h2(
                         error = %error,
                         "HTTP/2 probe failed; falling back to legacy download"
                     );
-					return H2DownloadOutcome::Fallback {
-						failure: classify_download_error(&error),
-						preserve_partial: false,
-					};
+                    return H2DownloadOutcome::Fallback {
+                        failure: classify_download_error(&error),
+                        preserve_partial: false,
+                    };
                 }
             };
 
@@ -159,114 +157,113 @@ pub(crate) async fn try_download_via_h2(
         drop(probe_body);
 
         let Some(total_size) = total_size else {
-			return H2DownloadOutcome::Fallback {
-				failure: H2DownloadFailure::Http,
-				preserve_partial: false,
-			};
+            return H2DownloadOutcome::Fallback {
+                failure: H2DownloadFailure::Http,
+                preserve_partial: false,
+            };
         };
         if total_size == 0 {
-			return H2DownloadOutcome::Fallback {
-				failure: H2DownloadFailure::Content,
-				preserve_partial: false,
-			};
+            return H2DownloadOutcome::Fallback {
+                failure: H2DownloadFailure::Content,
+                preserve_partial: false,
+            };
         }
         if status != StatusCode::PARTIAL_CONTENT {
-			return H2DownloadOutcome::Fallback {
-				failure: H2DownloadFailure::Http,
-				preserve_partial: false,
-			};
+            return H2DownloadOutcome::Fallback {
+                failure: H2DownloadFailure::Http,
+                preserve_partial: false,
+            };
         }
         total_size
     };
 
-	let result = single_stream(
-			&connection,
-            &uri,
-            request,
-            route,
-            destination,
-            part_path,
-			&integrity,
-			total_size,
-			policy,
-		)
-		.await;
+    let result = single_stream(
+        &connection,
+        &uri,
+        request,
+        route,
+        destination,
+        part_path,
+        &integrity,
+        total_size,
+        policy,
+    )
+    .await;
     match result {
         Ok(result) => H2DownloadOutcome::Completed(result),
-		Err(error) => {
-			let failure = classify_download_error(&error);
+        Err(error) => {
+            let failure = classify_download_error(&error);
             tracing::debug!(
                 url = %fetch::sanitize_url_for_log(&request.url),
                 error = %error,
                 "Multiplexed download failed; falling back to legacy download"
             );
-			H2DownloadOutcome::Fallback {
-				failure,
-				preserve_partial: integrity.supports_resume()
-					&& matches!(failure, H2DownloadFailure::Protocol),
-			}
+            H2DownloadOutcome::Fallback {
+                failure,
+                preserve_partial: integrity.supports_resume()
+                    && matches!(failure, H2DownloadFailure::Protocol),
+            }
         }
     }
 }
 
 async fn connect_authority(
-	url: &str,
+    url: &str,
 ) -> Result<Arc<SharedH2Connection>, H2DownloadFailure> {
-	let authority =
-		fetch::url_authority(url).ok_or(H2DownloadFailure::Http)?;
-	match super::h2_pool::shared_connection(&authority).await {
-		Ok(connection) => Ok(connection),
-		Err(error) => {
+    let authority = fetch::url_authority(url).ok_or(H2DownloadFailure::Http)?;
+    match super::h2_pool::shared_connection(&authority).await {
+        Ok(connection) => Ok(connection),
+        Err(error) => {
             tracing::debug!(
                 authority,
                 error = %error,
                 "Failed to establish shared HTTP/2 connection"
             );
-			Err(match error.kind {
-				H2ConnectFailureKind::Tcp => H2DownloadFailure::Connect,
-				H2ConnectFailureKind::Tls => H2DownloadFailure::Tls,
-				H2ConnectFailureKind::Protocol => H2DownloadFailure::Protocol,
-			})
-		}
-	}
+            Err(match error.kind {
+                H2ConnectFailureKind::Tcp => H2DownloadFailure::Connect,
+                H2ConnectFailureKind::Tls => H2DownloadFailure::Tls,
+                H2ConnectFailureKind::Protocol => H2DownloadFailure::Protocol,
+            })
+        }
+    }
 }
 
 fn classify_download_error(error: &crate::Error) -> H2DownloadFailure {
-	if fetch::is_integrity_error(error) {
-		return H2DownloadFailure::Integrity;
-	}
-	match error.raw.as_ref() {
-		crate::ErrorKind::HttpError { .. }
-		| crate::ErrorKind::LabrinthError(_) => H2DownloadFailure::Http,
-		crate::ErrorKind::IOError(_)
-		| crate::ErrorKind::StdIOError(_) => H2DownloadFailure::Io,
-		crate::ErrorKind::JSONError(_) => H2DownloadFailure::Content,
-		crate::ErrorKind::NetworkError(message)
-			if message.contains("below expectation") =>
-		{
-			H2DownloadFailure::Slow
-		}
-		crate::ErrorKind::NetworkError(message)
-			if message.contains("HTTP/2")
-				|| message.contains("range stream") =>
-		{
-			H2DownloadFailure::Protocol
-		}
-		crate::ErrorKind::OtherError(message)
-			if message.contains("HTTP/2")
-				|| message.contains("Content-Range")
-				|| message.contains("segment") =>
-		{
-			H2DownloadFailure::Protocol
-		}
-		crate::ErrorKind::OtherError(message)
-			if message.contains("empty")
-				|| message.contains("Invalid JAR") =>
-		{
-			H2DownloadFailure::Content
-		}
-		_ => H2DownloadFailure::Http,
-	}
+    if fetch::is_integrity_error(error) {
+        return H2DownloadFailure::Integrity;
+    }
+    match error.raw.as_ref() {
+        crate::ErrorKind::HttpError { .. }
+        | crate::ErrorKind::LabrinthError(_) => H2DownloadFailure::Http,
+        crate::ErrorKind::IOError(_) | crate::ErrorKind::StdIOError(_) => {
+            H2DownloadFailure::Io
+        }
+        crate::ErrorKind::JSONError(_) => H2DownloadFailure::Content,
+        crate::ErrorKind::NetworkError(message)
+            if message.contains("below expectation") =>
+        {
+            H2DownloadFailure::Slow
+        }
+        crate::ErrorKind::NetworkError(message)
+            if message.contains("HTTP/2")
+                || message.contains("range stream") =>
+        {
+            H2DownloadFailure::Protocol
+        }
+        crate::ErrorKind::OtherError(message)
+            if message.contains("HTTP/2")
+                || message.contains("Content-Range")
+                || message.contains("segment") =>
+        {
+            H2DownloadFailure::Protocol
+        }
+        crate::ErrorKind::OtherError(message)
+            if message.contains("empty") || message.contains("Invalid JAR") =>
+        {
+            H2DownloadFailure::Content
+        }
+        _ => H2DownloadFailure::Http,
+    }
 }
 
 fn request_headers(
@@ -361,28 +358,26 @@ async fn single_stream(
     part_path: &Path,
     integrity: &Integrity,
     total_size: u64,
-	policy: super::native::NativeH2Policy,
+    policy: super::native::NativeH2Policy,
 ) -> crate::Result<DownloadResult> {
     let mut headers = request_headers(request, route);
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
 
     let (response, mut stream) = open_stream(connection, uri, headers).await?;
-	if !response.status().is_success() {
-		return Err(crate::ErrorKind::HttpError {
-			status: response.status().as_u16(),
-			method: "GET".to_string(),
-			url: fetch::sanitize_url_for_log(uri.to_string().as_str()),
-		}
-		.into());
-	}
+    if !response.status().is_success() {
+        return Err(crate::ErrorKind::HttpError {
+            status: response.status().as_u16(),
+            method: "GET".to_string(),
+            url: fetch::sanitize_url_for_log(uri.to_string().as_str()),
+        }
+        .into());
+    }
 
     let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(integrity);
     let mut file = tokio::fs::File::create(part_path).await?;
     let mut downloaded = 0_u64;
-	let mut slow_policy = super::native_slow::NativeSlowPolicy::new(
-		0,
-		policy.expected_speed,
-	);
+    let mut slow_policy =
+        super::native_slow::NativeSlowPolicy::new(0, policy.expected_speed);
     loop {
         let chunk = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.data())
             .await
@@ -404,20 +399,19 @@ async fn single_stream(
         hashers.update(&chunk);
         downloaded += chunk.len() as u64;
         record_install_progress(request, downloaded, total_size).await;
-		if policy.abort_if_slow
-			&& matches!(
+        if policy.abort_if_slow
+            && matches!(
 				slow_policy.observe(
 					downloaded,
 					total_size.saturating_sub(downloaded),
 				),
 				super::native_slow::SlowDecision::Probe { .. }
-			)
-		{
-			return Err(crate::ErrorKind::NetworkError(
-				"HTTP/2 single stream stayed below expectation".to_string(),
-			)
-			.into());
-		}
+			) {
+            return Err(crate::ErrorKind::NetworkError(
+                "HTTP/2 single stream stayed below expectation".to_string(),
+            )
+            .into());
+        }
     }
     file.flush().await?;
     drop(file);
@@ -539,7 +533,7 @@ pub(crate) async fn download_asset_batch_via_h2<F>(
     items: Vec<H2BatchAsset>,
     concurrency: usize,
     apply_native_policy: bool,
-	native_semaphore: Option<&fetch::FetchSemaphore>,
+    native_semaphore: Option<&fetch::FetchSemaphore>,
     on_completed: F,
 ) -> Vec<H2BatchAsset>
 where
@@ -547,45 +541,45 @@ where
         + Send
         + 'static,
 {
-	if apply_native_policy
-		&& super::native::h2_ineligible_reason(route).is_some()
-	{
-		return items;
-	}
-	let _authority_permit = if apply_native_policy {
-		match super::native_budget::acquire(route).await {
-			Ok(permit) => Some(permit),
-			Err(_) => return items,
-		}
-	} else {
-		None
-	};
-	let _global_permit = if let Some(semaphore) = native_semaphore {
-		match semaphore.0.acquire().await {
-			Ok(permit) => Some(permit),
-			Err(_) => return items,
-		}
-	} else {
-		None
-	};
-	let connection = match connect_authority(&route.url).await {
-		Ok(connection) => connection,
-		Err(failure) => {
-			if apply_native_policy
-				&& failure.should_cooldown_authority()
-				&& let Some(authority) = fetch::url_authority(&route.url)
-			{
-				fetch::record_authority_h2_failure(&authority);
-			}
-			if apply_native_policy && failure.is_transfer_failure() {
-				super::native_breaker::record_failure(route);
-			}
-			return items;
-		}
-	};
-	if apply_native_policy {
-		super::native_breaker::record_success(route);
-	}
+    if apply_native_policy
+        && super::native::h2_ineligible_reason(route).is_some()
+    {
+        return items;
+    }
+    let _authority_permit = if apply_native_policy {
+        match super::native_budget::acquire(route).await {
+            Ok(permit) => Some(permit),
+            Err(_) => return items,
+        }
+    } else {
+        None
+    };
+    let _global_permit = if let Some(semaphore) = native_semaphore {
+        match semaphore.0.acquire().await {
+            Ok(permit) => Some(permit),
+            Err(_) => return items,
+        }
+    } else {
+        None
+    };
+    let connection = match connect_authority(&route.url).await {
+        Ok(connection) => connection,
+        Err(failure) => {
+            if apply_native_policy
+                && failure.should_cooldown_authority()
+                && let Some(authority) = fetch::url_authority(&route.url)
+            {
+                fetch::record_authority_h2_failure(&authority);
+            }
+            if apply_native_policy && failure.is_transfer_failure() {
+                super::native_breaker::record_failure(route);
+            }
+            return items;
+        }
+    };
+    if apply_native_policy {
+        super::native_breaker::record_success(route);
+    }
     let route_authority = fetch::url_authority(&route.url);
 
     // Items whose URL targets a different authority cannot be multiplexed on

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -1,11 +1,9 @@
 //! HTTP/2 multiplexed file downloads over shared per-authority connections.
 //!
 //! Every download to the same authority reuses one long-lived HTTP/2
-//! connection: small files are single streams, files at or above
-//! [`SEGMENTED_DOWNLOAD_THRESHOLD`] split into concurrent range streams on
-//! that same connection. Any protocol or server failure falls back to the
-//! legacy HTTP/1.1 single-stream path, so downloads remain correct even when
-//! a server or network does not support HTTP/2 or range requests.
+//! connection. General file downloads use one stream so larger files can
+//! switch to independent HTTP/1.1 range connections when that is faster;
+//! Minecraft assets use the dedicated batch multiplexer below.
 
 use super::h2_pool::{
 	H2ConnectFailureKind, SharedH2Connection,
@@ -23,14 +21,9 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use url::Url;
 
-const SEGMENTED_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
-const MIN_SEGMENT_SIZE: u64 = 256 * 1024;
-const MAX_SEGMENT_CONCURRENCY: usize = 8;
-const INITIAL_SEGMENT_CONCURRENCY: usize = 4;
-const RANGE_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 const STREAM_RECV_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Client-side concurrency target for the batch asset downloader. All
@@ -63,6 +56,7 @@ pub(crate) enum H2DownloadFailure {
 	Integrity,
 	Content,
 	Io,
+	Slow,
 }
 
 impl H2DownloadFailure {
@@ -76,6 +70,7 @@ impl H2DownloadFailure {
 			Self::Integrity => "HTTP/2 integrity validation failed",
 			Self::Content => "HTTP/2 content validation failed",
 			Self::Io => "HTTP/2 local I/O failed",
+			Self::Slow => "HTTP/2 single stream stayed below expectation",
 		}
 	}
 
@@ -92,13 +87,13 @@ impl H2DownloadFailure {
 	}
 }
 
-/// Attempts to download `request` to `destination` over a shared HTTP/2
-/// connection, multiplexing range streams for large files.
+/// Attempts to download `request` as one stream on a shared HTTP/2 connection.
 pub(crate) async fn try_download_via_h2(
     request: &DownloadRequest,
     route: &DownloadRoute,
     destination: &Path,
     part_path: &Path,
+	policy: super::native::NativeH2Policy,
 ) -> H2DownloadOutcome {
 	if let Some(reason) = super::native::h2_ineligible_reason(route) {
 		return H2DownloadOutcome::Fallback {
@@ -184,32 +179,18 @@ pub(crate) async fn try_download_via_h2(
         total_size
     };
 
-    let segmented = total_size >= SEGMENTED_DOWNLOAD_THRESHOLD;
-    let result = if segmented {
-        multiplexed_ranges(
-            Arc::clone(&connection),
+	let result = single_stream(
+			&connection,
             &uri,
             request,
             route,
             destination,
             part_path,
-            &integrity,
-            total_size,
-        )
-        .await
-    } else {
-        single_stream(
-            &connection,
-            &uri,
-            request,
-            route,
-            destination,
-            part_path,
-            &integrity,
-            total_size,
-        )
-        .await
-    };
+			&integrity,
+			total_size,
+			policy,
+		)
+		.await;
     match result {
         Ok(result) => H2DownloadOutcome::Completed(result),
 		Err(error) => {
@@ -221,8 +202,7 @@ pub(crate) async fn try_download_via_h2(
             );
 			H2DownloadOutcome::Fallback {
 				failure,
-				preserve_partial: !segmented
-					&& integrity.supports_resume()
+				preserve_partial: integrity.supports_resume()
 					&& matches!(failure, H2DownloadFailure::Protocol),
 			}
         }
@@ -261,6 +241,11 @@ fn classify_download_error(error: &crate::Error) -> H2DownloadFailure {
 		crate::ErrorKind::IOError(_)
 		| crate::ErrorKind::StdIOError(_) => H2DownloadFailure::Io,
 		crate::ErrorKind::JSONError(_) => H2DownloadFailure::Content,
+		crate::ErrorKind::NetworkError(message)
+			if message.contains("below expectation") =>
+		{
+			H2DownloadFailure::Slow
+		}
 		crate::ErrorKind::NetworkError(message)
 			if message.contains("HTTP/2")
 				|| message.contains("range stream") =>
@@ -337,33 +322,6 @@ fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
     total.parse().ok()
 }
 
-fn content_range_matches(
-    headers: &HeaderMap,
-    expected_start: u64,
-    expected_end: u64,
-    expected_total: u64,
-) -> bool {
-    let Some(value) = headers
-        .get(http::header::CONTENT_RANGE)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return false;
-    };
-    let Some((unit, value)) = value.split_once(' ') else {
-        return false;
-    };
-    let Some((range, total)) = value.split_once('/') else {
-        return false;
-    };
-    let Some((start, end)) = range.split_once('-') else {
-        return false;
-    };
-    unit.eq_ignore_ascii_case("bytes")
-        && start.parse::<u64>().ok() == Some(expected_start)
-        && end.parse::<u64>().ok() == Some(expected_end)
-        && total.parse::<u64>().ok() == Some(expected_total)
-}
-
 type StreamPair = (http::Response<()>, h2::RecvStream);
 
 async fn open_stream(
@@ -403,6 +361,7 @@ async fn single_stream(
     part_path: &Path,
     integrity: &Integrity,
     total_size: u64,
+	policy: super::native::NativeH2Policy,
 ) -> crate::Result<DownloadResult> {
     let mut headers = request_headers(request, route);
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
@@ -420,6 +379,10 @@ async fn single_stream(
     let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(integrity);
     let mut file = tokio::fs::File::create(part_path).await?;
     let mut downloaded = 0_u64;
+	let mut slow_policy = super::native_slow::NativeSlowPolicy::new(
+		0,
+		policy.expected_speed,
+	);
     loop {
         let chunk = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.data())
             .await
@@ -441,216 +404,44 @@ async fn single_stream(
         hashers.update(&chunk);
         downloaded += chunk.len() as u64;
         record_install_progress(request, downloaded, total_size).await;
-    }
-    file.flush().await?;
-    drop(file);
-    let computed = hashers.finish(downloaded);
-    record_install_stage(request).await;
-
-    verify_and_finalize(
-        part_path,
-        destination,
-        integrity,
-        computed,
-        downloaded,
-        total_size,
-    )
-    .await?;
-
-    Ok(DownloadResult {
-        path: destination.to_path_buf(),
-        url: uri.to_string(),
-        source: route.source,
-        size: downloaded,
-        attempts: 0,
-        fallback_count: 0,
-    })
-}
-
-/// Downloads a file by multiplexing concurrent range streams over the shared
-/// connection, writing each segment to a sibling file, then merging.
-async fn multiplexed_ranges(
-    connection: Arc<SharedH2Connection>,
-    uri: &Uri,
-    request: &DownloadRequest,
-    route: &DownloadRoute,
-    destination: &Path,
-    part_path: &Path,
-    integrity: &Integrity,
-    total_size: u64,
-) -> crate::Result<DownloadResult> {
-    let range_count = initial_segment_count(total_size);
-    let mut segments = Vec::with_capacity(range_count);
-    for index in 0..range_count {
-        let start = (total_size * index as u64) / range_count as u64;
-        let end = if index + 1 == range_count {
-            total_size.saturating_sub(1)
-        } else {
-            (total_size * (index + 1) as u64) / range_count as u64 - 1
-        };
-        if start > end {
-            continue;
-        }
-        segments.push((start, end));
-    }
-
-    let segment_count = segments.len();
-    let mut handles = Vec::new();
-    for (index, (start, end)) in segments.into_iter().enumerate() {
-        let connection = connection.clone();
-        let uri = uri.clone();
-        let headers = request_headers(request, route);
-        let segment_path = segment_path(part_path, index);
-        handles.push(tokio::spawn(async move {
-            let result = download_segment(
-                &connection,
-                &uri,
-                headers,
-                start,
-                end,
-                total_size,
-                &segment_path,
-            )
-            .await;
-            if result.is_err() {
-                let _ = tokio::fs::remove_file(&segment_path).await;
-            }
-            result
-        }));
-    }
-
-    let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(integrity);
-    let mut downloaded = 0_u64;
-    for (index, handle) in handles.into_iter().enumerate() {
-		let _segment_size = handle.await.map_err(|error| {
-			crate::ErrorKind::OtherError(format!(
-				"segment {index} task failed: {error}"
-			))
-		})??;
-    }
-
-    let mut file = tokio::fs::File::create(part_path).await?;
-    let mut buffer = vec![0_u8; 256 * 1024];
-    for index in 0..segment_count {
-        let path = segment_path(part_path, index);
-        let mut segment = tokio::fs::File::open(&path).await?;
-        loop {
-            let read = segment.read(&mut buffer).await?;
-            if read == 0 {
-                break;
-            }
-            hashers.update(&buffer[..read]);
-            file.write_all(&buffer[..read]).await?;
-            downloaded += read as u64;
-            record_install_progress(request, downloaded, total_size).await;
-        }
-        tokio::fs::remove_file(path).await?;
-    }
-    file.flush().await?;
-    drop(file);
-    let computed = hashers.finish(downloaded);
-    record_install_stage(request).await;
-
-    verify_and_finalize(
-        part_path,
-        destination,
-        integrity,
-        computed,
-        downloaded,
-        total_size,
-    )
-    .await?;
-
-    Ok(DownloadResult {
-        path: destination.to_path_buf(),
-        url: uri.to_string(),
-        source: route.source,
-        size: downloaded,
-        attempts: 0,
-        fallback_count: 0,
-    })
-}
-
-fn initial_segment_count(size: u64) -> usize {
-    let size_limited =
-        usize::try_from(size / MIN_SEGMENT_SIZE).unwrap_or(usize::MAX);
-    INITIAL_SEGMENT_CONCURRENCY
-        .min(MAX_SEGMENT_CONCURRENCY)
-        .min(size_limited.max(1))
-}
-
-async fn download_segment(
-    connection: &SharedH2Connection,
-    uri: &Uri,
-    mut headers: HeaderMap,
-    start: u64,
-    end: u64,
-    total_size: u64,
-    segment_path: &Path,
-) -> crate::Result<u64> {
-    headers.insert(
-        RANGE,
-        HeaderValue::from_str(&format!("bytes={start}-{end}")).unwrap(),
-    );
-    headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
-
-    let (response, mut stream) = open_stream(connection, uri, headers).await?;
-	if response.status() != StatusCode::PARTIAL_CONTENT {
-		return Err(crate::ErrorKind::HttpError {
-			status: response.status().as_u16(),
-			method: "GET".to_string(),
-			url: fetch::sanitize_url_for_log(uri.to_string().as_str()),
+		if policy.abort_if_slow
+			&& matches!(
+				slow_policy.observe(
+					downloaded,
+					total_size.saturating_sub(downloaded),
+				),
+				super::native_slow::SlowDecision::Probe { .. }
+			)
+		{
+			return Err(crate::ErrorKind::NetworkError(
+				"HTTP/2 single stream stayed below expectation".to_string(),
+			)
+			.into());
 		}
-		.into());
-	}
-    if !content_range_matches(response.headers(), start, end, total_size) {
-        return Err(crate::ErrorKind::OtherError(
-            "HTTP/2 range response had an invalid Content-Range".to_string(),
-        )
-        .into());
-    }
-
-    let mut file = tokio::fs::File::create(segment_path).await?;
-    let mut downloaded = 0_u64;
-    loop {
-        let chunk = tokio::time::timeout(RANGE_IDLE_TIMEOUT, stream.data())
-            .await
-            .map_err(|_| {
-                crate::ErrorKind::NetworkError(
-                    "range stream receive timed out".into(),
-                )
-            })?
-            .transpose()
-            .map_err(|error| {
-                crate::ErrorKind::NetworkError(format!(
-                    "range stream error: {error}"
-                ))
-            })?;
-        let Some(chunk) = chunk else {
-            break;
-        };
-        file.write_all(&chunk).await?;
-        downloaded += chunk.len() as u64;
     }
     file.flush().await?;
     drop(file);
-    let expected = end.saturating_sub(start).saturating_add(1);
-    if downloaded != expected {
-        return Err(crate::ErrorKind::OtherError(format!(
-            "HTTP/2 range response size mismatch: got {downloaded}, expected {expected}"
-        ))
-        .into());
-    }
-    Ok(downloaded)
-}
+    let computed = hashers.finish(downloaded);
+    record_install_stage(request).await;
 
-fn segment_path(part_path: &Path, index: usize) -> std::path::PathBuf {
-    let mut name = part_path
-        .file_name()
-        .map(|name| name.to_os_string())
-        .unwrap_or_default();
-    name.push(format!(".segment-{index}"));
-    part_path.with_file_name(name)
+    verify_and_finalize(
+        part_path,
+        destination,
+        integrity,
+        computed,
+        downloaded,
+        total_size,
+    )
+    .await?;
+
+    Ok(DownloadResult {
+        path: destination.to_path_buf(),
+        url: uri.to_string(),
+        source: route.source,
+        size: downloaded,
+        attempts: 0,
+        fallback_count: 0,
+    })
 }
 
 async fn record_install_stage(request: &DownloadRequest) {
@@ -761,17 +552,17 @@ where
 	{
 		return items;
 	}
-	let _global_permit = if let Some(semaphore) = native_semaphore {
-		match semaphore.0.acquire().await {
+	let _authority_permit = if apply_native_policy {
+		match super::native_budget::acquire(route).await {
 			Ok(permit) => Some(permit),
 			Err(_) => return items,
 		}
 	} else {
 		None
 	};
-	let _authority_permit = if apply_native_policy {
-		match super::native_budget::acquire(route).await {
-			Ok(permit) => permit,
+	let _global_permit = if let Some(semaphore) = native_semaphore {
+		match semaphore.0.acquire().await {
+			Ok(permit) => Some(permit),
 			Err(_) => return items,
 		}
 	} else {

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -7,7 +7,9 @@
 //! legacy HTTP/1.1 single-stream path, so downloads remain correct even when
 //! a server or network does not support HTTP/2 or range requests.
 
-use super::h2_pool::SharedH2Connection;
+use super::h2_pool::{
+	H2ConnectFailureKind, SharedH2Connection,
+};
 use crate::util::fetch;
 use crate::util::fetch::{
     DownloadRequest, DownloadResult, DownloadRoute, DownloadRouteSource,
@@ -45,10 +47,45 @@ pub(crate) enum H2DownloadOutcome {
     Completed(DownloadResult),
     /// The multiplexed path cannot be used; the caller should fall back to
     /// the legacy path.
-    Fallback {
-        reason: &'static str,
-        integrity_failure: bool,
-    },
+	Fallback {
+		failure: H2DownloadFailure,
+		preserve_partial: bool,
+	},
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum H2DownloadFailure {
+	Ineligible(&'static str),
+	Connect,
+	Tls,
+	Protocol,
+	Http,
+	Integrity,
+	Content,
+	Io,
+}
+
+impl H2DownloadFailure {
+	pub(crate) const fn as_str(self) -> &'static str {
+		match self {
+			Self::Ineligible(reason) => reason,
+			Self::Connect => "HTTP/2 TCP connection failed",
+			Self::Tls => "HTTP/2 TLS connection failed",
+			Self::Protocol => "HTTP/2 protocol failed",
+			Self::Http => "HTTP/2 response was unsuccessful",
+			Self::Integrity => "HTTP/2 integrity validation failed",
+			Self::Content => "HTTP/2 content validation failed",
+			Self::Io => "HTTP/2 local I/O failed",
+		}
+	}
+
+	pub(crate) const fn should_cooldown_authority(self) -> bool {
+		matches!(self, Self::Protocol)
+	}
+
+	pub(crate) const fn integrity_failure(self) -> bool {
+		matches!(self, Self::Integrity | Self::Content)
+	}
 }
 
 /// Attempts to download `request` to `destination` over a shared HTTP/2
@@ -59,17 +96,26 @@ pub(crate) async fn try_download_via_h2(
     destination: &Path,
     part_path: &Path,
 ) -> H2DownloadOutcome {
-    let Some(connection) = connect_authority(&route.url).await else {
-        return H2DownloadOutcome::Fallback {
-            reason: "no shared HTTP/2 connection",
-            integrity_failure: false,
-        };
-    };
-    let Ok(uri) = route.url.parse::<Uri>() else {
-        return H2DownloadOutcome::Fallback {
-            reason: "unparsable URL",
-            integrity_failure: false,
-        };
+	if let Some(reason) = super::native::h2_ineligible_reason(route) {
+		return H2DownloadOutcome::Fallback {
+			failure: H2DownloadFailure::Ineligible(reason.as_str()),
+			preserve_partial: false,
+		};
+	}
+	let connection = match connect_authority(&route.url).await {
+		Ok(connection) => connection,
+		Err(failure) => {
+			return H2DownloadOutcome::Fallback {
+				failure,
+				preserve_partial: false,
+			};
+		}
+	};
+	let Ok(uri) = route.url.parse::<Uri>() else {
+		return H2DownloadOutcome::Fallback {
+			failure: H2DownloadFailure::Http,
+			preserve_partial: false,
+		};
     };
 
     let integrity = request.integrity.clone();
@@ -98,10 +144,10 @@ pub(crate) async fn try_download_via_h2(
                         error = %error,
                         "HTTP/2 probe failed; falling back to legacy download"
                     );
-                    return H2DownloadOutcome::Fallback {
-                        reason: "probe failed",
-                        integrity_failure: false,
-                    };
+					return H2DownloadOutcome::Fallback {
+						failure: classify_download_error(&error),
+						preserve_partial: false,
+					};
                 }
             };
 
@@ -114,22 +160,22 @@ pub(crate) async fn try_download_via_h2(
         drop(probe_body);
 
         let Some(total_size) = total_size else {
-            return H2DownloadOutcome::Fallback {
-                reason: "unknown content size",
-                integrity_failure: false,
-            };
+			return H2DownloadOutcome::Fallback {
+				failure: H2DownloadFailure::Http,
+				preserve_partial: false,
+			};
         };
         if total_size == 0 {
-            return H2DownloadOutcome::Fallback {
-                reason: "empty content",
-                integrity_failure: false,
-            };
+			return H2DownloadOutcome::Fallback {
+				failure: H2DownloadFailure::Content,
+				preserve_partial: false,
+			};
         }
         if status != StatusCode::PARTIAL_CONTENT {
-            return H2DownloadOutcome::Fallback {
-                reason: "range requests unsupported",
-                integrity_failure: false,
-            };
+			return H2DownloadOutcome::Fallback {
+				failure: H2DownloadFailure::Http,
+				preserve_partial: false,
+			};
         }
         total_size
     };
@@ -162,33 +208,76 @@ pub(crate) async fn try_download_via_h2(
     };
     match result {
         Ok(result) => H2DownloadOutcome::Completed(result),
-        Err(error) => {
+		Err(error) => {
+			let failure = classify_download_error(&error);
             tracing::debug!(
                 url = %fetch::sanitize_url_for_log(&request.url),
                 error = %error,
                 "Multiplexed download failed; falling back to legacy download"
             );
-            H2DownloadOutcome::Fallback {
-                reason: "multiplexed download failed",
-                integrity_failure: fetch::is_integrity_error(&error),
-            }
+			H2DownloadOutcome::Fallback {
+				failure,
+				preserve_partial: !segmented
+					&& integrity.supports_resume()
+					&& matches!(failure, H2DownloadFailure::Protocol),
+			}
         }
     }
 }
 
-async fn connect_authority(url: &str) -> Option<Arc<SharedH2Connection>> {
-    let authority = fetch::url_authority(url)?;
-    match super::h2_pool::shared_connection(&authority).await {
-        Ok(connection) => Some(connection),
-        Err(error) => {
+async fn connect_authority(
+	url: &str,
+) -> Result<Arc<SharedH2Connection>, H2DownloadFailure> {
+	let authority =
+		fetch::url_authority(url).ok_or(H2DownloadFailure::Http)?;
+	match super::h2_pool::shared_connection(&authority).await {
+		Ok(connection) => Ok(connection),
+		Err(error) => {
             tracing::debug!(
                 authority,
                 error = %error,
                 "Failed to establish shared HTTP/2 connection"
             );
-            None
-        }
-    }
+			Err(match error.kind {
+				H2ConnectFailureKind::Tcp => H2DownloadFailure::Connect,
+				H2ConnectFailureKind::Tls => H2DownloadFailure::Tls,
+				H2ConnectFailureKind::Protocol => H2DownloadFailure::Protocol,
+			})
+		}
+	}
+}
+
+fn classify_download_error(error: &crate::Error) -> H2DownloadFailure {
+	if fetch::is_integrity_error(error) {
+		return H2DownloadFailure::Integrity;
+	}
+	match error.raw.as_ref() {
+		crate::ErrorKind::HttpError { .. }
+		| crate::ErrorKind::LabrinthError(_) => H2DownloadFailure::Http,
+		crate::ErrorKind::IOError(_)
+		| crate::ErrorKind::StdIOError(_) => H2DownloadFailure::Io,
+		crate::ErrorKind::JSONError(_) => H2DownloadFailure::Content,
+		crate::ErrorKind::NetworkError(message)
+			if message.contains("HTTP/2")
+				|| message.contains("range stream") =>
+		{
+			H2DownloadFailure::Protocol
+		}
+		crate::ErrorKind::OtherError(message)
+			if message.contains("HTTP/2")
+				|| message.contains("Content-Range")
+				|| message.contains("segment") =>
+		{
+			H2DownloadFailure::Protocol
+		}
+		crate::ErrorKind::OtherError(message)
+			if message.contains("empty")
+				|| message.contains("Invalid JAR") =>
+		{
+			H2DownloadFailure::Content
+		}
+		_ => H2DownloadFailure::Http,
+	}
 }
 
 fn request_headers(
@@ -315,13 +404,14 @@ async fn single_stream(
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
 
     let (response, mut stream) = open_stream(connection, uri, headers).await?;
-    if !response.status().is_success() {
-        return Err(crate::ErrorKind::OtherError(format!(
-            "HTTP/2 GET failed with status {}",
-            response.status()
-        ))
-        .into());
-    }
+	if !response.status().is_success() {
+		return Err(crate::ErrorKind::HttpError {
+			status: response.status().as_u16(),
+			method: "GET".to_string(),
+			url: fetch::sanitize_url_for_log(uri.to_string().as_str()),
+		}
+		.into());
+	}
 
     let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(integrity);
     let mut file = tokio::fs::File::create(part_path).await?;
@@ -428,18 +518,11 @@ async fn multiplexed_ranges(
     let mut hashers = fetch::IntegrityHashers::new_integrity_hashers(integrity);
     let mut downloaded = 0_u64;
     for (index, handle) in handles.into_iter().enumerate() {
-        let _segment_size = handle
-            .await
-            .map_err(|error| {
-                crate::ErrorKind::OtherError(format!(
-                    "segment {index} task failed: {error}"
-                ))
-            })?
-            .map_err(|error| {
-                crate::ErrorKind::OtherError(format!(
-                    "segment {index} failed: {error}"
-                ))
-            })?;
+		let _segment_size = handle.await.map_err(|error| {
+			crate::ErrorKind::OtherError(format!(
+				"segment {index} task failed: {error}"
+			))
+		})??;
     }
 
     let mut file = tokio::fs::File::create(part_path).await?;
@@ -508,13 +591,14 @@ async fn download_segment(
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
 
     let (response, mut stream) = open_stream(connection, uri, headers).await?;
-    if response.status() != StatusCode::PARTIAL_CONTENT {
-        return Err(crate::ErrorKind::OtherError(format!(
-            "HTTP/2 range GET failed with status {}",
-            response.status()
-        ))
-        .into());
-    }
+	if response.status() != StatusCode::PARTIAL_CONTENT {
+		return Err(crate::ErrorKind::HttpError {
+			status: response.status().as_u16(),
+			method: "GET".to_string(),
+			url: fetch::sanitize_url_for_log(uri.to_string().as_str()),
+		}
+		.into());
+	}
     if !content_range_matches(response.headers(), start, end, total_size) {
         return Err(crate::ErrorKind::OtherError(
             "HTTP/2 range response had an invalid Content-Range".to_string(),
@@ -656,19 +740,34 @@ impl Clone for H2BatchAsset {
 /// Returned items have exhausted every batch pass, so downstream can treat
 /// them as persistently failing against the chosen route.
 pub(crate) async fn download_asset_batch_via_h2<F>(
-    route: &DownloadRoute,
-    items: Vec<H2BatchAsset>,
-    concurrency: usize,
-    on_completed: F,
+	route: &DownloadRoute,
+	items: Vec<H2BatchAsset>,
+	concurrency: usize,
+	apply_native_policy: bool,
+	on_completed: F,
 ) -> Vec<H2BatchAsset>
 where
     F: FnMut(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>>
         + Send
         + 'static,
 {
-    let Some(connection) = connect_authority(&route.url).await else {
-        return items;
-    };
+	if apply_native_policy
+		&& super::native::h2_ineligible_reason(route).is_some()
+	{
+		return items;
+	}
+	let connection = match connect_authority(&route.url).await {
+		Ok(connection) => connection,
+		Err(failure) => {
+			if apply_native_policy
+				&& failure.should_cooldown_authority()
+				&& let Some(authority) = fetch::url_authority(&route.url)
+			{
+				fetch::record_authority_h2_failure(&authority);
+			}
+			return items;
+		}
+	};
     let route_authority = fetch::url_authority(&route.url);
 
     // Items whose URL targets a different authority cannot be multiplexed on

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -290,3 +290,17 @@ pub(crate) async fn shared_connection(
     *cached = Some(Arc::clone(&connection));
     Ok(connection)
 }
+
+pub(crate) async fn has_live_connection(authority: &str) -> bool {
+	let connections = CONNECTIONS.lock().await;
+	let Some(slot) = connections.get(authority).cloned() else {
+		return false;
+	};
+	drop(connections);
+	let live = slot
+		.lock()
+		.await
+		.as_ref()
+		.is_some_and(|connection| !connection.is_dead());
+	live
+}

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -25,29 +25,29 @@ const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum H2ConnectFailureKind {
-	Tcp,
-	Tls,
-	Protocol,
+    Tcp,
+    Tls,
+    Protocol,
 }
 
 #[derive(Debug)]
 pub(crate) struct H2ConnectError {
-	pub(crate) kind: H2ConnectFailureKind,
-	detail: String,
+    pub(crate) kind: H2ConnectFailureKind,
+    detail: String,
 }
 
 impl std::fmt::Display for H2ConnectError {
-	fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		formatter.write_str(&self.detail)
-	}
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.detail)
+    }
 }
 
 impl std::error::Error for H2ConnectError {}
 
 impl H2ConnectError {
-	fn new(kind: H2ConnectFailureKind, detail: String) -> Self {
-		Self { kind, detail }
-	}
+    fn new(kind: H2ConnectFailureKind, detail: String) -> Self {
+        Self { kind, detail }
+    }
 }
 
 /// A live shared HTTP/2 connection to one authority.
@@ -194,7 +194,7 @@ async fn connect_tcp(host: &str, port: u16) -> std::io::Result<TcpStream> {
 
 /// Connects a new shared HTTP/2 connection to `authority` (host[:port]).
 async fn establish(
-	authority: &str,
+    authority: &str,
 ) -> Result<Arc<SharedH2Connection>, H2ConnectError> {
     let (host, port) = authority
         .rsplit_once(':')
@@ -207,7 +207,7 @@ async fn establish(
         .pre_resolve(host)
         .await;
 
-	let tcp = connect_tcp(host, port).await.map_err(|error| {
+    let tcp = connect_tcp(host, port).await.map_err(|error| {
 		H2ConnectError::new(
 			H2ConnectFailureKind::Tcp,
 			format!(
@@ -217,39 +217,39 @@ async fn establish(
 	})?;
 
     let server_name =
-		ServerName::try_from(host.to_string()).map_err(|error| {
-			H2ConnectError::new(
-				H2ConnectFailureKind::Tls,
-				format!("invalid server name for {host}: {error}"),
-			)
-		})?;
+        ServerName::try_from(host.to_string()).map_err(|error| {
+            H2ConnectError::new(
+                H2ConnectFailureKind::Tls,
+                format!("invalid server name for {host}: {error}"),
+            )
+        })?;
     let connector = TlsConnector::from(tls_config());
     let tls = tokio::time::timeout(
         TLS_HANDSHAKE_TIMEOUT,
         connector.connect(server_name, tcp),
     )
     .await
-	.map_err(|_| {
-		H2ConnectError::new(
-			H2ConnectFailureKind::Tls,
-			format!("TLS handshake with {authority} timed out"),
-		)
-	})?
-	.map_err(|error| {
-		H2ConnectError::new(
-			H2ConnectFailureKind::Tls,
-			format!("TLS handshake with {authority} failed: {error}"),
-		)
-	})?;
+    .map_err(|_| {
+        H2ConnectError::new(
+            H2ConnectFailureKind::Tls,
+            format!("TLS handshake with {authority} timed out"),
+        )
+    })?
+    .map_err(|error| {
+        H2ConnectError::new(
+            H2ConnectFailureKind::Tls,
+            format!("TLS handshake with {authority} failed: {error}"),
+        )
+    })?;
 
-	let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
-		.await
-		.map_err(|error| {
-		H2ConnectError::new(
-			H2ConnectFailureKind::Protocol,
-			format!("HTTP/2 handshake with {authority} failed: {error}"),
-		)
-	})?;
+    let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
+        .await
+        .map_err(|error| {
+        H2ConnectError::new(
+            H2ConnectFailureKind::Protocol,
+            format!("HTTP/2 handshake with {authority} failed: {error}"),
+        )
+    })?;
 
     // Tune flow-control windows for high-stream multiplexing (e.g. hundreds
     // of concurrent asset downloads over one connection). With the default
@@ -277,7 +277,7 @@ async fn establish(
 /// Returns the live shared connection for `authority`, establishing one on
 /// first use or after a previous connection died.
 pub(crate) async fn shared_connection(
-	authority: &str,
+    authority: &str,
 ) -> Result<Arc<SharedH2Connection>, H2ConnectError> {
     let slot = connection_slot(authority).await;
     let mut cached = slot.lock().await;
@@ -292,15 +292,15 @@ pub(crate) async fn shared_connection(
 }
 
 pub(crate) async fn has_live_connection(authority: &str) -> bool {
-	let connections = CONNECTIONS.lock().await;
-	let Some(slot) = connections.get(authority).cloned() else {
-		return false;
-	};
-	drop(connections);
-	let live = slot
-		.lock()
-		.await
-		.as_ref()
-		.is_some_and(|connection| !connection.is_dead());
-	live
+    let connections = CONNECTIONS.lock().await;
+    let Some(slot) = connections.get(authority).cloned() else {
+        return false;
+    };
+    drop(connections);
+    let live = slot
+        .lock()
+        .await
+        .as_ref()
+        .is_some_and(|connection| !connection.is_dead());
+    live
 }

--- a/packages/app-lib/src/util/download/h2_pool.rs
+++ b/packages/app-lib/src/util/download/h2_pool.rs
@@ -23,6 +23,33 @@ use tokio_rustls::TlsConnector;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum H2ConnectFailureKind {
+	Tcp,
+	Tls,
+	Protocol,
+}
+
+#[derive(Debug)]
+pub(crate) struct H2ConnectError {
+	pub(crate) kind: H2ConnectFailureKind,
+	detail: String,
+}
+
+impl std::fmt::Display for H2ConnectError {
+	fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.detail)
+	}
+}
+
+impl std::error::Error for H2ConnectError {}
+
+impl H2ConnectError {
+	fn new(kind: H2ConnectFailureKind, detail: String) -> Self {
+		Self { kind, detail }
+	}
+}
+
 /// A live shared HTTP/2 connection to one authority.
 pub struct SharedH2Connection {
     sender: Mutex<SendRequest<Bytes>>,
@@ -166,7 +193,9 @@ async fn connect_tcp(host: &str, port: u16) -> std::io::Result<TcpStream> {
 }
 
 /// Connects a new shared HTTP/2 connection to `authority` (host[:port]).
-async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
+async fn establish(
+	authority: &str,
+) -> Result<Arc<SharedH2Connection>, H2ConnectError> {
     let (host, port) = authority
         .rsplit_once(':')
         .map(|(host, port)| (host, port.parse::<u16>().unwrap_or(443)))
@@ -178,42 +207,49 @@ async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
         .pre_resolve(host)
         .await;
 
-    let tcp = connect_tcp(host, port).await.map_err(|error| {
-        crate::ErrorKind::NetworkError(format!(
-            "failed to establish shared HTTP/2 connection to {authority}: {error}"
-        ))
-    })?;
+	let tcp = connect_tcp(host, port).await.map_err(|error| {
+		H2ConnectError::new(
+			H2ConnectFailureKind::Tcp,
+			format!(
+				"failed to establish shared HTTP/2 connection to {authority}: {error}"
+			),
+		)
+	})?;
 
     let server_name =
-        ServerName::try_from(host.to_string()).map_err(|error| {
-            crate::ErrorKind::InputError(format!(
-                "invalid server name for {host}: {error}"
-            ))
-        })?;
+		ServerName::try_from(host.to_string()).map_err(|error| {
+			H2ConnectError::new(
+				H2ConnectFailureKind::Tls,
+				format!("invalid server name for {host}: {error}"),
+			)
+		})?;
     let connector = TlsConnector::from(tls_config());
     let tls = tokio::time::timeout(
         TLS_HANDSHAKE_TIMEOUT,
         connector.connect(server_name, tcp),
     )
     .await
-    .map_err(|_| {
-        crate::ErrorKind::NetworkError(format!(
-            "TLS handshake with {authority} timed out"
-        ))
-    })?
-    .map_err(|error| {
-        crate::ErrorKind::NetworkError(format!(
-            "TLS handshake with {authority} failed: {error}"
-        ))
-    })?;
+	.map_err(|_| {
+		H2ConnectError::new(
+			H2ConnectFailureKind::Tls,
+			format!("TLS handshake with {authority} timed out"),
+		)
+	})?
+	.map_err(|error| {
+		H2ConnectError::new(
+			H2ConnectFailureKind::Tls,
+			format!("TLS handshake with {authority} failed: {error}"),
+		)
+	})?;
 
-    let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
-        .await
-        .map_err(|error| {
-        crate::ErrorKind::NetworkError(format!(
-            "HTTP/2 handshake with {authority} failed: {error}"
-        ))
-    })?;
+	let (sender, mut connection) = h2::client::handshake(Box::pin(tls))
+		.await
+		.map_err(|error| {
+		H2ConnectError::new(
+			H2ConnectFailureKind::Protocol,
+			format!("HTTP/2 handshake with {authority} failed: {error}"),
+		)
+	})?;
 
     // Tune flow-control windows for high-stream multiplexing (e.g. hundreds
     // of concurrent asset downloads over one connection). With the default
@@ -240,9 +276,9 @@ async fn establish(authority: &str) -> crate::Result<Arc<SharedH2Connection>> {
 
 /// Returns the live shared connection for `authority`, establishing one on
 /// first use or after a previous connection died.
-pub async fn shared_connection(
-    authority: &str,
-) -> crate::Result<Arc<SharedH2Connection>> {
+pub(crate) async fn shared_connection(
+	authority: &str,
+) -> Result<Arc<SharedH2Connection>, H2ConnectError> {
     let slot = connection_slot(authority).await;
     let mut cached = slot.lock().await;
     if let Some(connection) =

--- a/packages/app-lib/src/util/download/mod.rs
+++ b/packages/app-lib/src/util/download/mod.rs
@@ -13,6 +13,8 @@ pub mod h2_pool;
 pub mod legacy;
 pub mod log;
 pub(crate) mod native;
+pub(crate) mod native_breaker;
+pub(crate) mod native_budget;
 pub(crate) mod native_reputation;
 pub(crate) mod native_slow;
 pub mod shared;

--- a/packages/app-lib/src/util/download/mod.rs
+++ b/packages/app-lib/src/util/download/mod.rs
@@ -13,6 +13,8 @@ pub mod h2_pool;
 pub mod legacy;
 pub mod log;
 pub(crate) mod native;
+pub(crate) mod native_reputation;
+pub(crate) mod native_slow;
 pub mod shared;
 pub mod slow;
 pub mod xmcl;

--- a/packages/app-lib/src/util/download/mod.rs
+++ b/packages/app-lib/src/util/download/mod.rs
@@ -12,6 +12,7 @@ pub mod h2_download;
 pub mod h2_pool;
 pub mod legacy;
 pub mod log;
+pub(crate) mod native;
 pub mod shared;
 pub mod slow;
 pub mod xmcl;

--- a/packages/app-lib/src/util/download/native.rs
+++ b/packages/app-lib/src/util/download/native.rs
@@ -8,194 +8,183 @@ const LARGE_FILE_LIMIT: u64 = 64 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct NativeH2Policy {
-	pub(crate) abort_if_slow: bool,
-	pub(crate) expected_speed: Option<u64>,
+    pub(crate) abort_if_slow: bool,
+    pub(crate) expected_speed: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum NativeH2IneligibleReason {
-	Http1Fallback,
-	SystemProxy,
+    Http1Fallback,
+    SystemProxy,
 }
 
 impl NativeH2IneligibleReason {
-	pub(crate) const fn as_str(self) -> &'static str {
-		match self {
-			Self::Http1Fallback => "authority is temporarily using HTTP/1.1",
-			Self::SystemProxy => "system proxy requires the reqwest transport",
-		}
-	}
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Http1Fallback => "authority is temporarily using HTTP/1.1",
+            Self::SystemProxy => "system proxy requires the reqwest transport",
+        }
+    }
 }
 
 pub(crate) fn h2_ineligible_reason(
-	route: &DownloadRoute,
+    route: &DownloadRoute,
 ) -> Option<NativeH2IneligibleReason> {
-	let authority = crate::util::fetch::url_authority(&route.url)?;
-	if crate::util::fetch::authority_uses_http1_fallback(&authority) {
-		return Some(NativeH2IneligibleReason::Http1Fallback);
-	}
-	if route.proxy == ProxyPolicy::System && system_proxy_configured() {
-		return Some(NativeH2IneligibleReason::SystemProxy);
-	}
-	None
+    let authority = crate::util::fetch::url_authority(&route.url)?;
+    if crate::util::fetch::authority_uses_http1_fallback(&authority) {
+        return Some(NativeH2IneligibleReason::Http1Fallback);
+    }
+    if route.proxy == ProxyPolicy::System && system_proxy_configured() {
+        return Some(NativeH2IneligibleReason::SystemProxy);
+    }
+    None
 }
 
 pub(crate) async fn h2_policy(
-	route: &DownloadRoute,
-	size: Option<u64>,
+    route: &DownloadRoute,
+    size: Option<u64>,
 ) -> Option<NativeH2Policy> {
-	if h2_ineligible_reason(route).is_some() {
-		return None;
-	}
-	let Some(size) = size else {
-		return Some(NativeH2Policy {
-			abort_if_slow: false,
-			expected_speed: None,
-		});
-	};
-	let authority = crate::util::fetch::url_authority(&route.url)?;
-	let h2 = super::native_reputation::get_transport(
-		&authority,
-		route.proxy,
-		super::native_reputation::NativeTransport::H2Single,
-	);
-	let multi_range = super::native_reputation::get_transport(
-		&authority,
-		route.proxy,
-		super::native_reputation::NativeTransport::Http1MultiRange,
-	);
-	let expected_speed = h2.and_then(|health| health.throughput_bps).map(|speed| {
-		speed.min(u64::MAX as f64) as u64
-	});
-	if size < SMALL_FILE_LIMIT {
-		return Some(NativeH2Policy {
-			abort_if_slow: false,
-			expected_speed,
-		});
-	}
-	if size < MEDIUM_FILE_LIMIT {
-		return super::h2_pool::has_live_connection(&authority)
-			.await
-			.then_some(NativeH2Policy {
-				abort_if_slow: true,
-				expected_speed,
-			});
-	}
-	if !super::h2_pool::has_live_connection(&authority).await {
-		return None;
-	}
-	let h2 = h2.filter(|health| health.success_samples >= 2)?;
-	let h2_speed = h2.throughput_bps?;
-	let range_speed = multi_range.and_then(|health| health.throughput_bps);
-	if size < LARGE_FILE_LIMIT {
-		let h2_preferred = range_speed
-			.map(|range_speed| h2_speed >= range_speed * 1.1)
-			.unwrap_or(true);
-		return h2_preferred.then_some(NativeH2Policy {
-			abort_if_slow: true,
-			expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
-		});
-	}
-	let range = multi_range.filter(|health| health.success_samples >= 2)?;
-	let range_speed = range.throughput_bps?;
-	(h2.success_samples >= 3 && h2_speed >= range_speed * 1.25).then_some(
-		NativeH2Policy {
-			abort_if_slow: true,
-			expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
-		},
-	)
+    if h2_ineligible_reason(route).is_some() {
+        return None;
+    }
+    let Some(size) = size else {
+        return Some(NativeH2Policy {
+            abort_if_slow: false,
+            expected_speed: None,
+        });
+    };
+    let authority = crate::util::fetch::url_authority(&route.url)?;
+    let h2 = super::native_reputation::get_transport(
+        &authority,
+        route.proxy,
+        super::native_reputation::NativeTransport::H2Single,
+    );
+    let multi_range = super::native_reputation::get_transport(
+        &authority,
+        route.proxy,
+        super::native_reputation::NativeTransport::Http1MultiRange,
+    );
+    let expected_speed = h2
+        .and_then(|health| health.throughput_bps)
+        .map(|speed| speed.min(u64::MAX as f64) as u64);
+    if size < SMALL_FILE_LIMIT {
+        return Some(NativeH2Policy {
+            abort_if_slow: false,
+            expected_speed,
+        });
+    }
+    if size < MEDIUM_FILE_LIMIT {
+        return super::h2_pool::has_live_connection(&authority)
+            .await
+            .then_some(NativeH2Policy {
+                abort_if_slow: true,
+                expected_speed,
+            });
+    }
+    if !super::h2_pool::has_live_connection(&authority).await {
+        return None;
+    }
+    let h2 = h2.filter(|health| health.success_samples >= 2)?;
+    let h2_speed = h2.throughput_bps?;
+    let range_speed = multi_range.and_then(|health| health.throughput_bps);
+    if size < LARGE_FILE_LIMIT {
+        let h2_preferred = range_speed
+            .map(|range_speed| h2_speed >= range_speed * 1.1)
+            .unwrap_or(true);
+        return h2_preferred.then_some(NativeH2Policy {
+            abort_if_slow: true,
+            expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
+        });
+    }
+    let range = multi_range.filter(|health| health.success_samples >= 2)?;
+    let range_speed = range.throughput_bps?;
+    (h2.success_samples >= 3 && h2_speed >= range_speed * 1.25).then_some(
+        NativeH2Policy {
+            abort_if_slow: true,
+            expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
+        },
+    )
 }
 
 fn system_proxy_configured() -> bool {
-	let environment_proxy = [
-		"HTTPS_PROXY",
-		"https_proxy",
-		"HTTP_PROXY",
-		"http_proxy",
-		"ALL_PROXY",
-		"all_proxy",
-	]
-	.into_iter()
-	.any(|name| {
-		std::env::var_os(name).is_some_and(|value| !value.is_empty())
-	});
-	environment_proxy || platform_proxy_configured()
+    let environment_proxy = [
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ]
+    .into_iter()
+    .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()));
+    environment_proxy || platform_proxy_configured()
 }
 
 #[cfg(windows)]
 fn platform_proxy_configured() -> bool {
-	use winreg::RegKey;
-	use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
 
-	let Ok(settings) = RegKey::predef(HKEY_CURRENT_USER)
-		.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")
-	else {
-		return false;
-	};
-	let enabled = settings
-		.get_value::<u32, _>("ProxyEnable")
-		.is_ok_and(|value| value != 0);
-	let auto_configured = settings
-		.get_value::<String, _>("AutoConfigURL")
-		.is_ok_and(|value| !value.trim().is_empty());
-	enabled || auto_configured
+    let Ok(settings) = RegKey::predef(HKEY_CURRENT_USER).open_subkey(
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
+    ) else {
+        return false;
+    };
+    let enabled = settings
+        .get_value::<u32, _>("ProxyEnable")
+        .is_ok_and(|value| value != 0);
+    let auto_configured = settings
+        .get_value::<String, _>("AutoConfigURL")
+        .is_ok_and(|value| !value.trim().is_empty());
+    enabled || auto_configured
 }
 
 #[cfg(not(windows))]
 fn platform_proxy_configured() -> bool {
-	false
+    false
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::util::fetch::{
-		DownloadRouteSource, ProxyPolicy,
-	};
+    use super::*;
+    use crate::util::fetch::{DownloadRouteSource, ProxyPolicy};
 
-	fn route(proxy: ProxyPolicy) -> DownloadRoute {
-		DownloadRoute {
-			url: "https://native-policy.example/file".to_string(),
-			source: DownloadRouteSource::Official,
-			is_mirror: false,
-			allow_sensitive_headers: true,
-			supports_range: true,
-			proxy,
-		}
-	}
+    fn route(proxy: ProxyPolicy) -> DownloadRoute {
+        DownloadRoute {
+            url: "https://native-policy.example/file".to_string(),
+            source: DownloadRouteSource::Official,
+            is_mirror: false,
+            allow_sensitive_headers: true,
+            supports_range: true,
+            proxy,
+        }
+    }
 
-	#[test]
-	fn direct_routes_ignore_system_proxy_environment() {
-		assert_ne!(
-			h2_ineligible_reason(&route(ProxyPolicy::Direct)),
-			Some(NativeH2IneligibleReason::SystemProxy)
-		);
-	}
+    #[test]
+    fn direct_routes_ignore_system_proxy_environment() {
+        assert_ne!(
+            h2_ineligible_reason(&route(ProxyPolicy::Direct)),
+            Some(NativeH2IneligibleReason::SystemProxy)
+        );
+    }
 
-	#[tokio::test]
-	async fn medium_file_requires_a_live_h2_connection() {
-		assert!(
-			h2_policy(
-				&route(ProxyPolicy::Direct),
-				Some(8 * 1024 * 1024),
-			)
-			.await
-			.is_none()
-		);
-	}
+    #[tokio::test]
+    async fn medium_file_requires_a_live_h2_connection() {
+        assert!(
+            h2_policy(&route(ProxyPolicy::Direct), Some(8 * 1024 * 1024),)
+                .await
+                .is_none()
+        );
+    }
 
-	#[tokio::test]
-	async fn small_file_can_establish_h2_without_history() {
-		assert_eq!(
-			h2_policy(
-				&route(ProxyPolicy::Direct),
-				Some(1024 * 1024),
-			)
-			.await,
-			Some(NativeH2Policy {
-				abort_if_slow: false,
-				expected_speed: None,
-			})
-		);
-	}
+    #[tokio::test]
+    async fn small_file_can_establish_h2_without_history() {
+        assert_eq!(
+            h2_policy(&route(ProxyPolicy::Direct), Some(1024 * 1024),).await,
+            Some(NativeH2Policy {
+                abort_if_slow: false,
+                expected_speed: None,
+            })
+        );
+    }
 }

--- a/packages/app-lib/src/util/download/native.rs
+++ b/packages/app-lib/src/util/download/native.rs
@@ -1,0 +1,98 @@
+//! Policy boundary for the native download engine.
+
+use crate::util::fetch::{DownloadRoute, ProxyPolicy};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeH2IneligibleReason {
+	Http1Fallback,
+	SystemProxy,
+}
+
+impl NativeH2IneligibleReason {
+	pub(crate) const fn as_str(self) -> &'static str {
+		match self {
+			Self::Http1Fallback => "authority is temporarily using HTTP/1.1",
+			Self::SystemProxy => "system proxy requires the reqwest transport",
+		}
+	}
+}
+
+pub(crate) fn h2_ineligible_reason(
+	route: &DownloadRoute,
+) -> Option<NativeH2IneligibleReason> {
+	let authority = crate::util::fetch::url_authority(&route.url)?;
+	if crate::util::fetch::authority_uses_http1_fallback(&authority) {
+		return Some(NativeH2IneligibleReason::Http1Fallback);
+	}
+	if route.proxy == ProxyPolicy::System && system_proxy_configured() {
+		return Some(NativeH2IneligibleReason::SystemProxy);
+	}
+	None
+}
+
+fn system_proxy_configured() -> bool {
+	let environment_proxy = [
+		"HTTPS_PROXY",
+		"https_proxy",
+		"HTTP_PROXY",
+		"http_proxy",
+		"ALL_PROXY",
+		"all_proxy",
+	]
+	.into_iter()
+	.any(|name| {
+		std::env::var_os(name).is_some_and(|value| !value.is_empty())
+	});
+	environment_proxy || platform_proxy_configured()
+}
+
+#[cfg(windows)]
+fn platform_proxy_configured() -> bool {
+	use winreg::RegKey;
+	use winreg::enums::HKEY_CURRENT_USER;
+
+	let Ok(settings) = RegKey::predef(HKEY_CURRENT_USER)
+		.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")
+	else {
+		return false;
+	};
+	let enabled = settings
+		.get_value::<u32, _>("ProxyEnable")
+		.is_ok_and(|value| value != 0);
+	let auto_configured = settings
+		.get_value::<String, _>("AutoConfigURL")
+		.is_ok_and(|value| !value.trim().is_empty());
+	enabled || auto_configured
+}
+
+#[cfg(not(windows))]
+fn platform_proxy_configured() -> bool {
+	false
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::util::fetch::{
+		DownloadRouteSource, ProxyPolicy,
+	};
+
+	fn route(proxy: ProxyPolicy) -> DownloadRoute {
+		DownloadRoute {
+			url: "https://native-policy.example/file".to_string(),
+			source: DownloadRouteSource::Official,
+			is_mirror: false,
+			allow_sensitive_headers: true,
+			supports_range: true,
+			proxy,
+		}
+	}
+
+	#[test]
+	fn direct_routes_ignore_system_proxy_environment() {
+		assert_ne!(
+			h2_ineligible_reason(&route(ProxyPolicy::Direct)),
+			Some(NativeH2IneligibleReason::SystemProxy)
+		);
+	}
+}

--- a/packages/app-lib/src/util/download/native.rs
+++ b/packages/app-lib/src/util/download/native.rs
@@ -2,6 +2,16 @@
 
 use crate::util::fetch::{DownloadRoute, ProxyPolicy};
 
+const SMALL_FILE_LIMIT: u64 = 4 * 1024 * 1024;
+const MEDIUM_FILE_LIMIT: u64 = 16 * 1024 * 1024;
+const LARGE_FILE_LIMIT: u64 = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct NativeH2Policy {
+	pub(crate) abort_if_slow: bool,
+	pub(crate) expected_speed: Option<u64>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum NativeH2IneligibleReason {
 	Http1Fallback,
@@ -28,6 +38,72 @@ pub(crate) fn h2_ineligible_reason(
 		return Some(NativeH2IneligibleReason::SystemProxy);
 	}
 	None
+}
+
+pub(crate) async fn h2_policy(
+	route: &DownloadRoute,
+	size: Option<u64>,
+) -> Option<NativeH2Policy> {
+	if h2_ineligible_reason(route).is_some() {
+		return None;
+	}
+	let Some(size) = size else {
+		return Some(NativeH2Policy {
+			abort_if_slow: false,
+			expected_speed: None,
+		});
+	};
+	let authority = crate::util::fetch::url_authority(&route.url)?;
+	let h2 = super::native_reputation::get_transport(
+		&authority,
+		route.proxy,
+		super::native_reputation::NativeTransport::H2Single,
+	);
+	let multi_range = super::native_reputation::get_transport(
+		&authority,
+		route.proxy,
+		super::native_reputation::NativeTransport::Http1MultiRange,
+	);
+	let expected_speed = h2.and_then(|health| health.throughput_bps).map(|speed| {
+		speed.min(u64::MAX as f64) as u64
+	});
+	if size < SMALL_FILE_LIMIT {
+		return Some(NativeH2Policy {
+			abort_if_slow: false,
+			expected_speed,
+		});
+	}
+	if size < MEDIUM_FILE_LIMIT {
+		return super::h2_pool::has_live_connection(&authority)
+			.await
+			.then_some(NativeH2Policy {
+				abort_if_slow: true,
+				expected_speed,
+			});
+	}
+	if !super::h2_pool::has_live_connection(&authority).await {
+		return None;
+	}
+	let h2 = h2.filter(|health| health.success_samples >= 2)?;
+	let h2_speed = h2.throughput_bps?;
+	let range_speed = multi_range.and_then(|health| health.throughput_bps);
+	if size < LARGE_FILE_LIMIT {
+		let h2_preferred = range_speed
+			.map(|range_speed| h2_speed >= range_speed * 1.1)
+			.unwrap_or(true);
+		return h2_preferred.then_some(NativeH2Policy {
+			abort_if_slow: true,
+			expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
+		});
+	}
+	let range = multi_range.filter(|health| health.success_samples >= 2)?;
+	let range_speed = range.throughput_bps?;
+	(h2.success_samples >= 3 && h2_speed >= range_speed * 1.25).then_some(
+		NativeH2Policy {
+			abort_if_slow: true,
+			expected_speed: Some(h2_speed.min(u64::MAX as f64) as u64),
+		},
+	)
 }
 
 fn system_proxy_configured() -> bool {
@@ -93,6 +169,33 @@ mod tests {
 		assert_ne!(
 			h2_ineligible_reason(&route(ProxyPolicy::Direct)),
 			Some(NativeH2IneligibleReason::SystemProxy)
+		);
+	}
+
+	#[tokio::test]
+	async fn medium_file_requires_a_live_h2_connection() {
+		assert!(
+			h2_policy(
+				&route(ProxyPolicy::Direct),
+				Some(8 * 1024 * 1024),
+			)
+			.await
+			.is_none()
+		);
+	}
+
+	#[tokio::test]
+	async fn small_file_can_establish_h2_without_history() {
+		assert_eq!(
+			h2_policy(
+				&route(ProxyPolicy::Direct),
+				Some(1024 * 1024),
+			)
+			.await,
+			Some(NativeH2Policy {
+				abort_if_slow: false,
+				expected_speed: None,
+			})
 		);
 	}
 }

--- a/packages/app-lib/src/util/download/native_breaker.rs
+++ b/packages/app-lib/src/util/download/native_breaker.rs
@@ -1,0 +1,118 @@
+//! Short-lived route circuit breaker for native transfers.
+
+use crate::util::fetch::{DownloadRoute, ProxyPolicy};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+const FAILURE_THRESHOLD: u32 = 3;
+const DEFAULT_COOLDOWN: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct BreakerKey {
+	authority: String,
+	proxy: ProxyPolicy,
+}
+
+#[derive(Default)]
+struct BreakerState {
+	consecutive_failures: u32,
+	open_until: Option<Instant>,
+}
+
+static BREAKERS: LazyLock<Mutex<HashMap<BreakerKey, BreakerState>>> =
+	LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn key(route: &DownloadRoute) -> Option<BreakerKey> {
+	Some(BreakerKey {
+		authority: crate::util::fetch::url_authority(&route.url)?,
+		proxy: route.proxy,
+	})
+}
+
+pub(crate) fn is_open(route: &DownloadRoute) -> bool {
+	let Some(key) = key(route) else {
+		return false;
+	};
+	let mut breakers = BREAKERS.lock();
+	let Some(state) = breakers.get_mut(&key) else {
+		return false;
+	};
+	match state.open_until {
+		Some(until) if until > Instant::now() => true,
+		Some(_) => {
+			state.open_until = None;
+			state.consecutive_failures = 0;
+			false
+		}
+		None => false,
+	}
+}
+
+pub(crate) fn should_skip(
+	route: &DownloadRoute,
+	has_healthy_alternate: bool,
+) -> bool {
+	if !has_healthy_alternate {
+		return false;
+	}
+	is_open(route)
+}
+
+pub(crate) fn record_success(route: &DownloadRoute) {
+	let Some(key) = key(route) else {
+		return;
+	};
+	if let Some(state) = BREAKERS.lock().get_mut(&key) {
+		state.consecutive_failures = 0;
+		state.open_until = None;
+	}
+}
+
+pub(crate) fn record_failure(route: &DownloadRoute) {
+	record_failure_with_cooldown(route, DEFAULT_COOLDOWN);
+}
+
+pub(crate) fn record_failure_with_cooldown(
+	route: &DownloadRoute,
+	cooldown: Duration,
+) {
+	let Some(key) = key(route) else {
+		return;
+	};
+	let mut breakers = BREAKERS.lock();
+	let state = breakers.entry(key).or_default();
+	state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+	if state.consecutive_failures >= FAILURE_THRESHOLD {
+		state.open_until = Some(Instant::now() + cooldown);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::util::fetch::DownloadRouteSource;
+
+	fn route() -> DownloadRoute {
+		DownloadRoute {
+			url: "https://breaker.example/file".to_string(),
+			source: DownloadRouteSource::Official,
+			is_mirror: false,
+			allow_sensitive_headers: true,
+			supports_range: true,
+			proxy: ProxyPolicy::Direct,
+		}
+	}
+
+	#[test]
+	fn unique_route_is_never_skipped() {
+		let route = route();
+		for _ in 0..FAILURE_THRESHOLD {
+			record_failure(&route);
+		}
+		assert!(should_skip(&route, true));
+		assert!(!should_skip(&route, false));
+		record_success(&route);
+	}
+}

--- a/packages/app-lib/src/util/download/native_breaker.rs
+++ b/packages/app-lib/src/util/download/native_breaker.rs
@@ -11,108 +11,108 @@ const DEFAULT_COOLDOWN: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct BreakerKey {
-	authority: String,
-	proxy: ProxyPolicy,
+    authority: String,
+    proxy: ProxyPolicy,
 }
 
 #[derive(Default)]
 struct BreakerState {
-	consecutive_failures: u32,
-	open_until: Option<Instant>,
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
 }
 
 static BREAKERS: LazyLock<Mutex<HashMap<BreakerKey, BreakerState>>> =
-	LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 fn key(route: &DownloadRoute) -> Option<BreakerKey> {
-	Some(BreakerKey {
-		authority: crate::util::fetch::url_authority(&route.url)?,
-		proxy: route.proxy,
-	})
+    Some(BreakerKey {
+        authority: crate::util::fetch::url_authority(&route.url)?,
+        proxy: route.proxy,
+    })
 }
 
 pub(crate) fn is_open(route: &DownloadRoute) -> bool {
-	let Some(key) = key(route) else {
-		return false;
-	};
-	let mut breakers = BREAKERS.lock();
-	let Some(state) = breakers.get_mut(&key) else {
-		return false;
-	};
-	match state.open_until {
-		Some(until) if until > Instant::now() => true,
-		Some(_) => {
-			state.open_until = None;
-			state.consecutive_failures = 0;
-			false
-		}
-		None => false,
-	}
+    let Some(key) = key(route) else {
+        return false;
+    };
+    let mut breakers = BREAKERS.lock();
+    let Some(state) = breakers.get_mut(&key) else {
+        return false;
+    };
+    match state.open_until {
+        Some(until) if until > Instant::now() => true,
+        Some(_) => {
+            state.open_until = None;
+            state.consecutive_failures = 0;
+            false
+        }
+        None => false,
+    }
 }
 
 pub(crate) fn should_skip(
-	route: &DownloadRoute,
-	has_healthy_alternate: bool,
+    route: &DownloadRoute,
+    has_healthy_alternate: bool,
 ) -> bool {
-	if !has_healthy_alternate {
-		return false;
-	}
-	is_open(route)
+    if !has_healthy_alternate {
+        return false;
+    }
+    is_open(route)
 }
 
 pub(crate) fn record_success(route: &DownloadRoute) {
-	let Some(key) = key(route) else {
-		return;
-	};
-	if let Some(state) = BREAKERS.lock().get_mut(&key) {
-		state.consecutive_failures = 0;
-		state.open_until = None;
-	}
+    let Some(key) = key(route) else {
+        return;
+    };
+    if let Some(state) = BREAKERS.lock().get_mut(&key) {
+        state.consecutive_failures = 0;
+        state.open_until = None;
+    }
 }
 
 pub(crate) fn record_failure(route: &DownloadRoute) {
-	record_failure_with_cooldown(route, DEFAULT_COOLDOWN);
+    record_failure_with_cooldown(route, DEFAULT_COOLDOWN);
 }
 
 pub(crate) fn record_failure_with_cooldown(
-	route: &DownloadRoute,
-	cooldown: Duration,
+    route: &DownloadRoute,
+    cooldown: Duration,
 ) {
-	let Some(key) = key(route) else {
-		return;
-	};
-	let mut breakers = BREAKERS.lock();
-	let state = breakers.entry(key).or_default();
-	state.consecutive_failures = state.consecutive_failures.saturating_add(1);
-	if state.consecutive_failures >= FAILURE_THRESHOLD {
-		state.open_until = Some(Instant::now() + cooldown);
-	}
+    let Some(key) = key(route) else {
+        return;
+    };
+    let mut breakers = BREAKERS.lock();
+    let state = breakers.entry(key).or_default();
+    state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+    if state.consecutive_failures >= FAILURE_THRESHOLD {
+        state.open_until = Some(Instant::now() + cooldown);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::util::fetch::DownloadRouteSource;
+    use super::*;
+    use crate::util::fetch::DownloadRouteSource;
 
-	fn route() -> DownloadRoute {
-		DownloadRoute {
-			url: "https://breaker.example/file".to_string(),
-			source: DownloadRouteSource::Official,
-			is_mirror: false,
-			allow_sensitive_headers: true,
-			supports_range: true,
-			proxy: ProxyPolicy::Direct,
-		}
-	}
+    fn route() -> DownloadRoute {
+        DownloadRoute {
+            url: "https://breaker.example/file".to_string(),
+            source: DownloadRouteSource::Official,
+            is_mirror: false,
+            allow_sensitive_headers: true,
+            supports_range: true,
+            proxy: ProxyPolicy::Direct,
+        }
+    }
 
-	#[test]
-	fn unique_route_is_never_skipped() {
-		let route = route();
-		for _ in 0..FAILURE_THRESHOLD {
-			record_failure(&route);
-		}
-		assert!(should_skip(&route, true));
-		assert!(!should_skip(&route, false));
-		record_success(&route);
-	}
+    #[test]
+    fn unique_route_is_never_skipped() {
+        let route = route();
+        for _ in 0..FAILURE_THRESHOLD {
+            record_failure(&route);
+        }
+        assert!(should_skip(&route, true));
+        assert!(!should_skip(&route, false));
+        record_success(&route);
+    }
 }

--- a/packages/app-lib/src/util/download/native_budget.rs
+++ b/packages/app-lib/src/util/download/native_budget.rs
@@ -60,6 +60,37 @@ pub(crate) async fn acquire(
 	})
 }
 
+pub(crate) async fn acquire_many(
+	route: &DownloadRoute,
+	count: usize,
+) -> Result<Vec<NativeBudgetPermit>, tokio::sync::AcquireError> {
+	let authority = match budget(route) {
+		Some(budget) => Some(budget.acquire_many_owned(count as u32).await?),
+		None => None,
+	};
+	let global = Arc::clone(&GLOBAL_BUDGET)
+		.acquire_many_owned(count as u32)
+		.await?;
+	let mut global = global;
+	let mut authority = authority;
+	let mut permits = Vec::with_capacity(count);
+	for _ in 0..count {
+		let global = global
+			.split(1)
+			.expect("native global permit batch has enough permits");
+		let authority = authority.as_mut().map(|authority| {
+			authority
+				.split(1)
+				.expect("native authority permit batch has enough permits")
+		});
+		permits.push(NativeBudgetPermit {
+			_global: global,
+			_authority: authority,
+		});
+	}
+	Ok(permits)
+}
+
 pub(crate) fn try_acquire(
 	route: &DownloadRoute,
 ) -> Result<NativeBudgetPermit, TryAcquireError> {

--- a/packages/app-lib/src/util/download/native_budget.rs
+++ b/packages/app-lib/src/util/download/native_budget.rs
@@ -1,0 +1,92 @@
+//! Per-authority connection budget for the native download engine.
+
+use crate::util::fetch::{DownloadRoute, ProxyPolicy};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+
+const MAX_CONNECTIONS_PER_AUTHORITY: usize = 16;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct AuthorityKey {
+	authority: String,
+	proxy: ProxyPolicy,
+}
+
+static AUTHORITY_BUDGETS: LazyLock<
+	Mutex<HashMap<AuthorityKey, Arc<Semaphore>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn budget(route: &DownloadRoute) -> Option<Arc<Semaphore>> {
+	let authority = crate::util::fetch::url_authority(&route.url)?;
+	let key = AuthorityKey {
+		authority,
+		proxy: route.proxy,
+	};
+	let mut budgets = AUTHORITY_BUDGETS.lock();
+	if budgets.len() >= 256 {
+		budgets.retain(|_, budget| Arc::strong_count(budget) > 1);
+	}
+	Some(
+		budgets
+			.entry(key)
+			.or_insert_with(|| {
+				Arc::new(Semaphore::new(MAX_CONNECTIONS_PER_AUTHORITY))
+			})
+			.clone(),
+	)
+}
+
+pub(crate) async fn acquire(
+	route: &DownloadRoute,
+) -> Result<Option<OwnedSemaphorePermit>, tokio::sync::AcquireError> {
+	match budget(route) {
+		Some(budget) => budget.acquire_owned().await.map(Some),
+		None => Ok(None),
+	}
+}
+
+pub(crate) fn try_acquire(
+	route: &DownloadRoute,
+) -> Result<Option<OwnedSemaphorePermit>, TryAcquireError> {
+	match budget(route) {
+		Some(budget) => budget.try_acquire_owned().map(Some),
+		None => Ok(None),
+	}
+}
+
+pub(crate) fn available(route: &DownloadRoute) -> usize {
+	budget(route)
+		.map(|budget| budget.available_permits())
+		.unwrap_or(MAX_CONNECTIONS_PER_AUTHORITY)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::util::fetch::DownloadRouteSource;
+
+	fn route() -> DownloadRoute {
+		DownloadRoute {
+			url: "https://budget.example/file".to_string(),
+			source: DownloadRouteSource::Official,
+			is_mirror: false,
+			allow_sensitive_headers: true,
+			supports_range: true,
+			proxy: ProxyPolicy::Direct,
+		}
+	}
+
+	#[tokio::test]
+	async fn authority_budget_is_bounded() {
+		let route = route();
+		let mut permits = Vec::new();
+		for _ in 0..MAX_CONNECTIONS_PER_AUTHORITY {
+			permits.push(acquire(&route).await.unwrap());
+		}
+		assert!(matches!(try_acquire(&route), Err(TryAcquireError::NoPermits)));
+		drop(permits);
+		assert!(try_acquire(&route).is_ok());
+	}
+}

--- a/packages/app-lib/src/util/download/native_budget.rs
+++ b/packages/app-lib/src/util/download/native_budget.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
-const MAX_CONNECTIONS_PER_AUTHORITY: usize = 16;
+const MAX_NATIVE_CONNECTIONS: usize = 32;
+const MAX_CONNECTIONS_PER_AUTHORITY: usize = 8;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct AuthorityKey {
@@ -17,6 +18,13 @@ struct AuthorityKey {
 static AUTHORITY_BUDGETS: LazyLock<
 	Mutex<HashMap<AuthorityKey, Arc<Semaphore>>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
+static GLOBAL_BUDGET: LazyLock<Arc<Semaphore>> =
+	LazyLock::new(|| Arc::new(Semaphore::new(MAX_NATIVE_CONNECTIONS)));
+
+pub(crate) struct NativeBudgetPermit {
+	_global: OwnedSemaphorePermit,
+	_authority: Option<OwnedSemaphorePermit>,
+}
 
 fn budget(route: &DownloadRoute) -> Option<Arc<Semaphore>> {
 	let authority = crate::util::fetch::url_authority(&route.url)?;
@@ -40,20 +48,30 @@ fn budget(route: &DownloadRoute) -> Option<Arc<Semaphore>> {
 
 pub(crate) async fn acquire(
 	route: &DownloadRoute,
-) -> Result<Option<OwnedSemaphorePermit>, tokio::sync::AcquireError> {
-	match budget(route) {
-		Some(budget) => budget.acquire_owned().await.map(Some),
-		None => Ok(None),
-	}
+) -> Result<NativeBudgetPermit, tokio::sync::AcquireError> {
+	let authority = match budget(route) {
+		Some(budget) => Some(budget.acquire_owned().await?),
+		None => None,
+	};
+	let global = Arc::clone(&GLOBAL_BUDGET).acquire_owned().await?;
+	Ok(NativeBudgetPermit {
+		_global: global,
+		_authority: authority,
+	})
 }
 
 pub(crate) fn try_acquire(
 	route: &DownloadRoute,
-) -> Result<Option<OwnedSemaphorePermit>, TryAcquireError> {
-	match budget(route) {
-		Some(budget) => budget.try_acquire_owned().map(Some),
-		None => Ok(None),
-	}
+) -> Result<NativeBudgetPermit, TryAcquireError> {
+	let authority = match budget(route) {
+		Some(budget) => Some(budget.try_acquire_owned()?),
+		None => None,
+	};
+	let global = Arc::clone(&GLOBAL_BUDGET).try_acquire_owned()?;
+	Ok(NativeBudgetPermit {
+		_global: global,
+		_authority: authority,
+	})
 }
 
 pub(crate) fn available(route: &DownloadRoute) -> usize {

--- a/packages/app-lib/src/util/download/native_budget.rs
+++ b/packages/app-lib/src/util/download/native_budget.rs
@@ -11,131 +11,134 @@ const MAX_CONNECTIONS_PER_AUTHORITY: usize = 8;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct AuthorityKey {
-	authority: String,
-	proxy: ProxyPolicy,
+    authority: String,
+    proxy: ProxyPolicy,
 }
 
 static AUTHORITY_BUDGETS: LazyLock<
-	Mutex<HashMap<AuthorityKey, Arc<Semaphore>>>,
+    Mutex<HashMap<AuthorityKey, Arc<Semaphore>>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
 static GLOBAL_BUDGET: LazyLock<Arc<Semaphore>> =
-	LazyLock::new(|| Arc::new(Semaphore::new(MAX_NATIVE_CONNECTIONS)));
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_NATIVE_CONNECTIONS)));
 
 pub(crate) struct NativeBudgetPermit {
-	_global: OwnedSemaphorePermit,
-	_authority: Option<OwnedSemaphorePermit>,
+    _global: OwnedSemaphorePermit,
+    _authority: Option<OwnedSemaphorePermit>,
 }
 
 fn budget(route: &DownloadRoute) -> Option<Arc<Semaphore>> {
-	let authority = crate::util::fetch::url_authority(&route.url)?;
-	let key = AuthorityKey {
-		authority,
-		proxy: route.proxy,
-	};
-	let mut budgets = AUTHORITY_BUDGETS.lock();
-	if budgets.len() >= 256 {
-		budgets.retain(|_, budget| Arc::strong_count(budget) > 1);
-	}
-	Some(
-		budgets
-			.entry(key)
-			.or_insert_with(|| {
-				Arc::new(Semaphore::new(MAX_CONNECTIONS_PER_AUTHORITY))
-			})
-			.clone(),
-	)
+    let authority = crate::util::fetch::url_authority(&route.url)?;
+    let key = AuthorityKey {
+        authority,
+        proxy: route.proxy,
+    };
+    let mut budgets = AUTHORITY_BUDGETS.lock();
+    if budgets.len() >= 256 {
+        budgets.retain(|_, budget| Arc::strong_count(budget) > 1);
+    }
+    Some(
+        budgets
+            .entry(key)
+            .or_insert_with(|| {
+                Arc::new(Semaphore::new(MAX_CONNECTIONS_PER_AUTHORITY))
+            })
+            .clone(),
+    )
 }
 
 pub(crate) async fn acquire(
-	route: &DownloadRoute,
+    route: &DownloadRoute,
 ) -> Result<NativeBudgetPermit, tokio::sync::AcquireError> {
-	let authority = match budget(route) {
-		Some(budget) => Some(budget.acquire_owned().await?),
-		None => None,
-	};
-	let global = Arc::clone(&GLOBAL_BUDGET).acquire_owned().await?;
-	Ok(NativeBudgetPermit {
-		_global: global,
-		_authority: authority,
-	})
+    let authority = match budget(route) {
+        Some(budget) => Some(budget.acquire_owned().await?),
+        None => None,
+    };
+    let global = Arc::clone(&GLOBAL_BUDGET).acquire_owned().await?;
+    Ok(NativeBudgetPermit {
+        _global: global,
+        _authority: authority,
+    })
 }
 
 pub(crate) async fn acquire_many(
-	route: &DownloadRoute,
-	count: usize,
+    route: &DownloadRoute,
+    count: usize,
 ) -> Result<Vec<NativeBudgetPermit>, tokio::sync::AcquireError> {
-	let authority = match budget(route) {
-		Some(budget) => Some(budget.acquire_many_owned(count as u32).await?),
-		None => None,
-	};
-	let global = Arc::clone(&GLOBAL_BUDGET)
-		.acquire_many_owned(count as u32)
-		.await?;
-	let mut global = global;
-	let mut authority = authority;
-	let mut permits = Vec::with_capacity(count);
-	for _ in 0..count {
-		let global = global
-			.split(1)
-			.expect("native global permit batch has enough permits");
-		let authority = authority.as_mut().map(|authority| {
-			authority
-				.split(1)
-				.expect("native authority permit batch has enough permits")
-		});
-		permits.push(NativeBudgetPermit {
-			_global: global,
-			_authority: authority,
-		});
-	}
-	Ok(permits)
+    let authority = match budget(route) {
+        Some(budget) => Some(budget.acquire_many_owned(count as u32).await?),
+        None => None,
+    };
+    let global = Arc::clone(&GLOBAL_BUDGET)
+        .acquire_many_owned(count as u32)
+        .await?;
+    let mut global = global;
+    let mut authority = authority;
+    let mut permits = Vec::with_capacity(count);
+    for _ in 0..count {
+        let global = global
+            .split(1)
+            .expect("native global permit batch has enough permits");
+        let authority = authority.as_mut().map(|authority| {
+            authority
+                .split(1)
+                .expect("native authority permit batch has enough permits")
+        });
+        permits.push(NativeBudgetPermit {
+            _global: global,
+            _authority: authority,
+        });
+    }
+    Ok(permits)
 }
 
 pub(crate) fn try_acquire(
-	route: &DownloadRoute,
+    route: &DownloadRoute,
 ) -> Result<NativeBudgetPermit, TryAcquireError> {
-	let authority = match budget(route) {
-		Some(budget) => Some(budget.try_acquire_owned()?),
-		None => None,
-	};
-	let global = Arc::clone(&GLOBAL_BUDGET).try_acquire_owned()?;
-	Ok(NativeBudgetPermit {
-		_global: global,
-		_authority: authority,
-	})
+    let authority = match budget(route) {
+        Some(budget) => Some(budget.try_acquire_owned()?),
+        None => None,
+    };
+    let global = Arc::clone(&GLOBAL_BUDGET).try_acquire_owned()?;
+    Ok(NativeBudgetPermit {
+        _global: global,
+        _authority: authority,
+    })
 }
 
 pub(crate) fn available(route: &DownloadRoute) -> usize {
-	budget(route)
-		.map(|budget| budget.available_permits())
-		.unwrap_or(MAX_CONNECTIONS_PER_AUTHORITY)
+    budget(route)
+        .map(|budget| budget.available_permits())
+        .unwrap_or(MAX_CONNECTIONS_PER_AUTHORITY)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::util::fetch::DownloadRouteSource;
+    use super::*;
+    use crate::util::fetch::DownloadRouteSource;
 
-	fn route() -> DownloadRoute {
-		DownloadRoute {
-			url: "https://budget.example/file".to_string(),
-			source: DownloadRouteSource::Official,
-			is_mirror: false,
-			allow_sensitive_headers: true,
-			supports_range: true,
-			proxy: ProxyPolicy::Direct,
-		}
-	}
+    fn route() -> DownloadRoute {
+        DownloadRoute {
+            url: "https://budget.example/file".to_string(),
+            source: DownloadRouteSource::Official,
+            is_mirror: false,
+            allow_sensitive_headers: true,
+            supports_range: true,
+            proxy: ProxyPolicy::Direct,
+        }
+    }
 
-	#[tokio::test]
-	async fn authority_budget_is_bounded() {
-		let route = route();
-		let mut permits = Vec::new();
-		for _ in 0..MAX_CONNECTIONS_PER_AUTHORITY {
-			permits.push(acquire(&route).await.unwrap());
-		}
-		assert!(matches!(try_acquire(&route), Err(TryAcquireError::NoPermits)));
-		drop(permits);
-		assert!(try_acquire(&route).is_ok());
-	}
+    #[tokio::test]
+    async fn authority_budget_is_bounded() {
+        let route = route();
+        let mut permits = Vec::new();
+        for _ in 0..MAX_CONNECTIONS_PER_AUTHORITY {
+            permits.push(acquire(&route).await.unwrap());
+        }
+        assert!(matches!(
+            try_acquire(&route),
+            Err(TryAcquireError::NoPermits)
+        ));
+        drop(permits);
+        assert!(try_acquire(&route).is_ok());
+    }
 }

--- a/packages/app-lib/src/util/download/native_reputation.rs
+++ b/packages/app-lib/src/util/download/native_reputation.rs
@@ -1,0 +1,245 @@
+//! Persisted route reputation for the native download engine.
+
+use crate::util::fetch::ProxyPolicy;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{LazyLock, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const FILE_NAME: &str = "native-download-reputation.json";
+const SCHEMA_VERSION: u32 = 1;
+const MAX_ENTRIES: usize = 256;
+const MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+const WRITE_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ReputationKey {
+	family: String,
+	authority: String,
+	proxy: ProxyPolicy,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct NativeRouteReputation {
+	pub(crate) success_samples: u32,
+	pub(crate) failure_samples: u32,
+	#[serde(default)]
+	pub(crate) consecutive_failures: u32,
+	pub(crate) ttfb_ms: Option<f64>,
+	pub(crate) throughput_bps: Option<f64>,
+	updated_at: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedStore {
+	version: u32,
+	routes: Vec<PersistedRoute>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedRoute {
+	family: String,
+	authority: String,
+	proxy: ProxyPolicy,
+	#[serde(flatten)]
+	health: NativeRouteReputation,
+}
+
+static REPUTATION: LazyLock<Mutex<HashMap<ReputationKey, NativeRouteReputation>>> =
+	LazyLock::new(|| Mutex::new(HashMap::new()));
+static LOAD: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+static PATH: OnceLock<PathBuf> = OnceLock::new();
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+static WRITE_SCHEDULED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) async fn load_if_needed() {
+	LOAD.get_or_init(|| async {
+		let Some(path) = reputation_path() else {
+			return;
+		};
+		let _ = PATH.set(path.clone());
+		let Ok(contents) = tokio::fs::read(&path).await else {
+			return;
+		};
+		let Ok(store) = serde_json::from_slice::<PersistedStore>(&contents) else {
+			tracing::warn!(path = %path.display(), "Ignoring invalid native download reputation");
+			return;
+		};
+		if store.version != SCHEMA_VERSION {
+			return;
+		}
+		let cutoff = now_secs().saturating_sub(MAX_AGE_SECS);
+		let mut reputation = REPUTATION.lock();
+		for route in store.routes.into_iter().take(MAX_ENTRIES) {
+			if route.health.updated_at < cutoff {
+				continue;
+			}
+			reputation.insert(
+				ReputationKey {
+					family: route.family,
+					authority: route.authority,
+					proxy: route.proxy,
+				},
+				route.health,
+			);
+		}
+	})
+	.await;
+}
+
+pub(crate) fn get(
+	family: &str,
+	authority: &str,
+	proxy: ProxyPolicy,
+) -> Option<NativeRouteReputation> {
+	REPUTATION
+		.lock()
+		.get(&ReputationKey {
+			family: family.to_string(),
+			authority: authority.to_string(),
+			proxy,
+		})
+		.copied()
+}
+
+pub(crate) fn record_success(
+	family: &str,
+	authority: &str,
+	proxy: ProxyPolicy,
+	ttfb_ms: f64,
+	throughput_bps: Option<f64>,
+) {
+	let mut reputation = REPUTATION.lock();
+	let entry = reputation
+		.entry(ReputationKey {
+			family: family.to_string(),
+			authority: authority.to_string(),
+			proxy,
+		})
+		.or_default();
+	entry.success_samples = entry.success_samples.saturating_add(1);
+	entry.consecutive_failures = 0;
+	entry.ttfb_ms = Some(update_ewma(entry.ttfb_ms, ttfb_ms));
+	if let Some(throughput_bps) = throughput_bps {
+		entry.throughput_bps = Some(update_ewma(
+			entry.throughput_bps,
+			throughput_bps,
+		));
+	}
+	entry.updated_at = now_secs();
+	drop(reputation);
+	schedule_write();
+}
+
+pub(crate) fn record_failure(
+	family: &str,
+	authority: &str,
+	proxy: ProxyPolicy,
+) {
+	let mut reputation = REPUTATION.lock();
+	let entry = reputation
+		.entry(ReputationKey {
+			family: family.to_string(),
+			authority: authority.to_string(),
+			proxy,
+		})
+		.or_default();
+	entry.failure_samples = entry.failure_samples.saturating_add(1);
+	entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+	entry.updated_at = now_secs();
+	drop(reputation);
+	schedule_write();
+}
+
+fn update_ewma(current: Option<f64>, sample: f64) -> f64 {
+	current.map_or(sample, |current| current * 0.75 + sample * 0.25)
+}
+
+fn schedule_write() {
+	GENERATION.fetch_add(1, Ordering::AcqRel);
+	let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+		return;
+	};
+	if WRITE_SCHEDULED.swap(true, Ordering::AcqRel) {
+		return;
+	}
+	runtime.spawn(async {
+		loop {
+			let generation = GENERATION.load(Ordering::Acquire);
+			tokio::time::sleep(WRITE_DELAY).await;
+			if let Err(error) = write_snapshot().await {
+				tracing::warn!(%error, "Failed to persist native download reputation");
+			}
+			if GENERATION.load(Ordering::Acquire) == generation {
+				WRITE_SCHEDULED.store(false, Ordering::Release);
+				if GENERATION.load(Ordering::Acquire) == generation
+					|| WRITE_SCHEDULED.swap(true, Ordering::AcqRel)
+				{
+					break;
+				}
+			}
+		}
+	});
+}
+
+async fn write_snapshot() -> std::io::Result<()> {
+	let Some(path) = PATH.get().cloned().or_else(reputation_path) else {
+		return Ok(());
+	};
+	let mut routes = REPUTATION
+		.lock()
+		.iter()
+		.map(|(key, health)| PersistedRoute {
+			family: key.family.clone(),
+			authority: key.authority.clone(),
+			proxy: key.proxy,
+			health: *health,
+		})
+		.collect::<Vec<_>>();
+	routes.sort_unstable_by_key(|route| std::cmp::Reverse(route.health.updated_at));
+	routes.truncate(MAX_ENTRIES);
+	let bytes = serde_json::to_vec(&PersistedStore {
+		version: SCHEMA_VERSION,
+		routes,
+	})
+	.map_err(std::io::Error::other)?;
+	if let Some(parent) = path.parent() {
+		tokio::fs::create_dir_all(parent).await?;
+	}
+	let temporary = temporary_path(&path);
+	tokio::fs::write(&temporary, bytes).await?;
+	if let Err(error) = tokio::fs::rename(&temporary, &path).await {
+		if error.kind() != std::io::ErrorKind::AlreadyExists {
+			let _ = tokio::fs::remove_file(&temporary).await;
+			return Err(error);
+		}
+		tokio::fs::remove_file(&path).await?;
+		tokio::fs::rename(&temporary, &path).await?;
+	}
+	Ok(())
+}
+
+fn reputation_path() -> Option<PathBuf> {
+	crate::State::get_if_initialized().map(|state| {
+		state
+			.directories
+			.settings_dir
+			.join(FILE_NAME)
+	})
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+	let mut name = path.file_name().unwrap_or_default().to_os_string();
+	name.push(".tmp");
+	path.with_file_name(name)
+}
+
+fn now_secs() -> u64 {
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.map(|duration| duration.as_secs())
+		.unwrap_or(0)
+}

--- a/packages/app-lib/src/util/download/native_reputation.rs
+++ b/packages/app-lib/src/util/download/native_reputation.rs
@@ -15,6 +15,13 @@ const MAX_ENTRIES: usize = 256;
 const MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
 const WRITE_DELAY: Duration = Duration::from_secs(5);
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeTransport {
+	H2Single,
+	Http1MultiRange,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ReputationKey {
 	family: String,
@@ -37,6 +44,8 @@ pub(crate) struct NativeRouteReputation {
 struct PersistedStore {
 	version: u32,
 	routes: Vec<PersistedRoute>,
+	#[serde(default)]
+	transports: Vec<PersistedTransport>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -48,8 +57,34 @@ struct PersistedRoute {
 	health: NativeRouteReputation,
 }
 
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct NativeTransportReputation {
+	pub(crate) success_samples: u32,
+	pub(crate) throughput_bps: Option<f64>,
+	updated_at: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TransportKey {
+	authority: String,
+	proxy: ProxyPolicy,
+	transport: NativeTransport,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedTransport {
+	authority: String,
+	proxy: ProxyPolicy,
+	transport: NativeTransport,
+	#[serde(flatten)]
+	health: NativeTransportReputation,
+}
+
 static REPUTATION: LazyLock<Mutex<HashMap<ReputationKey, NativeRouteReputation>>> =
 	LazyLock::new(|| Mutex::new(HashMap::new()));
+static TRANSPORT_REPUTATION: LazyLock<
+	Mutex<HashMap<TransportKey, NativeTransportReputation>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static LOAD: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 static PATH: OnceLock<PathBuf> = OnceLock::new();
 static GENERATION: AtomicU64 = AtomicU64::new(0);
@@ -86,8 +121,65 @@ pub(crate) async fn load_if_needed() {
 				route.health,
 			);
 		}
+		drop(reputation);
+		let mut transports = TRANSPORT_REPUTATION.lock();
+		for transport in store.transports.into_iter().take(MAX_ENTRIES) {
+			if transport.health.updated_at < cutoff {
+				continue;
+			}
+			transports.insert(
+				TransportKey {
+					authority: transport.authority,
+					proxy: transport.proxy,
+					transport: transport.transport,
+				},
+				transport.health,
+			);
+		}
 	})
 	.await;
+}
+
+pub(crate) fn get_transport(
+	authority: &str,
+	proxy: ProxyPolicy,
+	transport: NativeTransport,
+) -> Option<NativeTransportReputation> {
+	TRANSPORT_REPUTATION
+		.lock()
+		.get(&TransportKey {
+			authority: authority.to_string(),
+			proxy,
+			transport,
+		})
+		.copied()
+}
+
+pub(crate) fn record_transport_success(
+	authority: &str,
+	proxy: ProxyPolicy,
+	transport: NativeTransport,
+	throughput_bps: f64,
+) {
+	if !throughput_bps.is_finite() || throughput_bps <= 0.0 {
+		return;
+	}
+	let mut reputation = TRANSPORT_REPUTATION.lock();
+	let entry = reputation
+		.entry(TransportKey {
+			authority: authority.to_string(),
+			proxy,
+			transport,
+		})
+		.or_default();
+	entry.success_samples = entry.success_samples.saturating_add(1);
+	entry.throughput_bps = Some(update_ewma(
+		entry.throughput_bps,
+		throughput_bps,
+	));
+	entry.updated_at = now_secs();
+	drop(reputation);
+	schedule_write();
 }
 
 pub(crate) fn get(
@@ -201,9 +293,24 @@ async fn write_snapshot() -> std::io::Result<()> {
 		.collect::<Vec<_>>();
 	routes.sort_unstable_by_key(|route| std::cmp::Reverse(route.health.updated_at));
 	routes.truncate(MAX_ENTRIES);
+	let mut transports = TRANSPORT_REPUTATION
+		.lock()
+		.iter()
+		.map(|(key, health)| PersistedTransport {
+			authority: key.authority.clone(),
+			proxy: key.proxy,
+			transport: key.transport,
+			health: *health,
+		})
+		.collect::<Vec<_>>();
+	transports.sort_unstable_by_key(|transport| {
+		std::cmp::Reverse(transport.health.updated_at)
+	});
+	transports.truncate(MAX_ENTRIES);
 	let bytes = serde_json::to_vec(&PersistedStore {
 		version: SCHEMA_VERSION,
 		routes,
+		transports,
 	})
 	.map_err(std::io::Error::other)?;
 	if let Some(parent) = path.parent() {
@@ -242,4 +349,35 @@ fn now_secs() -> u64 {
 		.duration_since(UNIX_EPOCH)
 		.map(|duration| duration.as_secs())
 		.unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn transport_reputation_is_independent() {
+		record_transport_success(
+			"transport-reputation.example:443",
+			ProxyPolicy::Direct,
+			NativeTransport::H2Single,
+			1024.0,
+		);
+		assert!(
+			get_transport(
+				"transport-reputation.example:443",
+				ProxyPolicy::Direct,
+				NativeTransport::H2Single,
+			)
+			.is_some()
+		);
+		assert!(
+			get_transport(
+				"transport-reputation.example:443",
+				ProxyPolicy::Direct,
+				NativeTransport::Http1MultiRange,
+			)
+			.is_none()
+		);
+	}
 }

--- a/packages/app-lib/src/util/download/native_reputation.rs
+++ b/packages/app-lib/src/util/download/native_reputation.rs
@@ -18,72 +18,73 @@ const WRITE_DELAY: Duration = Duration::from_secs(5);
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NativeTransport {
-	H2Single,
-	Http1MultiRange,
+    H2Single,
+    Http1MultiRange,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ReputationKey {
-	family: String,
-	authority: String,
-	proxy: ProxyPolicy,
+    family: String,
+    authority: String,
+    proxy: ProxyPolicy,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct NativeRouteReputation {
-	pub(crate) success_samples: u32,
-	pub(crate) failure_samples: u32,
-	#[serde(default)]
-	pub(crate) consecutive_failures: u32,
-	pub(crate) ttfb_ms: Option<f64>,
-	pub(crate) throughput_bps: Option<f64>,
-	updated_at: u64,
+    pub(crate) success_samples: u32,
+    pub(crate) failure_samples: u32,
+    #[serde(default)]
+    pub(crate) consecutive_failures: u32,
+    pub(crate) ttfb_ms: Option<f64>,
+    pub(crate) throughput_bps: Option<f64>,
+    updated_at: u64,
 }
 
 #[derive(Serialize, Deserialize)]
 struct PersistedStore {
-	version: u32,
-	routes: Vec<PersistedRoute>,
-	#[serde(default)]
-	transports: Vec<PersistedTransport>,
+    version: u32,
+    routes: Vec<PersistedRoute>,
+    #[serde(default)]
+    transports: Vec<PersistedTransport>,
 }
 
 #[derive(Serialize, Deserialize)]
 struct PersistedRoute {
-	family: String,
-	authority: String,
-	proxy: ProxyPolicy,
-	#[serde(flatten)]
-	health: NativeRouteReputation,
+    family: String,
+    authority: String,
+    proxy: ProxyPolicy,
+    #[serde(flatten)]
+    health: NativeRouteReputation,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct NativeTransportReputation {
-	pub(crate) success_samples: u32,
-	pub(crate) throughput_bps: Option<f64>,
-	updated_at: u64,
+    pub(crate) success_samples: u32,
+    pub(crate) throughput_bps: Option<f64>,
+    updated_at: u64,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct TransportKey {
-	authority: String,
-	proxy: ProxyPolicy,
-	transport: NativeTransport,
+    authority: String,
+    proxy: ProxyPolicy,
+    transport: NativeTransport,
 }
 
 #[derive(Serialize, Deserialize)]
 struct PersistedTransport {
-	authority: String,
-	proxy: ProxyPolicy,
-	transport: NativeTransport,
-	#[serde(flatten)]
-	health: NativeTransportReputation,
+    authority: String,
+    proxy: ProxyPolicy,
+    transport: NativeTransport,
+    #[serde(flatten)]
+    health: NativeTransportReputation,
 }
 
-static REPUTATION: LazyLock<Mutex<HashMap<ReputationKey, NativeRouteReputation>>> =
-	LazyLock::new(|| Mutex::new(HashMap::new()));
+static REPUTATION: LazyLock<
+    Mutex<HashMap<ReputationKey, NativeRouteReputation>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static TRANSPORT_REPUTATION: LazyLock<
-	Mutex<HashMap<TransportKey, NativeTransportReputation>>,
+    Mutex<HashMap<TransportKey, NativeTransportReputation>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
 static LOAD: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 static PATH: OnceLock<PathBuf> = OnceLock::new();
@@ -91,7 +92,7 @@ static GENERATION: AtomicU64 = AtomicU64::new(0);
 static WRITE_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 pub(crate) async fn load_if_needed() {
-	LOAD.get_or_init(|| async {
+    LOAD.get_or_init(|| async {
 		let Some(path) = reputation_path() else {
 			return;
 		};
@@ -141,124 +142,120 @@ pub(crate) async fn load_if_needed() {
 }
 
 pub(crate) fn get_transport(
-	authority: &str,
-	proxy: ProxyPolicy,
-	transport: NativeTransport,
+    authority: &str,
+    proxy: ProxyPolicy,
+    transport: NativeTransport,
 ) -> Option<NativeTransportReputation> {
-	TRANSPORT_REPUTATION
-		.lock()
-		.get(&TransportKey {
-			authority: authority.to_string(),
-			proxy,
-			transport,
-		})
-		.copied()
+    TRANSPORT_REPUTATION
+        .lock()
+        .get(&TransportKey {
+            authority: authority.to_string(),
+            proxy,
+            transport,
+        })
+        .copied()
 }
 
 pub(crate) fn record_transport_success(
-	authority: &str,
-	proxy: ProxyPolicy,
-	transport: NativeTransport,
-	throughput_bps: f64,
+    authority: &str,
+    proxy: ProxyPolicy,
+    transport: NativeTransport,
+    throughput_bps: f64,
 ) {
-	if !throughput_bps.is_finite() || throughput_bps <= 0.0 {
-		return;
-	}
-	let mut reputation = TRANSPORT_REPUTATION.lock();
-	let entry = reputation
-		.entry(TransportKey {
-			authority: authority.to_string(),
-			proxy,
-			transport,
-		})
-		.or_default();
-	entry.success_samples = entry.success_samples.saturating_add(1);
-	entry.throughput_bps = Some(update_ewma(
-		entry.throughput_bps,
-		throughput_bps,
-	));
-	entry.updated_at = now_secs();
-	drop(reputation);
-	schedule_write();
+    if !throughput_bps.is_finite() || throughput_bps <= 0.0 {
+        return;
+    }
+    let mut reputation = TRANSPORT_REPUTATION.lock();
+    let entry = reputation
+        .entry(TransportKey {
+            authority: authority.to_string(),
+            proxy,
+            transport,
+        })
+        .or_default();
+    entry.success_samples = entry.success_samples.saturating_add(1);
+    entry.throughput_bps =
+        Some(update_ewma(entry.throughput_bps, throughput_bps));
+    entry.updated_at = now_secs();
+    drop(reputation);
+    schedule_write();
 }
 
 pub(crate) fn get(
-	family: &str,
-	authority: &str,
-	proxy: ProxyPolicy,
+    family: &str,
+    authority: &str,
+    proxy: ProxyPolicy,
 ) -> Option<NativeRouteReputation> {
-	REPUTATION
-		.lock()
-		.get(&ReputationKey {
-			family: family.to_string(),
-			authority: authority.to_string(),
-			proxy,
-		})
-		.copied()
+    REPUTATION
+        .lock()
+        .get(&ReputationKey {
+            family: family.to_string(),
+            authority: authority.to_string(),
+            proxy,
+        })
+        .copied()
 }
 
 pub(crate) fn record_success(
-	family: &str,
-	authority: &str,
-	proxy: ProxyPolicy,
-	ttfb_ms: f64,
-	throughput_bps: Option<f64>,
+    family: &str,
+    authority: &str,
+    proxy: ProxyPolicy,
+    ttfb_ms: f64,
+    throughput_bps: Option<f64>,
 ) {
-	let mut reputation = REPUTATION.lock();
-	let entry = reputation
-		.entry(ReputationKey {
-			family: family.to_string(),
-			authority: authority.to_string(),
-			proxy,
-		})
-		.or_default();
-	entry.success_samples = entry.success_samples.saturating_add(1);
-	entry.consecutive_failures = 0;
-	entry.ttfb_ms = Some(update_ewma(entry.ttfb_ms, ttfb_ms));
-	if let Some(throughput_bps) = throughput_bps {
-		entry.throughput_bps = Some(update_ewma(
-			entry.throughput_bps,
-			throughput_bps,
-		));
-	}
-	entry.updated_at = now_secs();
-	drop(reputation);
-	schedule_write();
+    let mut reputation = REPUTATION.lock();
+    let entry = reputation
+        .entry(ReputationKey {
+            family: family.to_string(),
+            authority: authority.to_string(),
+            proxy,
+        })
+        .or_default();
+    entry.success_samples = entry.success_samples.saturating_add(1);
+    entry.consecutive_failures = 0;
+    entry.ttfb_ms = Some(update_ewma(entry.ttfb_ms, ttfb_ms));
+    if let Some(throughput_bps) = throughput_bps {
+        entry.throughput_bps =
+            Some(update_ewma(entry.throughput_bps, throughput_bps));
+    }
+    entry.updated_at = now_secs();
+    drop(reputation);
+    schedule_write();
 }
 
 pub(crate) fn record_failure(
-	family: &str,
-	authority: &str,
-	proxy: ProxyPolicy,
+    family: &str,
+    authority: &str,
+    proxy: ProxyPolicy,
 ) {
-	let mut reputation = REPUTATION.lock();
-	let entry = reputation
-		.entry(ReputationKey {
-			family: family.to_string(),
-			authority: authority.to_string(),
-			proxy,
-		})
-		.or_default();
-	entry.failure_samples = entry.failure_samples.saturating_add(1);
-	entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
-	entry.updated_at = now_secs();
-	drop(reputation);
-	schedule_write();
+    let mut reputation = REPUTATION.lock();
+    let entry = reputation
+        .entry(ReputationKey {
+            family: family.to_string(),
+            authority: authority.to_string(),
+            proxy,
+        })
+        .or_default();
+    entry.failure_samples = entry.failure_samples.saturating_add(1);
+    entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+    entry.updated_at = now_secs();
+    drop(reputation);
+    schedule_write();
 }
 
 fn update_ewma(current: Option<f64>, sample: f64) -> f64 {
-	current.map_or(sample, |current| current * 0.75 + sample * 0.25)
+    current.map_or(sample, |current| current * 0.75 + sample * 0.25)
 }
 
 fn schedule_write() {
-	GENERATION.fetch_add(1, Ordering::AcqRel);
-	let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-		return;
-	};
-	if WRITE_SCHEDULED.swap(true, Ordering::AcqRel) {
-		return;
-	}
-	runtime.spawn(async {
+    GENERATION.fetch_add(1, Ordering::AcqRel);
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    if WRITE_SCHEDULED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    runtime.spawn(async {
 		loop {
 			let generation = GENERATION.load(Ordering::Acquire);
 			tokio::time::sleep(WRITE_DELAY).await;
@@ -278,106 +275,104 @@ fn schedule_write() {
 }
 
 async fn write_snapshot() -> std::io::Result<()> {
-	let Some(path) = PATH.get().cloned().or_else(reputation_path) else {
-		return Ok(());
-	};
-	let mut routes = REPUTATION
-		.lock()
-		.iter()
-		.map(|(key, health)| PersistedRoute {
-			family: key.family.clone(),
-			authority: key.authority.clone(),
-			proxy: key.proxy,
-			health: *health,
-		})
-		.collect::<Vec<_>>();
-	routes.sort_unstable_by_key(|route| std::cmp::Reverse(route.health.updated_at));
-	routes.truncate(MAX_ENTRIES);
-	let mut transports = TRANSPORT_REPUTATION
-		.lock()
-		.iter()
-		.map(|(key, health)| PersistedTransport {
-			authority: key.authority.clone(),
-			proxy: key.proxy,
-			transport: key.transport,
-			health: *health,
-		})
-		.collect::<Vec<_>>();
-	transports.sort_unstable_by_key(|transport| {
-		std::cmp::Reverse(transport.health.updated_at)
-	});
-	transports.truncate(MAX_ENTRIES);
-	let bytes = serde_json::to_vec(&PersistedStore {
-		version: SCHEMA_VERSION,
-		routes,
-		transports,
-	})
-	.map_err(std::io::Error::other)?;
-	if let Some(parent) = path.parent() {
-		tokio::fs::create_dir_all(parent).await?;
-	}
-	let temporary = temporary_path(&path);
-	tokio::fs::write(&temporary, bytes).await?;
-	if let Err(error) = tokio::fs::rename(&temporary, &path).await {
-		if error.kind() != std::io::ErrorKind::AlreadyExists {
-			let _ = tokio::fs::remove_file(&temporary).await;
-			return Err(error);
-		}
-		tokio::fs::remove_file(&path).await?;
-		tokio::fs::rename(&temporary, &path).await?;
-	}
-	Ok(())
+    let Some(path) = PATH.get().cloned().or_else(reputation_path) else {
+        return Ok(());
+    };
+    let mut routes = REPUTATION
+        .lock()
+        .iter()
+        .map(|(key, health)| PersistedRoute {
+            family: key.family.clone(),
+            authority: key.authority.clone(),
+            proxy: key.proxy,
+            health: *health,
+        })
+        .collect::<Vec<_>>();
+    routes.sort_unstable_by_key(|route| {
+        std::cmp::Reverse(route.health.updated_at)
+    });
+    routes.truncate(MAX_ENTRIES);
+    let mut transports = TRANSPORT_REPUTATION
+        .lock()
+        .iter()
+        .map(|(key, health)| PersistedTransport {
+            authority: key.authority.clone(),
+            proxy: key.proxy,
+            transport: key.transport,
+            health: *health,
+        })
+        .collect::<Vec<_>>();
+    transports.sort_unstable_by_key(|transport| {
+        std::cmp::Reverse(transport.health.updated_at)
+    });
+    transports.truncate(MAX_ENTRIES);
+    let bytes = serde_json::to_vec(&PersistedStore {
+        version: SCHEMA_VERSION,
+        routes,
+        transports,
+    })
+    .map_err(std::io::Error::other)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let temporary = temporary_path(&path);
+    tokio::fs::write(&temporary, bytes).await?;
+    if let Err(error) = tokio::fs::rename(&temporary, &path).await {
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return Err(error);
+        }
+        tokio::fs::remove_file(&path).await?;
+        tokio::fs::rename(&temporary, &path).await?;
+    }
+    Ok(())
 }
 
 fn reputation_path() -> Option<PathBuf> {
-	crate::State::get_if_initialized().map(|state| {
-		state
-			.directories
-			.settings_dir
-			.join(FILE_NAME)
-	})
+    crate::State::get_if_initialized()
+        .map(|state| state.directories.settings_dir.join(FILE_NAME))
 }
 
 fn temporary_path(path: &Path) -> PathBuf {
-	let mut name = path.file_name().unwrap_or_default().to_os_string();
-	name.push(".tmp");
-	path.with_file_name(name)
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".tmp");
+    path.with_file_name(name)
 }
 
 fn now_secs() -> u64 {
-	SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.map(|duration| duration.as_secs())
-		.unwrap_or(0)
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn transport_reputation_is_independent() {
-		record_transport_success(
-			"transport-reputation.example:443",
-			ProxyPolicy::Direct,
-			NativeTransport::H2Single,
-			1024.0,
-		);
-		assert!(
-			get_transport(
-				"transport-reputation.example:443",
-				ProxyPolicy::Direct,
-				NativeTransport::H2Single,
-			)
-			.is_some()
-		);
-		assert!(
-			get_transport(
-				"transport-reputation.example:443",
-				ProxyPolicy::Direct,
-				NativeTransport::Http1MultiRange,
-			)
-			.is_none()
-		);
-	}
+    #[test]
+    fn transport_reputation_is_independent() {
+        record_transport_success(
+            "transport-reputation.example:443",
+            ProxyPolicy::Direct,
+            NativeTransport::H2Single,
+            1024.0,
+        );
+        assert!(
+            get_transport(
+                "transport-reputation.example:443",
+                ProxyPolicy::Direct,
+                NativeTransport::H2Single,
+            )
+            .is_some()
+        );
+        assert!(
+            get_transport(
+                "transport-reputation.example:443",
+                ProxyPolicy::Direct,
+                NativeTransport::Http1MultiRange,
+            )
+            .is_none()
+        );
+    }
 }

--- a/packages/app-lib/src/util/download/native_slow.rs
+++ b/packages/app-lib/src/util/download/native_slow.rs
@@ -13,130 +13,131 @@ const MIN_SAVINGS: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SlowDecision {
-	Continue,
-	Probe { bytes_per_second: u64 },
-	Commit,
+    Continue,
+    Probe { bytes_per_second: u64 },
+    Commit,
 }
 
 pub(crate) struct NativeSlowPolicy {
-	started_at: Instant,
-	window_started_at: Instant,
-	window_start_bytes: u64,
-	slow_windows: u8,
-	committed: bool,
-	expected_speed: Option<u64>,
+    started_at: Instant,
+    window_started_at: Instant,
+    window_start_bytes: u64,
+    slow_windows: u8,
+    committed: bool,
+    expected_speed: Option<u64>,
 }
 
 impl NativeSlowPolicy {
-	pub(crate) fn new(starting_bytes: u64, expected_speed: Option<u64>) -> Self {
-		let now = Instant::now();
-		Self {
-			started_at: now,
-			window_started_at: now,
-			window_start_bytes: starting_bytes,
-			slow_windows: 0,
-			committed: false,
-			expected_speed,
-		}
-	}
+    pub(crate) fn new(
+        starting_bytes: u64,
+        expected_speed: Option<u64>,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            started_at: now,
+            window_started_at: now,
+            window_start_bytes: starting_bytes,
+            slow_windows: 0,
+            committed: false,
+            expected_speed,
+        }
+    }
 
-	pub(crate) fn observe(
-		&mut self,
-		downloaded: u64,
-		remaining: u64,
-	) -> SlowDecision {
-		if self.committed {
-			return SlowDecision::Continue;
-		}
-		let elapsed = self.window_started_at.elapsed();
-		if elapsed < WINDOW {
-			return SlowDecision::Continue;
-		}
-		let speed = downloaded
-			.saturating_sub(self.window_start_bytes)
-			.checked_div(elapsed.as_secs().max(1))
-			.unwrap_or(0);
-		self.window_started_at = Instant::now();
-		self.window_start_bytes = downloaded;
+    pub(crate) fn observe(
+        &mut self,
+        downloaded: u64,
+        remaining: u64,
+    ) -> SlowDecision {
+        if self.committed {
+            return SlowDecision::Continue;
+        }
+        let elapsed = self.window_started_at.elapsed();
+        if elapsed < WINDOW {
+            return SlowDecision::Continue;
+        }
+        let speed = downloaded
+            .saturating_sub(self.window_start_bytes)
+            .checked_div(elapsed.as_secs().max(1))
+            .unwrap_or(0);
+        self.window_started_at = Instant::now();
+        self.window_start_bytes = downloaded;
 
-		if remaining < MIN_REMAINING_BYTES
-			|| estimated_duration(remaining, speed)
-				<= RECONNECT_OVERHEAD + MIN_SAVINGS
-		{
-			self.committed = true;
-			return SlowDecision::Commit;
-		}
-		let expected_floor = self
-			.expected_speed
-			.map(|expected| expected.saturating_mul(40) / 100)
-			.unwrap_or(COLD_SPEED_FLOOR)
-			.max(ABSOLUTE_SPEED_FLOOR);
-		if speed < expected_floor {
-			self.slow_windows = self.slow_windows.saturating_add(1);
-		} else {
-			self.slow_windows = 0;
-		}
-		if self.started_at.elapsed() >= MIN_FLOW
-			&& self.slow_windows >= REQUIRED_SLOW_WINDOWS
-		{
-			self.slow_windows = 0;
-			SlowDecision::Probe {
-				bytes_per_second: speed,
-			}
-		} else {
-			SlowDecision::Continue
-		}
-	}
+        if remaining < MIN_REMAINING_BYTES
+            || estimated_duration(remaining, speed)
+                <= RECONNECT_OVERHEAD + MIN_SAVINGS
+        {
+            self.committed = true;
+            return SlowDecision::Commit;
+        }
+        let expected_floor = self
+            .expected_speed
+            .map(|expected| expected.saturating_mul(40) / 100)
+            .unwrap_or(COLD_SPEED_FLOOR)
+            .max(ABSOLUTE_SPEED_FLOOR);
+        if speed < expected_floor {
+            self.slow_windows = self.slow_windows.saturating_add(1);
+        } else {
+            self.slow_windows = 0;
+        }
+        if self.started_at.elapsed() >= MIN_FLOW
+            && self.slow_windows >= REQUIRED_SLOW_WINDOWS
+        {
+            self.slow_windows = 0;
+            SlowDecision::Probe {
+                bytes_per_second: speed,
+            }
+        } else {
+            SlowDecision::Continue
+        }
+    }
 
-	pub(crate) fn commit(&mut self) {
-		self.committed = true;
-	}
+    pub(crate) fn commit(&mut self) {
+        self.committed = true;
+    }
 }
 
 pub(crate) fn should_switch(
-	current_speed: u64,
-	candidate_speed: u64,
-	remaining_bytes: u64,
-	restart_bytes: u64,
+    current_speed: u64,
+    candidate_speed: u64,
+    remaining_bytes: u64,
+    restart_bytes: u64,
 ) -> bool {
-	if current_speed == 0 || candidate_speed == 0 {
-		return false;
-	}
-	if candidate_speed.saturating_mul(100)
-		< current_speed.saturating_mul(125)
-	{
-		return false;
-	}
-	let stay = estimated_duration(remaining_bytes, current_speed);
-	let switch = RECONNECT_OVERHEAD
-		+ estimated_duration(restart_bytes, candidate_speed);
-	let required_savings = MIN_SAVINGS.max(stay.mul_f64(0.15));
-	switch.saturating_add(required_savings) < stay
+    if current_speed == 0 || candidate_speed == 0 {
+        return false;
+    }
+    if candidate_speed.saturating_mul(100) < current_speed.saturating_mul(125) {
+        return false;
+    }
+    let stay = estimated_duration(remaining_bytes, current_speed);
+    let switch =
+        RECONNECT_OVERHEAD + estimated_duration(restart_bytes, candidate_speed);
+    let required_savings = MIN_SAVINGS.max(stay.mul_f64(0.15));
+    switch.saturating_add(required_savings) < stay
 }
 
 fn estimated_duration(bytes: u64, speed: u64) -> Duration {
-	if speed == 0 {
-		return Duration::MAX;
-	}
-	Duration::from_secs_f64(bytes as f64 / speed as f64)
+    if speed == 0 {
+        return Duration::MAX;
+    }
+    Duration::from_secs_f64(bytes as f64 / speed as f64)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn switch_requires_repayment_of_restarted_bytes() {
-		assert!(!should_switch(1024, 2048, 1024, 1024 * 1024));
-	}
+    #[test]
+    fn switch_requires_repayment_of_restarted_bytes() {
+        assert!(!should_switch(1024, 2048, 1024, 1024 * 1024));
+    }
 
-	#[test]
-	fn faster_candidate_wins_early_in_a_large_download() {
-		assert!(should_switch(
-			256 * 1024,
-			2 * 1024 * 1024,
-			64 * 1024 * 1024,
-			64 * 1024 * 1024,
-		));
-	}
+    #[test]
+    fn faster_candidate_wins_early_in_a_large_download() {
+        assert!(should_switch(
+            256 * 1024,
+            2 * 1024 * 1024,
+            64 * 1024 * 1024,
+            64 * 1024 * 1024,
+        ));
+    }
 }

--- a/packages/app-lib/src/util/download/native_slow.rs
+++ b/packages/app-lib/src/util/download/native_slow.rs
@@ -1,0 +1,142 @@
+//! Slow-transfer and optimal-stop policy for the native download engine.
+
+use std::time::{Duration, Instant};
+
+const WINDOW: Duration = Duration::from_secs(3);
+const MIN_FLOW: Duration = Duration::from_secs(10);
+const REQUIRED_SLOW_WINDOWS: u8 = 2;
+const MIN_REMAINING_BYTES: u64 = 1024 * 1024;
+const ABSOLUTE_SPEED_FLOOR: u64 = 16 * 1024;
+const COLD_SPEED_FLOOR: u64 = 256 * 1024;
+const RECONNECT_OVERHEAD: Duration = Duration::from_millis(600);
+const MIN_SAVINGS: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SlowDecision {
+	Continue,
+	Probe { bytes_per_second: u64 },
+	Commit,
+}
+
+pub(crate) struct NativeSlowPolicy {
+	started_at: Instant,
+	window_started_at: Instant,
+	window_start_bytes: u64,
+	slow_windows: u8,
+	committed: bool,
+	expected_speed: Option<u64>,
+}
+
+impl NativeSlowPolicy {
+	pub(crate) fn new(starting_bytes: u64, expected_speed: Option<u64>) -> Self {
+		let now = Instant::now();
+		Self {
+			started_at: now,
+			window_started_at: now,
+			window_start_bytes: starting_bytes,
+			slow_windows: 0,
+			committed: false,
+			expected_speed,
+		}
+	}
+
+	pub(crate) fn observe(
+		&mut self,
+		downloaded: u64,
+		remaining: u64,
+	) -> SlowDecision {
+		if self.committed {
+			return SlowDecision::Continue;
+		}
+		let elapsed = self.window_started_at.elapsed();
+		if elapsed < WINDOW {
+			return SlowDecision::Continue;
+		}
+		let speed = downloaded
+			.saturating_sub(self.window_start_bytes)
+			.checked_div(elapsed.as_secs().max(1))
+			.unwrap_or(0);
+		self.window_started_at = Instant::now();
+		self.window_start_bytes = downloaded;
+
+		if remaining < MIN_REMAINING_BYTES
+			|| estimated_duration(remaining, speed)
+				<= RECONNECT_OVERHEAD + MIN_SAVINGS
+		{
+			self.committed = true;
+			return SlowDecision::Commit;
+		}
+		let expected_floor = self
+			.expected_speed
+			.map(|expected| expected.saturating_mul(40) / 100)
+			.unwrap_or(COLD_SPEED_FLOOR)
+			.max(ABSOLUTE_SPEED_FLOOR);
+		if speed < expected_floor {
+			self.slow_windows = self.slow_windows.saturating_add(1);
+		} else {
+			self.slow_windows = 0;
+		}
+		if self.started_at.elapsed() >= MIN_FLOW
+			&& self.slow_windows >= REQUIRED_SLOW_WINDOWS
+		{
+			self.slow_windows = 0;
+			SlowDecision::Probe {
+				bytes_per_second: speed,
+			}
+		} else {
+			SlowDecision::Continue
+		}
+	}
+
+	pub(crate) fn commit(&mut self) {
+		self.committed = true;
+	}
+}
+
+pub(crate) fn should_switch(
+	current_speed: u64,
+	candidate_speed: u64,
+	remaining_bytes: u64,
+	restart_bytes: u64,
+) -> bool {
+	if current_speed == 0 || candidate_speed == 0 {
+		return false;
+	}
+	if candidate_speed.saturating_mul(100)
+		< current_speed.saturating_mul(125)
+	{
+		return false;
+	}
+	let stay = estimated_duration(remaining_bytes, current_speed);
+	let switch = RECONNECT_OVERHEAD
+		+ estimated_duration(restart_bytes, candidate_speed);
+	let required_savings = MIN_SAVINGS.max(stay.mul_f64(0.15));
+	switch.saturating_add(required_savings) < stay
+}
+
+fn estimated_duration(bytes: u64, speed: u64) -> Duration {
+	if speed == 0 {
+		return Duration::MAX;
+	}
+	Duration::from_secs_f64(bytes as f64 / speed as f64)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn switch_requires_repayment_of_restarted_bytes() {
+		assert!(!should_switch(1024, 2048, 1024, 1024 * 1024));
+	}
+
+	#[test]
+	fn faster_candidate_wins_early_in_a_large_download() {
+		assert!(should_switch(
+			256 * 1024,
+			2 * 1024 * 1024,
+			64 * 1024 * 1024,
+			64 * 1024 * 1024,
+		));
+	}
+}

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -1362,6 +1362,18 @@ pub(crate) static DOWNLOAD_DNS_RESOLVER: LazyLock<Arc<DownloadDnsResolver>> =
     LazyLock::new(|| Arc::new(DownloadDnsResolver::default()));
 static TAIL_HEDGE_SEMAPHORE: LazyLock<Semaphore> =
     LazyLock::new(|| Semaphore::new(MAX_GLOBAL_TAIL_HEDGES));
+static FILE_VALIDATION_SEMAPHORE: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(4));
+
+async fn acquire_native_validation_permit()
+-> crate::Result<Option<SemaphorePermit<'static>>> {
+    if crate::util::download::active_engine()
+        == crate::util::download::DownloadEngine::XmclCompat
+    {
+        return Ok(None);
+    }
+    Ok(Some(FILE_VALIDATION_SEMAPHORE.acquire().await?))
+}
 
 static H2_FALLBACK_AUTHORITIES: LazyLock<Mutex<HashMap<String, Instant>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -3069,6 +3081,7 @@ async fn compute_file_integrity(
     path: &Path,
     integrity: &Integrity,
 ) -> crate::Result<ComputedIntegrity> {
+    let _permit = acquire_native_validation_permit().await?;
     let mut file = File::open(path)
         .await
         .map_err(|error| IOError::with_path(error, path))?;
@@ -3152,6 +3165,7 @@ pub(crate) async fn validate_file_content(
     if validation == ContentValidation::None {
         return Ok(());
     }
+    let _permit = acquire_native_validation_permit().await?;
     let path = path.to_path_buf();
     tokio::task::spawn_blocking(move || -> crate::Result<()> {
         let file = std::fs::File::open(&path)
@@ -3787,20 +3801,14 @@ async fn acquire_initial_segment_permits<'a>(
     count: usize,
 ) -> crate::Result<Vec<NativeConnectionPermit<'a>>> {
     let queue_started = Instant::now();
-    let mut batch = semaphore.0.acquire_many(count as u32).await?;
-    let mut global_permits = Vec::with_capacity(count);
-    while batch.num_permits() > 1 {
-        global_permits.push(
-            batch
-                .split(1)
-                .expect("a multi-permit semaphore guard can be split"),
-        );
-    }
-    global_permits.push(batch);
+    let native_permits =
+        crate::util::download::native_budget::acquire_many(route, count).await?;
+    let mut global = semaphore.0.acquire_many(count as u32).await?;
     let mut permits = Vec::with_capacity(count);
-    for global in global_permits {
-        let native = crate::util::download::native_budget::acquire(route)
-            .await?;
+    for native in native_permits {
+        let global = global
+            .split(1)
+            .expect("fetch permit batch has enough permits");
         permits.push(NativeConnectionPermit {
             _global: global,
             _native: native,
@@ -3836,9 +3844,9 @@ fn try_acquire_native_connection<'a>(
     route: &DownloadRoute,
     semaphore: &'a FetchSemaphore,
 ) -> Option<NativeConnectionPermit<'a>> {
-    let global = semaphore.0.try_acquire().ok()?;
     let native =
         crate::util::download::native_budget::try_acquire(route).ok()?;
+    let global = semaphore.0.try_acquire().ok()?;
     Some(NativeConnectionPermit {
         _global: global,
         _native: native,

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -50,7 +50,7 @@ const METADATA_HEDGE_DELAY: time::Duration = time::Duration::from_secs(2);
 const METADATA_HEDGE_DELAY: time::Duration = time::Duration::from_millis(100);
 const SEGMENTED_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 const INITIAL_SEGMENT_CONCURRENCY: usize = 4;
-const MAX_SEGMENT_CONCURRENCY: usize = 8;
+const MAX_SEGMENT_CONCURRENCY: usize = 4;
 const MIN_SEGMENT_SIZE: u64 = 256 * 1024;
 const ROUTE_PROBE_BYTES: u64 = 256 * 1024;
 const ROUTE_PROBE_MIN_IMPROVEMENT_PERCENT: u64 = 25;
@@ -3781,11 +3781,11 @@ fn configured_semaphore_limit(semaphore: &FetchSemaphore) -> usize {
     semaphore.0.available_permits().max(1)
 }
 
-async fn acquire_initial_segment_permits(
+async fn acquire_initial_segment_permits<'a>(
     route: &DownloadRoute,
-    semaphore: &FetchSemaphore,
+    semaphore: &'a FetchSemaphore,
     count: usize,
-) -> crate::Result<Vec<NativeConnectionPermit<'_>>> {
+) -> crate::Result<Vec<NativeConnectionPermit<'a>>> {
     let queue_started = Instant::now();
     let mut batch = semaphore.0.acquire_many(count as u32).await?;
     let mut global_permits = Vec::with_capacity(count);
@@ -3799,11 +3799,11 @@ async fn acquire_initial_segment_permits(
     global_permits.push(batch);
     let mut permits = Vec::with_capacity(count);
     for global in global_permits {
-        let authority = crate::util::download::native_budget::acquire(route)
+        let native = crate::util::download::native_budget::acquire(route)
             .await?;
         permits.push(NativeConnectionPermit {
             _global: global,
-            _authority: authority,
+            _native: native,
         });
     }
     tracing::debug!(
@@ -3816,19 +3816,19 @@ async fn acquire_initial_segment_permits(
 
 struct NativeConnectionPermit<'a> {
     _global: SemaphorePermit<'a>,
-    _authority: Option<tokio::sync::OwnedSemaphorePermit>,
+    _native: crate::util::download::native_budget::NativeBudgetPermit,
 }
 
 async fn acquire_native_connection<'a>(
     route: &DownloadRoute,
     semaphore: &'a FetchSemaphore,
 ) -> crate::Result<NativeConnectionPermit<'a>> {
-    let global = semaphore.0.acquire().await?;
-    let authority =
+    let native =
         crate::util::download::native_budget::acquire(route).await?;
+    let global = semaphore.0.acquire().await?;
     Ok(NativeConnectionPermit {
         _global: global,
-        _authority: authority,
+        _native: native,
     })
 }
 
@@ -3837,11 +3837,11 @@ fn try_acquire_native_connection<'a>(
     semaphore: &'a FetchSemaphore,
 ) -> Option<NativeConnectionPermit<'a>> {
     let global = semaphore.0.try_acquire().ok()?;
-    let authority =
+    let native =
         crate::util::download::native_budget::try_acquire(route).ok()?;
     Some(NativeConnectionPermit {
         _global: global,
-        _authority: authority,
+        _native: native,
     })
 }
 
@@ -5617,25 +5617,36 @@ async fn download_to_path_inner(
 
     prepare_native_download_routes(&request, &mut routes, semaphore).await;
 
-    // Prefer a multiplexed HTTP/2 download over a shared per-authority
-    // connection: one handshake per CDN instead of one per file, and range
-    // streams for large files. Any failure falls through to the legacy path.
+    // Prefer one stream on a healthy shared HTTP/2 connection when the file
+    // size and transport reputation justify it. Larger or slow H2 transfers
+    // fall through to independent HTTP/1.1 range connections.
     let mut h2_failed_nonofficial = None;
-    if request.allow_segmented_download
+    let h2_selection = if request.allow_segmented_download
         && !part_resume_expected(&part_path).await
         && !request.url.starts_with("http://")
-        && request
-            .integrity
-            .size
-            .is_none_or(|size| size < SEGMENTED_DOWNLOAD_THRESHOLD)
-        && let Some(h2_route) = routes.first().cloned()
     {
+        if let Some(h2_route) = routes.first().cloned() {
+            crate::util::download::native::h2_policy(
+                &h2_route,
+                request.integrity.size,
+            )
+            .await
+            .map(|policy| (h2_route, policy))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    if let Some((h2_route, h2_policy)) = h2_selection {
         let h2_permit = acquire_native_connection(&h2_route, semaphore).await?;
+        let h2_started = Instant::now();
         match crate::util::download::h2_download::try_download_via_h2(
             &request,
             &h2_route,
             destination,
             &part_path,
+            h2_policy,
         )
         .await
         {
@@ -5645,6 +5656,15 @@ async fn download_to_path_inner(
                 crate::util::download::native_breaker::record_success(
                     &h2_route,
                 );
+                if let Some(authority) = original_route_authority(&h2_route) {
+                    crate::util::download::native_reputation::record_transport_success(
+                        &authority,
+                        h2_route.proxy,
+                        crate::util::download::native_reputation::NativeTransport::H2Single,
+                        result.size as f64
+                            / h2_started.elapsed().as_secs_f64().max(0.001),
+                    );
+                }
                 if let Some(tracking) = &request.install_tracking
                     && let Err(error) = tracking
                         .reporter
@@ -5836,6 +5856,20 @@ async fn download_to_path_inner(
                     {
                         SegmentedDownloadOutcome::Success(result) => {
                             finalize_download(&part_path, destination).await?;
+                            if let Some(authority) =
+                                original_route_authority(route)
+                            {
+                                crate::util::download::native_reputation::record_transport_success(
+                                    &authority,
+                                    route.proxy,
+                                    crate::util::download::native_reputation::NativeTransport::Http1MultiRange,
+                                    result.size as f64
+                                        / result
+                                            .transfer_elapsed
+                                            .as_secs_f64()
+                                            .max(0.001),
+                                );
+                            }
                             record_route_success(
                                 route,
                                 request.resource,
@@ -8089,7 +8123,7 @@ mod tests {
     #[test]
     fn segmented_concurrency_respects_effective_and_global_limits() {
         assert_eq!(segmented_concurrency_cap(64), MAX_SEGMENT_CONCURRENCY);
-        assert_eq!(segmented_concurrency_cap(8), 8);
+        assert_eq!(segmented_concurrency_cap(8), 4);
         assert_eq!(segmented_concurrency_cap(4), 4);
         assert_eq!(segmented_concurrency_cap(1), 1);
         assert_eq!(initial_segment_count(16 * 1024 * 1024, 3), 3);
@@ -8099,6 +8133,10 @@ mod tests {
     async fn segmented_permits_wait_fairly_instead_of_falling_back() {
         let semaphore = FetchSemaphore(Semaphore::new(4));
         let held = semaphore.0.acquire_many(4).await.unwrap();
+        let route = direct_test_route(
+            "https://example.com/file".to_string(),
+            DownloadRouteSource::Official,
+        );
         let started = Instant::now();
         let (_, permits) = tokio::join!(
             async move {
@@ -8106,7 +8144,7 @@ mod tests {
                 drop(held);
             },
             acquire_initial_segment_permits(
-                &direct_test_route("https://example.com/file"),
+                &route,
                 &semaphore,
                 4,
             ),
@@ -8134,7 +8172,7 @@ mod tests {
         assert_eq!(route_segmented_concurrency_cap(&bmclapi, 64), 4);
         assert_eq!(
             route_segmented_concurrency_cap(&official, 64),
-            8
+            4
         );
     }
 
@@ -8667,7 +8705,9 @@ mod tests {
             .unwrap();
         let semaphore = FetchSemaphore(Semaphore::new(4));
         let (progress, _receiver) = tokio::sync::mpsc::unbounded_channel();
-        let permit = semaphore.0.acquire().await.unwrap();
+        let permit = acquire_native_connection(&route, &semaphore)
+            .await
+            .unwrap();
         let speed = DownloadSpeedTracker::default();
         let validator = Mutex::new(None);
         let result = download_segment(

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -3802,7 +3802,8 @@ async fn acquire_initial_segment_permits<'a>(
 ) -> crate::Result<Vec<NativeConnectionPermit<'a>>> {
     let queue_started = Instant::now();
     let native_permits =
-        crate::util::download::native_budget::acquire_many(route, count).await?;
+        crate::util::download::native_budget::acquire_many(route, count)
+            .await?;
     let mut global = semaphore.0.acquire_many(count as u32).await?;
     let mut permits = Vec::with_capacity(count);
     for native in native_permits {
@@ -3831,8 +3832,7 @@ async fn acquire_native_connection<'a>(
     route: &DownloadRoute,
     semaphore: &'a FetchSemaphore,
 ) -> crate::Result<NativeConnectionPermit<'a>> {
-    let native =
-        crate::util::download::native_budget::acquire(route).await?;
+    let native = crate::util::download::native_budget::acquire(route).await?;
     let global = semaphore.0.acquire().await?;
     Ok(NativeConnectionPermit {
         _global: global,
@@ -4132,14 +4132,13 @@ fn route_health_is_cold(
             .get(&key)
             .map(|entry| entry.success_samples)
             .unwrap_or(0);
-        let persisted_samples =
-            crate::util::download::native_reputation::get(
-                key.family.as_str(),
-                &key.authority,
-                route.proxy,
-            )
-            .map(|entry| entry.success_samples)
-            .unwrap_or(0);
+        let persisted_samples = crate::util::download::native_reputation::get(
+            key.family.as_str(),
+            &key.authority,
+            route.proxy,
+        )
+        .map(|entry| entry.success_samples)
+        .unwrap_or(0);
         in_memory_samples.max(persisted_samples)
             < COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD
     })
@@ -4946,8 +4945,7 @@ async fn try_segmented_download(
     let configured_limit = configured_semaphore_limit(semaphore);
     let concurrency_cap =
         route_segmented_concurrency_cap(route, configured_limit);
-    let requested_initial_count =
-        initial_segment_count(size, concurrency_cap);
+    let requested_initial_count = initial_segment_count(size, concurrency_cap);
     if requested_initial_count < 2 {
         tracing::debug!(
             original_url = %sanitize_url_for_log(&route.url),
@@ -5022,10 +5020,11 @@ async fn try_segmented_download(
     let mut expansion_exhausted = false;
     let mut last_block_reason = None;
     let mut downloaded = 0_u64;
-    let mut slow_policy = crate::util::download::native_slow::NativeSlowPolicy::new(
-        0,
-        expected_route_speed(route, request.resource),
-    );
+    let mut slow_policy =
+        crate::util::download::native_slow::NativeSlowPolicy::new(
+            0,
+            expected_route_speed(route, request.resource),
+        );
     let mut alternate_probe: Option<RouteProbeFuture<'_>> = None;
     let mut alternate_probe_finished = false;
     let mut confirmed_switch = None;
@@ -5321,8 +5320,7 @@ async fn try_segmented_download(
     }
     let computed = hashers.finish(merged_size);
     record_install_download_stage(request, DownloadItemStatus::Verifying).await;
-    if let Err(error) =
-        verify_computed_integrity(&request.integrity, &computed)
+    if let Err(error) = verify_computed_integrity(&request.integrity, &computed)
     {
         let _ = remove_if_exists(part_path).await;
         return SegmentedDownloadOutcome::IntegrityFailed(error);
@@ -5765,9 +5763,9 @@ async fn download_to_path_inner(
                 || single_thread_routes.contains(&route.url);
             if !recovery_route
                 && crate::util::download::native_breaker::should_skip(
-                route,
-                has_breaker_alternate,
-            )
+                    route,
+                    has_breaker_alternate,
+                )
             {
                 continue;
             }
@@ -5980,11 +5978,7 @@ async fn download_to_path_inner(
                             break;
                         }
                         SegmentedDownloadOutcome::IntegrityFailed(error) => {
-                            record_route_failure(
-                                route,
-                                request.resource,
-                                None,
-                            );
+                            record_route_failure(route, request.resource, None);
                             record_download_attempt_failure(
                                 &mut attempt_history,
                                 route,
@@ -6066,7 +6060,8 @@ async fn download_to_path_inner(
                 } else {
                     0
                 };
-                let permit = acquire_native_connection(route, semaphore).await?;
+                let permit =
+                    acquire_native_connection(route, semaphore).await?;
                 let mut activity = crate::State::get_if_initialized()
                     .map(|state| state.begin_download_connection());
                 record_install_download_started(
@@ -6192,9 +6187,11 @@ async fn download_to_path_inner(
                             route,
                             request.resource,
                             (status == StatusCode::TOO_MANY_REQUESTS)
-                                .then_some(response_retry_after.unwrap_or_else(
-                                    || fetch_retry_delay(attempts),
-                                )),
+                                .then_some(
+                                    response_retry_after.unwrap_or_else(|| {
+                                        fetch_retry_delay(attempts)
+                                    }),
+                                ),
                         );
                         if status == StatusCode::TOO_MANY_REQUESTS
                             || status.is_server_error()
@@ -6241,18 +6238,18 @@ async fn download_to_path_inner(
                         )
                         .await;
                     }
-                    let decision = if status == StatusCode::RANGE_NOT_SATISFIABLE
-                    {
-                        "disable_range_and_retry_single"
-                    } else if terminal_status {
-                        "drop_route"
-                    } else if cooldown_and_switch {
-                        "cooldown_and_switch"
-                    } else if status == StatusCode::TOO_MANY_REQUESTS {
-                        "cooldown_then_retry"
-                    } else {
-                        "retry_next_round"
-                    };
+                    let decision =
+                        if status == StatusCode::RANGE_NOT_SATISFIABLE {
+                            "disable_range_and_retry_single"
+                        } else if terminal_status {
+                            "drop_route"
+                        } else if cooldown_and_switch {
+                            "cooldown_and_switch"
+                        } else if status == StatusCode::TOO_MANY_REQUESTS {
+                            "cooldown_then_retry"
+                        } else {
+                            "retry_next_round"
+                        };
                     record_download_attempt_failure(
                         &mut attempt_history,
                         route,
@@ -6694,8 +6691,7 @@ async fn download_to_path_inner(
                         || attempts >= 2
                     {
                         terminal_routes.insert(route.url.clone());
-                        if is_official_route(route)
-                            && official_integrity_retry
+                        if is_official_route(route) && official_integrity_retry
                         {
                             return Err(attach_download_attempt_history(
                                 last_error.take().unwrap(),
@@ -8151,11 +8147,7 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 drop(held);
             },
-            acquire_initial_segment_permits(
-                &route,
-                &semaphore,
-                4,
-            ),
+            acquire_initial_segment_permits(&route, &semaphore, 4,),
         );
         let permits = permits.unwrap();
         assert_eq!(permits.len(), 4);
@@ -8178,10 +8170,7 @@ mod tests {
         );
 
         assert_eq!(route_segmented_concurrency_cap(&bmclapi, 64), 4);
-        assert_eq!(
-            route_segmented_concurrency_cap(&official, 64),
-            4
-        );
+        assert_eq!(route_segmented_concurrency_cap(&official, 64), 4);
     }
 
     #[test]
@@ -8374,7 +8363,7 @@ mod tests {
             &client,
             &client,
             ResourceClass::Other,
-			0,
+            0,
         )
         .await
         .expect("the local range route should be measurably faster");
@@ -8403,7 +8392,7 @@ mod tests {
                 &client,
                 &client,
                 ResourceClass::Other,
-				0,
+                0,
             )
             .await
             .is_none()
@@ -8713,9 +8702,8 @@ mod tests {
             .unwrap();
         let semaphore = FetchSemaphore(Semaphore::new(4));
         let (progress, _receiver) = tokio::sync::mpsc::unbounded_channel();
-        let permit = acquire_native_connection(&route, &semaphore)
-            .await
-            .unwrap();
+        let permit =
+            acquire_native_connection(&route, &semaphore).await.unwrap();
         let speed = DownloadSpeedTracker::default();
         let validator = Mutex::new(None);
         let result = download_segment(

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -50,7 +50,7 @@ const METADATA_HEDGE_DELAY: time::Duration = time::Duration::from_secs(2);
 const METADATA_HEDGE_DELAY: time::Duration = time::Duration::from_millis(100);
 const SEGMENTED_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 const INITIAL_SEGMENT_CONCURRENCY: usize = 4;
-const MAX_SEGMENT_CONCURRENCY: usize = 12;
+const MAX_SEGMENT_CONCURRENCY: usize = 8;
 const MIN_SEGMENT_SIZE: u64 = 256 * 1024;
 const ROUTE_PROBE_BYTES: u64 = 256 * 1024;
 const ROUTE_PROBE_MIN_IMPROVEMENT_PERCENT: u64 = 25;
@@ -1572,6 +1572,7 @@ fn record_route_success(
         if crate::util::download::active_engine()
             != crate::util::download::DownloadEngine::XmclCompat
         {
+            crate::util::download::native_breaker::record_success(route);
             crate::util::download::native_reputation::record_success(
                 key.family.as_str(),
                 &key.authority,
@@ -1604,6 +1605,24 @@ fn record_route_failure(
         state.record_download_error();
     }
     record_route_health_failure(route, resource, cooldown);
+}
+
+fn record_native_transfer_failure(
+    route: &DownloadRoute,
+    cooldown: Option<time::Duration>,
+) {
+    if crate::util::download::active_engine()
+        == crate::util::download::DownloadEngine::XmclCompat
+    {
+        return;
+    }
+    if let Some(cooldown) = cooldown {
+        crate::util::download::native_breaker::record_failure_with_cooldown(
+            route, cooldown,
+        );
+    } else {
+        crate::util::download::native_breaker::record_failure(route);
+    }
 }
 
 fn record_route_health_failure(
@@ -3735,7 +3754,11 @@ fn route_segmented_concurrency_cap(
     route: &DownloadRoute,
     available_permits: usize,
 ) -> usize {
-    let cap = segmented_concurrency_cap(available_permits);
+    let fair_share = (available_permits / 2).max(2);
+    let cap = segmented_concurrency_cap(available_permits)
+        .min(fair_share)
+        .min(8)
+        .min(crate::util::download::native_budget::available(route));
     if route.source == DownloadRouteSource::Bmclapi
         || route.source == DownloadRouteSource::Tianpao
         || is_modrinth_cdn_url(&route.url)
@@ -3759,26 +3782,67 @@ fn configured_semaphore_limit(semaphore: &FetchSemaphore) -> usize {
 }
 
 async fn acquire_initial_segment_permits(
+    route: &DownloadRoute,
     semaphore: &FetchSemaphore,
     count: usize,
-) -> crate::Result<Vec<SemaphorePermit<'_>>> {
+) -> crate::Result<Vec<NativeConnectionPermit<'_>>> {
     let queue_started = Instant::now();
     let mut batch = semaphore.0.acquire_many(count as u32).await?;
-    let mut permits = Vec::with_capacity(count);
+    let mut global_permits = Vec::with_capacity(count);
     while batch.num_permits() > 1 {
-        permits.push(
+        global_permits.push(
             batch
                 .split(1)
                 .expect("a multi-permit semaphore guard can be split"),
         );
     }
-    permits.push(batch);
+    global_permits.push(batch);
+    let mut permits = Vec::with_capacity(count);
+    for global in global_permits {
+        let authority = crate::util::download::native_budget::acquire(route)
+            .await?;
+        permits.push(NativeConnectionPermit {
+            _global: global,
+            _authority: authority,
+        });
+    }
     tracing::debug!(
         queue_wait_ms = queue_started.elapsed().as_millis(),
         actual_segments = permits.len(),
         "Acquired initial segmented download permits"
     );
     Ok(permits)
+}
+
+struct NativeConnectionPermit<'a> {
+    _global: SemaphorePermit<'a>,
+    _authority: Option<tokio::sync::OwnedSemaphorePermit>,
+}
+
+async fn acquire_native_connection<'a>(
+    route: &DownloadRoute,
+    semaphore: &'a FetchSemaphore,
+) -> crate::Result<NativeConnectionPermit<'a>> {
+    let global = semaphore.0.acquire().await?;
+    let authority =
+        crate::util::download::native_budget::acquire(route).await?;
+    Ok(NativeConnectionPermit {
+        _global: global,
+        _authority: authority,
+    })
+}
+
+fn try_acquire_native_connection<'a>(
+    route: &DownloadRoute,
+    semaphore: &'a FetchSemaphore,
+) -> Option<NativeConnectionPermit<'a>> {
+    let global = semaphore.0.try_acquire().ok()?;
+    let authority =
+        crate::util::download::native_budget::try_acquire(route).ok()?;
+    Some(NativeConnectionPermit {
+        _global: global,
+        _authority: authority,
+    })
 }
 
 fn initial_segment_count(size: u64, available_permits: usize) -> usize {
@@ -3910,7 +3974,7 @@ async fn probe_route_throughput(
     }
     let probe_bytes = ROUTE_PROBE_BYTES.min(total_size);
     let probe_end = probe_bytes.checked_sub(1)?;
-    let _permit = semaphore.0.acquire().await.ok()?;
+    let _permit = acquire_native_connection(route, semaphore).await.ok()?;
     let started = Instant::now();
     let response = tokio::time::timeout(
         ROUTE_PROBE_TIMEOUT,
@@ -4492,7 +4556,7 @@ async fn download_segment(
     credentials: Option<&crate::state::ModrinthCredentials>,
     download_meta: Option<&DownloadMeta>,
     part_path: &Path,
-    _permit: SemaphorePermit<'_>,
+    _permit: NativeConnectionPermit<'_>,
     system_client: &reqwest::Client,
     direct_client: &reqwest::Client,
     progress: tokio::sync::mpsc::UnboundedSender<u64>,
@@ -4641,8 +4705,9 @@ async fn download_segment(
                             < MAX_TAIL_HEDGES_PER_FILE;
                     if hedge_reserved {
                         let global_permit = TAIL_HEDGE_SEMAPHORE.try_acquire();
-                        let connection_permit = semaphore.0.try_acquire();
-                        if let (Ok(_global_permit), Ok(_connection_permit)) =
+                        let connection_permit =
+                            try_acquire_native_connection(route, semaphore);
+                        if let (Ok(_global_permit), Some(_connection_permit)) =
                             (global_permit, connection_permit)
                         {
                             hedge_count.fetch_add(1, Ordering::AcqRel);
@@ -4873,7 +4938,8 @@ async fn try_segmented_download(
     let configured_limit = configured_semaphore_limit(semaphore);
     let concurrency_cap =
         route_segmented_concurrency_cap(route, configured_limit);
-    let requested_initial_count = initial_segment_count(size, configured_limit);
+    let requested_initial_count =
+        initial_segment_count(size, concurrency_cap);
     if requested_initial_count < 2 {
         tracing::debug!(
             original_url = %sanitize_url_for_log(&route.url),
@@ -4888,6 +4954,7 @@ async fn try_segmented_download(
         };
     }
     let permits = match acquire_initial_segment_permits(
+        route,
         semaphore,
         requested_initial_count,
     )
@@ -4943,6 +5010,8 @@ async fn try_segmented_download(
     let mut scheduler = tokio::time::interval(time::Duration::from_millis(250));
     scheduler.tick().await;
     let mut last_expansion = Instant::now();
+    let mut expansion_baseline = None;
+    let mut expansion_exhausted = false;
     let mut last_block_reason = None;
     let mut downloaded = 0_u64;
     let mut slow_policy = crate::util::download::native_slow::NativeSlowPolicy::new(
@@ -5059,6 +5128,25 @@ async fn try_segmented_download(
                     .filter(|range| range.is_active())
                     .map(DownloadRange::remaining)
                     .sum();
+                if expansion_exhausted {
+                    continue;
+                }
+                if last_expansion.elapsed() >= SEGMENT_EXPANSION_INTERVAL
+                    && let Some(baseline) = expansion_baseline.take()
+                {
+                    if u128::from(snapshot.recent_average) * 100
+                        < u128::from(baseline) * 115
+                    {
+                        expansion_exhausted = true;
+                        tracing::debug!(
+                            original_url = %sanitize_url_for_log(&route.url),
+                            baseline_speed = baseline,
+                            expanded_speed = snapshot.recent_average,
+                            "Stopping range expansion because the last connection added less than 15 percent throughput"
+                        );
+                        continue;
+                    }
+                }
                 if let Some(reason) = expansion_block_reason(
                     snapshot,
                     active_ranges,
@@ -5089,7 +5177,8 @@ async fn try_segmented_download(
                     .max_by_key(|range| range.remaining())
                     .cloned();
                 if let Some(range) = range
-                    && let Ok(permit) = semaphore.0.try_acquire()
+                    && let Some(permit) =
+                        try_acquire_native_connection(route, semaphore)
                     && let Some(new_range) =
                         range.split_tail(next_range_index)
                     {
@@ -5127,6 +5216,7 @@ async fn try_segmented_download(
                             &hedge_active,
                         ));
                         ranges.push(new_range);
+                        expansion_baseline = Some(snapshot.recent_average);
                         last_expansion = Instant::now();
                         last_block_reason = None;
                     }
@@ -5534,8 +5624,13 @@ async fn download_to_path_inner(
     if request.allow_segmented_download
         && !part_resume_expected(&part_path).await
         && !request.url.starts_with("http://")
+        && request
+            .integrity
+            .size
+            .is_none_or(|size| size < SEGMENTED_DOWNLOAD_THRESHOLD)
         && let Some(h2_route) = routes.first().cloned()
     {
+        let h2_permit = acquire_native_connection(&h2_route, semaphore).await?;
         match crate::util::download::h2_download::try_download_via_h2(
             &request,
             &h2_route,
@@ -5547,6 +5642,9 @@ async fn download_to_path_inner(
             crate::util::download::h2_download::H2DownloadOutcome::Completed(
                 result,
             ) => {
+                crate::util::download::native_breaker::record_success(
+                    &h2_route,
+                );
                 if let Some(tracking) = &request.install_tracking
                     && let Err(error) = tracking
                         .reporter
@@ -5581,6 +5679,9 @@ async fn download_to_path_inner(
                 {
                     record_authority_h2_failure(&authority);
                 }
+                if failure.is_transfer_failure() {
+                    record_native_transfer_failure(&h2_route, None);
+                }
                 tracing::debug!(
                     url = %sanitize_url_for_log(&h2_route.url),
                     source = h2_route.source.as_str(),
@@ -5596,6 +5697,7 @@ async fn download_to_path_inner(
                     .await?;
             }
         }
+        drop(h2_permit);
     }
 
     let mut official_integrity_retry = h2_failed_nonofficial.is_some();
@@ -5620,6 +5722,25 @@ async fn download_to_path_inner(
         let mut attempted_routes = Vec::new();
         for (route_index, route) in routes.iter().enumerate() {
             if terminal_routes.contains(&route.url) {
+                continue;
+            }
+            let has_breaker_alternate = routes.iter().enumerate().any(
+                |(candidate_index, candidate)| {
+                    candidate_index != route_index
+                        && !terminal_routes.contains(&candidate.url)
+                        && !crate::util::download::native_breaker::is_open(
+                            candidate,
+                        )
+                },
+            );
+            let recovery_route = preferred_route.as_ref() == Some(route)
+                || single_thread_routes.contains(&route.url);
+            if !recovery_route
+                && crate::util::download::native_breaker::should_skip(
+                route,
+                has_breaker_alternate,
+            )
+            {
                 continue;
             }
             if preferred_route
@@ -5705,8 +5826,8 @@ async fn download_to_path_inner(
                         semaphore,
                         credentials.as_ref(),
                         progress.as_deref_mut(),
-                        &NO_REDIRECT_REQWEST_CLIENT,
-                        &DIRECT_REQWEST_CLIENT,
+                        &HTTP1_NO_REDIRECT_REQWEST_CLIENT,
+                        &HTTP1_DIRECT_REQWEST_CLIENT,
                         attempts,
                         file_attempt_budget,
                         allow_low_throughput_abort,
@@ -5789,6 +5910,7 @@ async fn download_to_path_inner(
                         }
                         SegmentedDownloadOutcome::SourceFailed => {
                             record_route_failure(route, request.resource, None);
+                            record_native_transfer_failure(route, None);
                             let error: crate::Error = ErrorKind::OtherError(
                                 format!("File transfer failed from {log_url}"),
                             )
@@ -5902,7 +6024,7 @@ async fn download_to_path_inner(
                 } else {
                     0
                 };
-                let permit = semaphore.0.acquire().await?;
+                let permit = acquire_native_connection(route, semaphore).await?;
                 let mut activity = crate::State::get_if_initialized()
                     .map(|state| state.begin_download_connection());
                 record_install_download_started(
@@ -5945,6 +6067,7 @@ async fn download_to_path_inner(
                         drop(permit);
                         drop(activity.take());
                         record_route_failure(route, request.resource, None);
+                        record_native_transfer_failure(route, None);
                         record_download_attempt_failure(
                             &mut attempt_history,
                             route,
@@ -5971,6 +6094,7 @@ async fn download_to_path_inner(
                         drop(permit);
                         drop(activity.take());
                         record_route_failure(route, request.resource, None);
+                        record_native_transfer_failure(route, None);
                         let error = ErrorKind::NetworkError(format!(
                             "no response received for {:.0} seconds while downloading {log_url} to {}",
                             first_byte_timeout.as_secs_f64(),
@@ -6030,6 +6154,14 @@ async fn download_to_path_inner(
                                     || fetch_retry_delay(attempts),
                                 )),
                         );
+                        if status == StatusCode::TOO_MANY_REQUESTS
+                            || status.is_server_error()
+                        {
+                            record_native_transfer_failure(
+                                route,
+                                response_retry_after,
+                            );
+                        }
                     }
                     let error = response_status_error(
                         response,
@@ -6371,6 +6503,7 @@ async fn download_to_path_inner(
 
                 if let Some(error) = transfer_error {
                     record_route_failure(route, request.resource, None);
+                    record_native_transfer_failure(route, None);
                     preserve_or_remove_partial(
                         &part_path,
                         &request.integrity,
@@ -7972,7 +8105,11 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 drop(held);
             },
-            acquire_initial_segment_permits(&semaphore, 4),
+            acquire_initial_segment_permits(
+                &direct_test_route("https://example.com/file"),
+                &semaphore,
+                4,
+            ),
         );
         let permits = permits.unwrap();
         assert_eq!(permits.len(), 4);
@@ -7997,7 +8134,7 @@ mod tests {
         assert_eq!(route_segmented_concurrency_cap(&bmclapi, 64), 4);
         assert_eq!(
             route_segmented_concurrency_cap(&official, 64),
-            MAX_SEGMENT_CONCURRENCY
+            8
         );
     }
 

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -953,6 +953,17 @@ fn official_route(url: &str, resource: ResourceClass) -> DownloadRoute {
     route
 }
 
+fn is_official_route(route: &DownloadRoute) -> bool {
+    !route.is_mirror && route.source == DownloadRouteSource::Official
+}
+
+fn official_fallback_route(routes: &[DownloadRoute]) -> Option<DownloadRoute> {
+    routes
+        .iter()
+        .find(|candidate| is_official_route(candidate))
+        .cloned()
+}
+
 fn url_with_base(original: &Url, base: &str, path: &str) -> Option<String> {
     let mut target = Url::parse(base).ok()?;
     target.set_path(path);
@@ -3599,6 +3610,7 @@ enum SegmentedDownloadOutcome {
     },
     SwitchRoute(RouteProbeResult),
     SourceFailed,
+    IntegrityFailed(crate::Error),
     Fatal(crate::Error),
 }
 
@@ -4561,6 +4573,11 @@ async fn download_segment(
                 "server ignored Range and returned 200",
             ));
         }
+        if response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+            return Err(SegmentDownloadError::Protocol(
+                "server returned HTTP 416 for range request",
+            ));
+        }
         if response.status() != StatusCode::PARTIAL_CONTENT {
             if attempt < SEGMENT_RETRY_ATTEMPTS {
                 tokio::time::sleep(fetch_retry_delay(attempt)).await;
@@ -5206,12 +5223,11 @@ async fn try_segmented_download(
     }
     let computed = hashers.finish(merged_size);
     record_install_download_stage(request, DownloadItemStatus::Verifying).await;
-    if verify_computed_integrity(&request.integrity, &computed).is_err() {
+    if let Err(error) =
+        verify_computed_integrity(&request.integrity, &computed)
+    {
         let _ = remove_if_exists(part_path).await;
-        return SegmentedDownloadOutcome::FallbackSingle {
-            disable_range: true,
-            reason: "segmented integrity validation failed",
-        };
+        return SegmentedDownloadOutcome::IntegrityFailed(error);
     }
     if validate_file_content(part_path, request.integrity.content)
         .await
@@ -5514,7 +5530,7 @@ async fn download_to_path_inner(
     // Prefer a multiplexed HTTP/2 download over a shared per-authority
     // connection: one handshake per CDN instead of one per file, and range
     // streams for large files. Any failure falls through to the legacy path.
-    let mut h2_failed_mirror = None;
+    let mut h2_failed_nonofficial = None;
     if request.allow_segmented_download
         && !part_resume_expected(&part_path).await
         && !request.url.starts_with("http://")
@@ -5552,8 +5568,8 @@ async fn download_to_path_inner(
                 preserve_partial,
             } => {
                 if failure.integrity_failure() {
-                    if h2_route.is_mirror {
-                        h2_failed_mirror = Some(h2_route.url.clone());
+                    if !is_official_route(&h2_route) {
+                        h2_failed_nonofficial = Some(h2_route.url.clone());
                         tracing::warn!(
                             url = %sanitize_url_for_log(&h2_route.url),
                             source = h2_route.source.as_str(),
@@ -5582,7 +5598,8 @@ async fn download_to_path_inner(
         }
     }
 
-    if let Some(failed_route) = h2_failed_mirror.take() {
+    let mut official_integrity_retry = h2_failed_nonofficial.is_some();
+    if let Some(failed_route) = h2_failed_nonofficial.take() {
         routes.retain(|route| route.url != failed_route);
     }
     let mut attempts = 0;
@@ -5591,7 +5608,10 @@ async fn download_to_path_inner(
     let mut fallback_count = 0;
     let mut partial_route_index = None;
     let mut terminal_routes = HashSet::new();
-    let mut preferred_route = None;
+    let mut preferred_route = official_integrity_retry
+        .then(|| official_fallback_route(&routes))
+        .flatten();
+    let mut single_thread_routes = HashSet::new();
     let mut busted_for_route: Option<(usize, String)> = None;
     let file_attempt_budget = routes.len().saturating_mul(3).max(1);
     for (round, retry_with_single_thread) in
@@ -5665,6 +5685,7 @@ async fn download_to_path_inner(
                 // resuming it over a single connection wastes less transfer.
                 if request.allow_segmented_download
                     && !retry_with_single_thread
+                    && !single_thread_routes.contains(&route.url)
                     && route.supports_range
                     && range_splitting_allowed(route)
                     && request.integrity.size.is_some_and(|size| {
@@ -5793,6 +5814,49 @@ async fn download_to_path_inner(
                                 "Segmented file download failed; retrying or switching source"
                             );
                             break;
+                        }
+                        SegmentedDownloadOutcome::IntegrityFailed(error) => {
+                            record_route_failure(
+                                route,
+                                request.resource,
+                                None,
+                            );
+                            record_download_attempt_failure(
+                                &mut attempt_history,
+                                route,
+                                attempts,
+                                &error,
+                                if is_official_route(route) {
+                                    "abort"
+                                } else {
+                                    "fallback_official"
+                                },
+                                None,
+                                None,
+                                None,
+                            );
+                            last_error = Some(error);
+                            terminal_routes.insert(route.url.clone());
+                            if !is_official_route(route)
+                                && let Some(official) =
+                                    official_fallback_route(&routes)
+                            {
+                                remove_if_exists(&part_path).await?;
+                                official_integrity_retry = true;
+                                preferred_route = Some(official);
+                                break;
+                            }
+                            if official_integrity_retry {
+                                return Err(attach_download_attempt_history(
+                                    last_error.take().unwrap(),
+                                    &attempt_history,
+                                    attempts,
+                                    file_attempt_budget,
+                                ));
+                            }
+                            disable_range_splitting(route);
+                            single_thread_routes.insert(route.url.clone());
+                            terminal_routes.remove(&route.url);
                         }
                         SegmentedDownloadOutcome::SwitchRoute(probe) => {
                             preferred_route = Some(probe.route);
@@ -5957,14 +6021,16 @@ async fn download_to_path_inner(
                     "Received file download response"
                 );
                 if status.is_client_error() || status.is_server_error() {
-                    record_route_failure(
-                        route,
-                        request.resource,
-                        (status == StatusCode::TOO_MANY_REQUESTS)
-                            .then_some(response_retry_after.unwrap_or_else(
-                                || fetch_retry_delay(attempts),
-                            )),
-                    );
+                    if status != StatusCode::RANGE_NOT_SATISFIABLE {
+                        record_route_failure(
+                            route,
+                            request.resource,
+                            (status == StatusCode::TOO_MANY_REQUESTS)
+                                .then_some(response_retry_after.unwrap_or_else(
+                                    || fetch_retry_delay(attempts),
+                                )),
+                        );
+                    }
                     let error = response_status_error(
                         response,
                         &Method::GET,
@@ -5973,10 +6039,11 @@ async fn download_to_path_inner(
                     .await;
                     drop(permit);
                     drop(activity.take());
-                    if resume_offset > 0
-                        && status == StatusCode::RANGE_NOT_SATISFIABLE
-                    {
+                    if status == StatusCode::RANGE_NOT_SATISFIABLE {
                         remove_if_exists(&part_path).await?;
+                        disable_range_splitting(route);
+                        single_thread_routes.insert(route.url.clone());
+                        preferred_route = Some(route.clone());
                     }
                     let terminal_status = matches!(
                         status,
@@ -6000,7 +6067,10 @@ async fn download_to_path_inner(
                         )
                         .await;
                     }
-                    let decision = if terminal_status {
+                    let decision = if status == StatusCode::RANGE_NOT_SATISFIABLE
+                    {
+                        "disable_range_and_retry_single"
+                    } else if terminal_status {
                         "drop_route"
                     } else if cooldown_and_switch {
                         "cooldown_and_switch"
@@ -6410,9 +6480,15 @@ async fn download_to_path_inner(
                     } else {
                         remove_if_exists(&part_path).await?;
                     }
-                    let decision = if routes.len() > 1 {
-                        "clear_partial_and_switch"
-                    } else if attempts >= 2 {
+                    let official = (!is_official_route(route))
+                        .then(|| official_fallback_route(&routes))
+                        .flatten();
+                    let decision = if official.is_some() {
+                        "fallback_official"
+                    } else if attempts >= 2
+                        || (is_official_route(route)
+                            && official_integrity_retry)
+                    {
                         "drop_route_after_clean_retry"
                     } else {
                         "clear_partial_and_retry"
@@ -6433,10 +6509,27 @@ async fn download_to_path_inner(
                             cache_busted_download_url(&route.url, attempts),
                         ));
                     }
-                    if routes.len() > 1 || attempts >= 2 {
-                        terminal_routes.insert(route.url.clone());
-                    }
                     last_error = Some(error);
+                    if let Some(official) = official {
+                        terminal_routes.insert(route.url.clone());
+                        official_integrity_retry = true;
+                        preferred_route = Some(official);
+                    } else if (is_official_route(route)
+                        && official_integrity_retry)
+                        || attempts >= 2
+                    {
+                        terminal_routes.insert(route.url.clone());
+                        if is_official_route(route)
+                            && official_integrity_retry
+                        {
+                            return Err(attach_download_attempt_history(
+                                last_error.take().unwrap(),
+                                &attempt_history,
+                                attempts,
+                                file_attempt_budget,
+                            ));
+                        }
+                    }
                     break;
                 }
                 if let Err(error) =
@@ -7983,6 +8076,26 @@ mod tests {
         assert_eq!(
             native_first_byte_timeout(&mirror, false),
             FILE_TRANSFER_FIRST_BYTE_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn official_fallback_excludes_alternate_sources() {
+        let alternate = route(
+            "https://alternate.example/file".to_string(),
+            DownloadRouteSource::Alternate,
+            false,
+            true,
+        );
+        let official = route(
+            "https://official.example/file".to_string(),
+            DownloadRouteSource::Official,
+            false,
+            true,
+        );
+        assert_eq!(
+            official_fallback_route(&[alternate, official.clone()]),
+            Some(official)
         );
     }
 

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -218,7 +218,7 @@ impl Integrity {
 
     /// Resuming a partial download is only safe when a content hash can
     /// prove the stitched-together file is what the server intended.
-    fn supports_resume(&self) -> bool {
+    pub(crate) fn supports_resume(&self) -> bool {
         self.size.is_some() && self.has_hash()
     }
 
@@ -1325,7 +1325,7 @@ static TAIL_HEDGE_SEMAPHORE: LazyLock<Semaphore> =
 static H2_FALLBACK_AUTHORITIES: LazyLock<Mutex<HashMap<String, Instant>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-fn authority_uses_http1_fallback(authority: &str) -> bool {
+pub(crate) fn authority_uses_http1_fallback(authority: &str) -> bool {
     let mut fallbacks = H2_FALLBACK_AUTHORITIES.lock();
     match fallbacks.get(authority) {
         Some(until) if *until > Instant::now() => true,
@@ -1337,7 +1337,7 @@ fn authority_uses_http1_fallback(authority: &str) -> bool {
     }
 }
 
-fn record_authority_h2_failure(authority: &str) {
+pub(crate) fn record_authority_h2_failure(authority: &str) {
     let now = Instant::now();
     let mut fallbacks = H2_FALLBACK_AUTHORITIES.lock();
     fallbacks.retain(|_, until| *until > now);
@@ -4122,6 +4122,21 @@ async fn ensure_task_routes_probed(
     order_auto_routes(routes, request.resource, mirror_first_loader);
 }
 
+pub(crate) async fn prepare_native_download_routes(
+    request: &DownloadRequest,
+    routes: &mut Vec<DownloadRoute>,
+    semaphore: &FetchSemaphore,
+) {
+    ensure_task_routes_probed(
+        request,
+        routes,
+        semaphore,
+        &NO_REDIRECT_REQWEST_CLIENT,
+        &DIRECT_REQWEST_CLIENT,
+    )
+    .await;
+}
+
 fn segment_path(part_path: &Path, index: usize) -> PathBuf {
     suffixed_path(part_path, &format!(".segment-{index}"))
 }
@@ -5394,6 +5409,8 @@ async fn download_to_path_inner(
         .await;
     }
 
+    prepare_native_download_routes(&request, &mut routes, semaphore).await;
+
     // Prefer a multiplexed HTTP/2 download over a shared per-authority
     // connection: one handshake per CDN instead of one per file, and range
     // streams for large files. Any failure falls through to the legacy path.
@@ -5431,10 +5448,10 @@ async fn download_to_path_inner(
                 return Ok(result);
             }
             crate::util::download::h2_download::H2DownloadOutcome::Fallback {
-                reason,
-                integrity_failure,
+                failure,
+                preserve_partial,
             } => {
-                if integrity_failure {
+                if failure.integrity_failure() {
                     if h2_route.is_mirror {
                         h2_failed_mirror = Some(h2_route.url.clone());
                         tracing::warn!(
@@ -5443,18 +5460,22 @@ async fn download_to_path_inner(
                             "Mirror hash validation failed; falling back to the official source"
                         );
                     }
-                } else if let Some(authority) = url_authority(&h2_route.url) {
+                } else if failure.should_cooldown_authority()
+                    && let Some(authority) = url_authority(&h2_route.url)
+                {
                     record_authority_h2_failure(&authority);
                 }
                 tracing::debug!(
                     url = %sanitize_url_for_log(&h2_route.url),
                     source = h2_route.source.as_str(),
-                    reason,
+                    failure = ?failure,
+                    reason = failure.as_str(),
+                    preserve_partial,
                     "Multiplexed download unavailable; using legacy path"
                 );
-                // Clean up partials and segments left by the multiplexed
-                // attempt; the legacy path starts from a clean slate.
-                remove_if_exists(&part_path).await?;
+                if !preserve_partial {
+                    remove_if_exists(&part_path).await?;
+                }
                 cleanup_segment_files(&part_path, MAX_SEGMENT_CONCURRENCY)
                     .await?;
             }
@@ -5464,15 +5485,6 @@ async fn download_to_path_inner(
     if let Some(failed_route) = h2_failed_mirror.take() {
         routes.retain(|route| route.url != failed_route);
     }
-    ensure_task_routes_probed(
-        &request,
-        &mut routes,
-        semaphore,
-        &NO_REDIRECT_REQWEST_CLIENT,
-        &DIRECT_REQWEST_CLIENT,
-    )
-    .await;
-
     let mut attempts = 0;
     let mut last_error = None;
     let mut attempt_history = VecDeque::new();

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -59,10 +59,6 @@ const SEGMENT_RETRY_ATTEMPTS: usize = 3;
 const SEGMENT_EXPANSION_SAMPLE_COUNT: usize = 3;
 const SEGMENT_EXPANSION_INTERVAL: time::Duration =
     time::Duration::from_millis(1500);
-const SUSTAINED_LOW_THROUGHPUT_WINDOW: time::Duration =
-    time::Duration::from_secs(5);
-const SUSTAINED_LOW_THROUGHPUT_FLOOR: u64 = 256 * 1024;
-const SUSTAINED_LOW_THROUGHPUT_MIN_REMAINING: u64 = 1024 * 1024;
 #[cfg(not(test))]
 const RANGE_IDLE_RECONNECT_TIMEOUT: time::Duration =
     time::Duration::from_secs(8);
@@ -88,9 +84,15 @@ const FILE_TRANSFER_READ_TIMEOUT: time::Duration = time::Duration::from_secs(2);
 #[cfg(not(test))]
 const FILE_TRANSFER_FIRST_BYTE_TIMEOUT: time::Duration =
     time::Duration::from_secs(20);
+#[cfg(not(test))]
+const REASSIGNABLE_FIRST_BYTE_TIMEOUT: time::Duration =
+    time::Duration::from_secs(5);
 #[cfg(test)]
 const FILE_TRANSFER_FIRST_BYTE_TIMEOUT: time::Duration =
     time::Duration::from_secs(2);
+#[cfg(test)]
+const REASSIGNABLE_FIRST_BYTE_TIMEOUT: time::Duration =
+    time::Duration::from_millis(500);
 const MAX_DOWNLOAD_ATTEMPT_HISTORY: usize = 12;
 const MAX_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const H2_FALLBACK_TTL: time::Duration = time::Duration::from_secs(600);
@@ -337,6 +339,18 @@ enum ResourceFamily {
     Modrinth,
     CurseForge,
     Other,
+}
+
+impl ResourceFamily {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Minecraft => "minecraft",
+            Self::Loader => "loader",
+            Self::Modrinth => "modrinth",
+            Self::CurseForge => "curseforge",
+            Self::Other => "other",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -1111,12 +1125,28 @@ fn order_auto_routes(
             .is_some_and(|state| state.auto_prefers_mirror());
     let health = ROUTE_HEALTH.lock().clone();
     routes.sort_by(|left, right| {
-        let left_health = route_health_key(left, resource)
-            .and_then(|key| health.get(&key).cloned())
-            .unwrap_or_default();
-        let right_health = route_health_key(right, resource)
-            .and_then(|key| health.get(&key).cloned())
-            .unwrap_or_default();
+        let route_health = |route: &DownloadRoute| {
+            let Some(key) = route_health_key(route, resource) else {
+                return RouteHealth::default();
+            };
+            health.get(&key).cloned().unwrap_or_else(|| {
+                crate::util::download::native_reputation::get(
+                    key.family.as_str(),
+                    &key.authority,
+                    route.proxy,
+                )
+                .map(|persisted| RouteHealth {
+                    success_samples: persisted.success_samples,
+                    ttfb_ms: persisted.ttfb_ms,
+                    throughput_bps: persisted.throughput_bps,
+                    consecutive_failures: persisted.consecutive_failures,
+                    cooldown_until: None,
+                })
+                .unwrap_or_default()
+            })
+        };
+        let left_health = route_health(left);
+        let right_health = route_health(right);
         let now = Instant::now();
         let left_cooling =
             left_health.cooldown_until.is_some_and(|until| until > now);
@@ -1526,6 +1556,19 @@ fn record_route_success(
         DOWNLOAD_DNS_RESOLVER.record_host_success(&host, remote_addr.ip());
     }
     if let Some(key) = route_health_key(route, resource) {
+        let throughput_bps = (!transfer_elapsed.is_zero())
+            .then(|| bytes as f64 / transfer_elapsed.as_secs_f64());
+        if crate::util::download::active_engine()
+            != crate::util::download::DownloadEngine::XmclCompat
+        {
+            crate::util::download::native_reputation::record_success(
+                key.family.as_str(),
+                &key.authority,
+                route.proxy,
+                ttfb.as_secs_f64() * 1000.0,
+                throughput_bps,
+            );
+        }
         let mut health = ROUTE_HEALTH.lock();
         let entry = health.entry(key).or_default();
         entry.success_samples = entry.success_samples.saturating_add(1);
@@ -1558,6 +1601,15 @@ fn record_route_health_failure(
     cooldown: Option<time::Duration>,
 ) {
     if let Some(key) = route_health_key(route, resource) {
+        if crate::util::download::active_engine()
+            != crate::util::download::DownloadEngine::XmclCompat
+        {
+            crate::util::download::native_reputation::record_failure(
+                key.family.as_str(),
+                &key.authority,
+                route.proxy,
+            );
+        }
         let mut health = ROUTE_HEALTH.lock();
         let entry = health.entry(key).or_default();
         entry.consecutive_failures =
@@ -3769,30 +3821,22 @@ fn expansion_block_reason(
     None
 }
 
-fn sustained_low_throughput(
-    downloaded: u64,
-    window_start_bytes: u64,
-    elapsed: time::Duration,
-    remaining_bytes: u64,
-) -> Option<u64> {
-    if elapsed < SUSTAINED_LOW_THROUGHPUT_WINDOW
-        || remaining_bytes < SUSTAINED_LOW_THROUGHPUT_MIN_REMAINING
-    {
-        return None;
-    }
-    let bytes_per_second = downloaded
-        .saturating_sub(window_start_bytes)
-        .checked_div(elapsed.as_secs().max(1))
-        .unwrap_or(0);
-    (bytes_per_second < SUSTAINED_LOW_THROUGHPUT_FLOOR)
-        .then_some(bytes_per_second)
-}
-
 fn allow_low_throughput_route_switch(
     has_alternate_route: bool,
     retry_with_single_thread: bool,
 ) -> bool {
     has_alternate_route && !retry_with_single_thread
+}
+
+fn native_first_byte_timeout(
+    route: &DownloadRoute,
+    has_alternate_route: bool,
+) -> time::Duration {
+    if route.is_mirror && has_alternate_route {
+        REASSIGNABLE_FIRST_BYTE_TIMEOUT
+    } else {
+        FILE_TRANSFER_FIRST_BYTE_TIMEOUT
+    }
 }
 
 fn should_use_segmented_download(size: u64, resumable_part_bytes: u64) -> bool {
@@ -3812,6 +3856,27 @@ fn measured_bytes_per_second(bytes: u64, elapsed: time::Duration) -> u64 {
     let bytes_per_second = u128::from(bytes).saturating_mul(1_000_000_000)
         / elapsed.as_nanos().max(1);
     bytes_per_second.min(u128::from(u64::MAX)) as u64
+}
+
+fn expected_route_speed(
+    route: &DownloadRoute,
+    resource: ResourceClass,
+) -> Option<u64> {
+    let key = route_health_key(route, resource)?;
+    ROUTE_HEALTH
+        .lock()
+        .get(&key)
+        .and_then(|health| health.throughput_bps)
+        .or_else(|| {
+            crate::util::download::native_reputation::get(
+                key.family.as_str(),
+                &key.authority,
+                route.proxy,
+            )
+            .and_then(|health| health.throughput_bps)
+        })
+        .filter(|speed| speed.is_finite() && *speed > 0.0)
+        .map(|speed| speed.min(u64::MAX as f64) as u64)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3926,6 +3991,7 @@ async fn probe_faster_route(
     system_client: &reqwest::Client,
     direct_client: &reqwest::Client,
     resource: ResourceClass,
+    downloaded_bytes: u64,
 ) -> Option<RouteProbeResult> {
     let current_authority = effective_route_authority(current_route);
     let mut seen = HashSet::new();
@@ -3960,6 +4026,11 @@ async fn probe_faster_route(
         if probe_is_meaningfully_faster(
             probe.bytes_per_second,
             current_bytes_per_second,
+        ) && crate::util::download::native_slow::should_switch(
+            current_bytes_per_second,
+            probe.bytes_per_second,
+            total_size.saturating_sub(downloaded_bytes),
+            total_size,
         ) {
             return Some(probe);
         }
@@ -3972,9 +4043,21 @@ fn route_health_is_cold(
     resource: ResourceClass,
 ) -> bool {
     route_health_key(route, resource).is_none_or(|key| {
-        ROUTE_HEALTH.lock().get(&key).is_none_or(|entry| {
-            entry.success_samples < COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD
-        })
+        let in_memory_samples = ROUTE_HEALTH
+            .lock()
+            .get(&key)
+            .map(|entry| entry.success_samples)
+            .unwrap_or(0);
+        let persisted_samples =
+            crate::util::download::native_reputation::get(
+                key.family.as_str(),
+                &key.authority,
+                route.proxy,
+            )
+            .map(|entry| entry.success_samples)
+            .unwrap_or(0);
+        in_memory_samples.max(persisted_samples)
+            < COLD_START_ROUTE_HEALTH_SAMPLE_THRESHOLD
     })
 }
 
@@ -4127,6 +4210,7 @@ pub(crate) async fn prepare_native_download_routes(
     routes: &mut Vec<DownloadRoute>,
     semaphore: &FetchSemaphore,
 ) {
+    crate::util::download::native_reputation::load_if_needed().await;
     ensure_task_routes_probed(
         request,
         routes,
@@ -4135,6 +4219,15 @@ pub(crate) async fn prepare_native_download_routes(
         &DIRECT_REQWEST_CLIENT,
     )
     .await;
+    if source_mode_for_resource(request.resource)
+        == crate::state::DownloadSourceMode::Auto
+    {
+        order_auto_routes(
+            routes,
+            request.resource,
+            uses_mirror_first_loader_routes(&request.url, request.resource),
+        );
+    }
 }
 
 fn segment_path(part_path: &Path, index: usize) -> PathBuf {
@@ -4835,8 +4928,10 @@ async fn try_segmented_download(
     let mut last_expansion = Instant::now();
     let mut last_block_reason = None;
     let mut downloaded = 0_u64;
-    let mut throughput_window_started = Instant::now();
-    let mut throughput_window_bytes = 0_u64;
+    let mut slow_policy = crate::util::download::native_slow::NativeSlowPolicy::new(
+        0,
+        expected_route_speed(route, request.resource),
+    );
     let mut alternate_probe: Option<RouteProbeFuture<'_>> = None;
     let mut alternate_probe_finished = false;
     let mut confirmed_switch = None;
@@ -4896,16 +4991,16 @@ async fn try_segmented_download(
                 }
             }
             _ = scheduler.tick() => {
-                let throughput_elapsed = throughput_window_started.elapsed();
+                let slow_decision = slow_policy.observe(
+                    downloaded,
+                    size.saturating_sub(downloaded),
+                );
                 if allow_low_throughput_abort
                     && !alternate_probe_finished
                     && alternate_probe.is_none()
-                    && let Some(bytes_per_second) = sustained_low_throughput(
-                        downloaded,
-                        throughput_window_bytes,
-                        throughput_elapsed,
-                        size.saturating_sub(downloaded),
-                    )
+                    && let crate::util::download::native_slow::SlowDecision::Probe {
+                        bytes_per_second,
+                    } = slow_decision
                 {
                     tracing::warn!(
                         original_url = %sanitize_url_for_log(&route.url),
@@ -4926,11 +5021,16 @@ async fn try_segmented_download(
                         system_client,
                         direct_client,
                         request.resource,
+                        downloaded,
                     )));
                 }
-                if throughput_elapsed >= SUSTAINED_LOW_THROUGHPUT_WINDOW {
-                    throughput_window_started = Instant::now();
-                    throughput_window_bytes = downloaded;
+                if matches!(
+                    slow_decision,
+                    crate::util::download::native_slow::SlowDecision::Commit
+                ) {
+                    alternate_probe = None;
+                    alternate_probe_finished = true;
+                    slow_policy.commit();
                 }
                 if hedge_active.load(Ordering::Acquire) {
                     continue;
@@ -5749,6 +5849,8 @@ async fn download_to_path_inner(
                 )
                 .await;
                 let request_started = Instant::now();
+                let first_byte_timeout =
+                    native_first_byte_timeout(route, can_switch_route);
                 // A truncated or invalid body may be a corrupt edge-cache
                 // object; the retry then uses a cache-busted URL that forces a
                 // fresh origin fetch instead of the same broken copy.
@@ -5762,7 +5864,7 @@ async fn download_to_path_inner(
                     })
                     .unwrap_or_else(|| route.clone());
                 let (response, final_url) = match tokio::time::timeout(
-                    FILE_TRANSFER_FIRST_BYTE_TIMEOUT,
+                    first_byte_timeout,
                     send_path_request(
                         &attempt_route,
                         request.header.as_ref(),
@@ -5807,7 +5909,7 @@ async fn download_to_path_inner(
                         record_route_failure(route, request.resource, None);
                         let error = ErrorKind::NetworkError(format!(
                             "no response received for {:.0} seconds while downloading {log_url} to {}",
-                            FILE_TRANSFER_FIRST_BYTE_TIMEOUT.as_secs_f64(),
+                            first_byte_timeout.as_secs_f64(),
                             destination.display(),
                         ))
                         .into();
@@ -5825,7 +5927,7 @@ async fn download_to_path_inner(
                             path = %destination.display(),
                             url = %log_url,
                             source = route.source.as_str(),
-                            no_data_seconds = FILE_TRANSFER_FIRST_BYTE_TIMEOUT.as_secs_f64(),
+                            no_data_seconds = first_byte_timeout.as_secs_f64(),
                             downloaded_bytes = 0,
                             attempt = attempts,
                             max_attempts = file_attempt_budget,
@@ -6048,8 +6150,11 @@ async fn download_to_path_inner(
                 let transfer_started = Instant::now();
                 let mut downloaded = starting_size;
                 let mut last_tracking_bytes = starting_size;
-                let mut throughput_window_started = Instant::now();
-                let mut throughput_window_bytes = starting_size;
+                let mut slow_policy =
+                    crate::util::download::native_slow::NativeSlowPolicy::new(
+                        starting_size,
+                        expected_route_speed(route, request.resource),
+                    );
                 let mut throughput_timer =
                     tokio::time::interval(time::Duration::from_millis(250));
                 throughput_timer.tick().await;
@@ -6103,25 +6208,23 @@ async fn download_to_path_inner(
                             }
                         }
                         _ = throughput_timer.tick() => {
-                            let throughput_elapsed =
-                                throughput_window_started.elapsed();
+                            let slow_decision = slow_policy.observe(
+                                downloaded,
+                                total_size.saturating_sub(downloaded),
+                            );
                             if allow_low_throughput_abort
                                 && total_size >= SEGMENTED_DOWNLOAD_THRESHOLD
                                 && !alternate_probe_finished
                                 && alternate_probe.is_none()
-                                && let Some(bytes_per_second) = sustained_low_throughput(
-                                    downloaded,
-                                    throughput_window_bytes,
-                                    throughput_elapsed,
-                                    total_size.saturating_sub(downloaded),
-                                )
+                                && let crate::util::download::native_slow::SlowDecision::Probe {
+                                    bytes_per_second,
+                                } = slow_decision
                             {
                                 tracing::warn!(
                                     path = %destination.display(),
                                     url = %log_url,
                                     source = route.source.as_str(),
                                     bytes_per_second,
-                                    elapsed_ms = throughput_elapsed.as_millis(),
                                     remaining_bytes = total_size.saturating_sub(downloaded),
                                     "Sustained low throughput; probing alternate routes"
                                 );
@@ -6137,11 +6240,16 @@ async fn download_to_path_inner(
                                     &NO_REDIRECT_REQWEST_CLIENT,
                                     &DIRECT_REQWEST_CLIENT,
                                     request.resource,
+                                    downloaded,
                                 )));
                             }
-                            if throughput_elapsed >= SUSTAINED_LOW_THROUGHPUT_WINDOW {
-                                throughput_window_started = Instant::now();
-                                throughput_window_bytes = downloaded;
+                            if matches!(
+                                slow_decision,
+                                crate::util::download::native_slow::SlowDecision::Commit
+                            ) {
+                                alternate_probe = None;
+                                alternate_probe_finished = true;
+                                slow_policy.commit();
                             }
                         }
                         probe = async {
@@ -7854,41 +7962,28 @@ mod tests {
     }
 
     #[test]
-    fn sustained_low_throughput_requires_time_and_remaining_data() {
-        assert_eq!(
-            sustained_low_throughput(
-                128 * 1024,
-                0,
-                SUSTAINED_LOW_THROUGHPUT_WINDOW,
-                2 * 1024 * 1024,
-            ),
-            Some(26_214)
-        );
-        assert_eq!(
-            sustained_low_throughput(
-                2 * 1024 * 1024,
-                0,
-                SUSTAINED_LOW_THROUGHPUT_WINDOW,
-                2 * 1024 * 1024,
-            ),
-            None
-        );
-        assert_eq!(
-            sustained_low_throughput(
-                128 * 1024,
-                0,
-                time::Duration::from_secs(1),
-                2 * 1024 * 1024,
-            ),
-            None
-        );
-    }
-
-    #[test]
     fn low_throughput_only_switches_routes_before_fallback_rounds() {
         assert!(allow_low_throughput_route_switch(true, false));
         assert!(!allow_low_throughput_route_switch(true, true));
         assert!(!allow_low_throughput_route_switch(false, false));
+    }
+
+    #[test]
+    fn reassignable_mirror_uses_shorter_first_byte_timeout() {
+        let mirror = route(
+            "https://mirror.example/file".to_string(),
+            DownloadRouteSource::Bmclapi,
+            true,
+            true,
+        );
+        assert_eq!(
+            native_first_byte_timeout(&mirror, true),
+            REASSIGNABLE_FIRST_BYTE_TIMEOUT
+        );
+        assert_eq!(
+            native_first_byte_timeout(&mirror, false),
+            FILE_TRANSFER_FIRST_BYTE_TIMEOUT
+        );
     }
 
     #[test]
@@ -7983,6 +8078,7 @@ mod tests {
             &client,
             &client,
             ResourceClass::Other,
+			0,
         )
         .await
         .expect("the local range route should be measurably faster");
@@ -8011,6 +8107,7 @@ mod tests {
                 &client,
                 &client,
                 ResourceClass::Other,
+				0,
             )
             .await
             .is_none()


### PR DESCRIPTION
Draft pull request.

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

</details>

新特性：
- 添加自适应原生下载策略，用于 HTTP/2 选择、基于吞吐量的路由切换、分段并发以及重试行为。
- 持久化路由和传输性能信誉，以改进未来下载时的路由和传输方式选择。
- 添加原生连接预算与熔断机制，用于全局和按 authority 维度的传输管理。

缺陷修复：
- 显式处理无效的范围响应，并在遇到 HTTP 416 时通过禁用范围拆分、改用单连接重试进行恢复。
- 在镜像完整性检查失败后优先使用官方源，并根据失败类型保留或清理部分下载的内容。

增强：
- 重构 HTTP/2 下载，改为使用基于策略的单流并对回退失败进行分类处理，而不是使用多路复用的范围流。
- 在常规与批量资源下载中整合原生的健康度、速度、回退和传输指标。
- 对可重新分配的镜像使用更短的首字节超时，并在分段范围扩展带来的吞吐提升不足时停止继续扩展。

测试：
- 更新下载测试，以覆盖原生连接许可、有界并发、官方源回退选择以及自适应超时和吞吐行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

</details>

新特性：
- 添加自适应原生下载策略，用于 HTTP/2 选择、基于吞吐量的路由切换、分段并发以及重试行为。
- 持久化路由和传输性能信誉，以改进未来下载时的路由和传输方式选择。
- 添加原生连接预算与熔断机制，用于全局和按 authority 维度的传输管理。

缺陷修复：
- 显式处理无效的范围响应，并在遇到 HTTP 416 时通过禁用范围拆分、改用单连接重试进行恢复。
- 在镜像完整性检查失败后优先使用官方源，并根据失败类型保留或清理部分下载的内容。

增强：
- 重构 HTTP/2 下载，改为使用基于策略的单流并对回退失败进行分类处理，而不是使用多路复用的范围流。
- 在常规与批量资源下载中整合原生的健康度、速度、回退和传输指标。
- 对可重新分配的镜像使用更短的首字节超时，并在分段范围扩展带来的吞吐提升不足时停止继续扩展。

测试：
- 更新下载测试，以覆盖原生连接许可、有界并发、官方源回退选择以及自适应超时和吞吐行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入自适应传输选择、持久化性能跟踪、有边界的连接管理以及更健壮的回退行为，改进原生下载引擎。

新功能：
- 新增自适应原生下载策略，可根据路由和传输性能在 HTTP/2 与分段式 HTTP/1.1 传输之间进行选择。
- 持久化路由和传输信誉，以提升后续的源站与传输方式选择。
- 引入全局及按 authority 维度的原生连接预算和熔断器机制。

缺陷修复：
- 从无效的范围响应和 HTTP 416 错误中恢复，通过禁用范围拆分并使用单一连接重试下载。
- 在镜像完整性校验失败后优先使用官方源，并根据失败类型保留或删除部分已下载内容。

改进增强：
- 重构通用 HTTP/2 下载逻辑，采用基于策略驱动的单流下载，并进行分类化的回退处理。
- 将原生健康检查、吞吐量、回退、超时和连接管理策略应用于单个下载和批量下载。
- 限制分段并发度，并在额外连接带来的吞吐提升不足时停止扩展范围。

测试：
- 更新下载测试，用于验证原生连接上限、有边界并发、官方源回退、自适应超时和吞吐策略等行为。

杂项：
- 调整日志默认设置，在减少 SQLx 噪音的同时暴露 HTTP/2 及相关传输诊断信息。
- 限制原生 mrpack 内容下载任务的并发度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the native download engine with adaptive transport selection, persistent performance tracking, bounded connection management, and more resilient fallback behavior.

New Features:
- Add adaptive native download policies that select HTTP/2 or segmented HTTP/1.1 transfers based on route and transport performance.
- Persist route and transport reputation to improve future source and transport selection.
- Introduce global and per-authority native connection budgets and circuit breakers.

Bug Fixes:
- Recover from invalid range responses and HTTP 416 errors by disabling range splitting and retrying with a single connection.
- Prefer the official source after mirror integrity failures while preserving or removing partial downloads according to the failure type.

Enhancements:
- Refactor general HTTP/2 downloads to use policy-driven single streams with classified fallback handling.
- Apply native health, throughput, fallback, timeout, and connection-management policies to individual and batch downloads.
- Limit segmented concurrency and stop expanding ranges when additional connections provide insufficient throughput gains.

Tests:
- Update download tests for native connection limits, bounded concurrency, official-source fallback, adaptive timeouts, and throughput policies.

Chores:
- Adjust logging defaults to expose HTTP/2 and related transport diagnostics while reducing SQLx noise.
- Cap native mrpack content-download task concurrency.

</details>

</details>

</details>

</details>