### PR TITLE
解決 zh-TW 每日任務會被 zh-CN 覆蓋掉的問題

### DIFF
--- a/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
+++ b/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
@@ -37,7 +37,7 @@ const challengeText = computed(() => {
 	} else {
 		return lowerLocale.startsWith('zh')
 			? challenge.value.text['zh-CN']
-			: challenge.value.text['en-US'],
+			: challenge.value.text['en-US']
 	}
 })
 

--- a/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
+++ b/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
@@ -30,11 +30,16 @@ const dailyIndex = stableGreetingIndex(
 const challengeIndex = ref(dailyIndex)
 
 const challenge = computed(() => dailyChallenges[challengeIndex.value])
-const challengeText = computed(() =>
-	locale.value.toLowerCase().startsWith('zh')
-		? challenge.value.text['zh-CN']
-		: challenge.value.text['en-US'],
-)
+const challengeText = computed(() => {
+	const lowerLocale = locale.value.toLowerCase()
+	if (lowerLocale == 'zh-TW') {
+		return challenge.value.text['zh-TW']
+	} else {
+		return locale.value.toLowerCase().startsWith('zh')
+			? challenge.value.text['zh-CN']
+			: challenge.value.text['en-US'],
+	}
+})
 
 const difficultyDotClass: Record<ChallengeDifficulty, string> = {
 	easy: 'bg-brand-green',

--- a/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
+++ b/apps/app-frontend/src/components/home/HomeDailyChallenge.vue
@@ -32,10 +32,10 @@ const challengeIndex = ref(dailyIndex)
 const challenge = computed(() => dailyChallenges[challengeIndex.value])
 const challengeText = computed(() => {
 	const lowerLocale = locale.value.toLowerCase()
-	if (lowerLocale == 'zh-TW') {
+	if (lowerLocale == 'zh-tw') {
 		return challenge.value.text['zh-TW']
 	} else {
-		return locale.value.toLowerCase().startsWith('zh')
+		return lowerLocale.startsWith('zh')
 			? challenge.value.text['zh-CN']
 			: challenge.value.text['en-US'],
 	}


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 确保 zh-TW 用户看到繁体中文的每日挑战文本，而不会被简体中文文本覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 确保 zh-TW 用户看到繁体中文的每日挑战文本，而不是简体中文文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure zh-TW users see Traditional Chinese daily challenge text instead of Simplified Chinese text.

</details>

</details>