### PR TITLE
feat(translation): surface DeepL API error details in settings UI

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/TranslationSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/TranslationSettings.vue
@@ -384,6 +384,7 @@ function reportOperationError(error?: unknown, context?: string) {
 			? errorMessage
 			: formatMessage(message)
 	handleError(new Error(displayMessage))
+}
 
 watch(
 	settings,

--- a/apps/app-frontend/src/components/ui/settings/TranslationSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/TranslationSettings.vue
@@ -376,8 +376,14 @@ function reportOperationError(error?: unknown, context?: string) {
 				provider: messages.operationFailed,
 			}[errorKind]
 		: messages.operationFailed
-	handleError(new Error(formatMessage(message)))
-}
+	// Surface the underlying provider error (e.g. DeepL HTTP status, quota
+	// or endpoint mistakes) instead of a generic message, so users can fix
+	// the configuration themselves.
+	const displayMessage =
+		errorKind === 'provider' && errorMessage.includes('DeepL API error')
+			? errorMessage
+			: formatMessage(message)
+	handleError(new Error(displayMessage))
 
 watch(
 	settings,


### PR DESCRIPTION
## 问题背景

关联 #353。v1.8.10 的官方 DeepL 源失败时（例如 HTTP 400/403、额度 456、端点和 Key 不匹配等），设置页只显示泛化的「翻译操作失败，请检查配置后重试。」，用户无法得知具体原因——错误详情只存在于 launcher 日志里。

## 改动

`TranslationSettings.vue` 的 `reportOperationError` 中：当错误归类为 `provider` 且消息包含 `DeepL API error` 时，直接把底层 API 错误信息展示给用户（如 `DeepL API error: HTTP 403 Forbidden - {"message":"Forbidden..."}`），其余路径保持原有通用提示不变。

## 说明

- 不新增 i18n 键，不改变其他 provider 的行为。
- 沿用现有 `getTranslationErrorKind()` 归类逻辑。
- 与 #353 中说明的「main 已修复官方端点 text 数组格式」问题相互独立：本 PR 改善的是错误可见性，方便用户自查配置（尤其 403 Key 不匹配 / 456 额度不足这类情况）。

## Sourcery 摘要

在翻译设置中显示底层 DeepL API 错误，以便用户诊断配置、端点和配额问题。

新功能：
- 当提供商操作失败时，在翻译设置 UI 中显示可操作的 DeepL API 错误详细信息。

增强功能：
- 对于非 DeepL 错误和其他提供商，保留现有的通用错误消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show underlying DeepL API errors in translation settings so users can diagnose configuration, endpoint, and quota issues.

New Features:
- Surface actionable DeepL API error details in the translation settings UI when provider operations fail.

Enhancements:
- Preserve the existing generic error messaging for non-DeepL errors and other providers.

</details>