### PR TITLE
fix(translation): 修正 DeepL 语言代码映射（繁体中文与地区码）

### DIFF
--- a/packages/app-lib/src/api/translation.rs
+++ b/packages/app-lib/src/api/translation.rs
@@ -471,6 +471,19 @@ fn provider_language(locale: &str, provider: TranslationProvider) -> String {
     }
 }
 
+/// DeepL 的 source_lang 只接受基础语言码，ZH-HANT/ZH-HANS 仅可用于
+/// target_lang；显式指定繁体源时必须回退到 ZH。
+fn provider_source_language(locale: &str, provider: TranslationProvider) -> String {
+    if provider == TranslationProvider::DeepL {
+        match provider_language(locale, provider).as_str() {
+            "ZH-HANT" | "ZH-HANS" => "ZH".to_string(),
+            mapped => mapped.to_string(),
+        }
+    } else {
+        provider_language(locale, provider)
+    }
+}
+
 fn parse_google_response(
     value: &Value,
     format: TranslationTextFormat,
@@ -926,7 +939,7 @@ async fn translate_uncached(
     let source = if request.source_language == "auto" {
         "auto".to_string()
     } else {
-        provider_language(&request.source_language, settings.settings.provider)
+        provider_source_language(&request.source_language, settings.settings.provider)
     };
     let target =
         provider_language(&request.target_language, settings.settings.provider);
@@ -1377,6 +1390,22 @@ mod tests {
         assert_eq!(
             provider_language("no-NO", TranslationProvider::DeepL),
             "NB"
+        );
+    }
+
+    #[test]
+    fn deepl_source_language_uses_base_chinese_code() {
+        assert_eq!(
+            provider_source_language("zh-TW", TranslationProvider::DeepL),
+            "ZH"
+        );
+        assert_eq!(
+            provider_source_language("zh-CN", TranslationProvider::DeepL),
+            "ZH"
+        );
+        assert_eq!(
+            provider_source_language("ja-JP", TranslationProvider::DeepL),
+            "JA"
         );
     }
 

--- a/packages/app-lib/src/api/translation.rs
+++ b/packages/app-lib/src/api/translation.rs
@@ -473,7 +473,10 @@ fn provider_language(locale: &str, provider: TranslationProvider) -> String {
 
 /// DeepL 的 source_lang 只接受基础语言码，ZH-HANT/ZH-HANS 仅可用于
 /// target_lang；显式指定繁体源时必须回退到 ZH。
-fn provider_source_language(locale: &str, provider: TranslationProvider) -> String {
+fn provider_source_language(
+    locale: &str,
+    provider: TranslationProvider,
+) -> String {
     if provider == TranslationProvider::DeepL {
         match provider_language(locale, provider).as_str() {
             "ZH-HANT" | "ZH-HANS" => "ZH".to_string(),
@@ -939,7 +942,10 @@ async fn translate_uncached(
     let source = if request.source_language == "auto" {
         "auto".to_string()
     } else {
-        provider_source_language(&request.source_language, settings.settings.provider)
+        provider_source_language(
+            &request.source_language,
+            settings.settings.provider,
+        )
     };
     let target =
         provider_language(&request.target_language, settings.settings.provider);

--- a/packages/app-lib/src/api/translation.rs
+++ b/packages/app-lib/src/api/translation.rs
@@ -458,13 +458,14 @@ fn provider_language(locale: &str, provider: TranslationProvider) -> String {
             value => value.to_string(),
         },
         TranslationProvider::DeepL => match normalized.as_str() {
-            "zh-CN" => "ZH".to_string(),
-            "zh-TW" => "ZH".to_string(),
+            "zh-CN" | "zh" => "ZH".to_string(),
+            "zh-TW" => "ZH-HANT".to_string(),
             "en" | "en-US" => "EN-US".to_string(),
             "en-GB" => "EN-GB".to_string(),
             "pt" | "pt-BR" => "PT-BR".to_string(),
             "pt-PT" => "PT-PT".to_string(),
-            value => value.to_uppercase(),
+            "nb" | "nb-NO" | "no" | "no-NO" => "NB".to_string(),
+            value => value.split('-').next().unwrap_or(value).to_uppercase(),
         },
         TranslationProvider::Ai => normalized,
     }
@@ -1343,10 +1344,14 @@ mod tests {
     }
 
     #[test]
-    fn deepl_language_codes_are_uppercased() {
+    fn deepl_language_codes_are_normalized() {
         assert_eq!(
             provider_language("zh-CN", TranslationProvider::DeepL),
             "ZH"
+        );
+        assert_eq!(
+            provider_language("zh-TW", TranslationProvider::DeepL),
+            "ZH-HANT"
         );
         assert_eq!(
             provider_language("en-US", TranslationProvider::DeepL),
@@ -1357,6 +1362,22 @@ mod tests {
             "PT-BR"
         );
         assert_eq!(provider_language("ja", TranslationProvider::DeepL), "JA");
+        assert_eq!(
+            provider_language("ja-JP", TranslationProvider::DeepL),
+            "JA"
+        );
+        assert_eq!(
+            provider_language("de-DE", TranslationProvider::DeepL),
+            "DE"
+        );
+        assert_eq!(
+            provider_language("es-419", TranslationProvider::DeepL),
+            "ES"
+        );
+        assert_eq!(
+            provider_language("no-NO", TranslationProvider::DeepL),
+            "NB"
+        );
     }
 
     #[test]


### PR DESCRIPTION
跟进 #353 里排查出来的问题，单独把 DeepL 语言代码这块修一下。

设置里目标语言选日文、韩文、德文这些之后，发出去的 target_lang 是 "JA-JP"、"KO-KR"、"DE-DE" 这种带地区后缀的格式，DeepL 官方接口只收不带后缀的代码（JA、KO、DE），直接 400：

Bad request. Reason: Value for 'target_lang' not supported.

之前 provider_language() 只有 en/zh/pt 三个特判分支，其它语言基本全踩这个坑。

另外 zh-TW 一直映射到 "ZH"，而 DeepL 的 ZH 是简体中文，繁体用户拿到的译文是简体。接口本身支持 ZH-HANT：实测同一句，ZH 输出"来自…问候"，ZH-HANT 输出"來自…問候"。

改动：
- zh-TW -> ZH-HANT；zh / zh-CN -> ZH 不变
- no / no-NO -> NB（DeepL 用 NB 表示挪威语，不认 NO）
- 其余语言取第一个语言段转大写：ja-JP -> JA、ko-KR -> KO、de-DE -> DE、es-419 -> ES、sr-CS -> SR 等

测试用例同步补了 zh-TW、ja-JP、de-DE、es-419、no-NO 几条。

验证：改动前把界面语言列表里出现的 33 个 locale 逐一请求过官方 API（有效 key），除 fil-PH（菲律宾语，DeepL 目前不支持，仍会报错，属预期行为）外全部 200；而带地区后缀的请求（如 JA-JP）可稳定复现上面的 400。

## Sourcery 总结

规范 DeepL 翻译的区域设置到语言代码的转换，包括繁体中文和挪威语支持。

错误修复：
- 修正 DeepL 语言映射，以保留繁体中文，并使用服务商支持的语言代码，避免使用不受支持的区域后缀。

增强功能：
- 增加对中文、日语、德语、西班牙语和挪威语 DeepL 区域设置规范化的覆盖。

测试：
- 扩展针对区域设置和 DeepL 专用代码的翻译语言映射测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

规范化基于区域设置的 DeepL 语言代码，以确保请求有效，并提供准确的繁体中文翻译。

错误修复：
- 修正 DeepL 语言映射，以保留繁体中文，并使用不带区域后缀且受支持的基础语言代码。
- 将挪威语区域设置映射到 DeepL 的 NB 代码，并确保源语言请求使用受支持的基础中文代码。

测试：
- 扩展语言映射覆盖范围，涵盖繁体中文、区域设置和挪威语，并包括源语言规范化测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 DeepL 区域设置映射规范化为受支持的语言代码，并保留准确的繁体中文翻译输出。

错误修复：
- 通过使用受支持的基础语言代码，修正区域区域设置的 DeepL 目标语言映射。
- 使用 ZH-HANT 目标代码保留繁体中文翻译，并将挪威语区域设置映射到 NB。
- 将 DeepL 源语言请求规范化为受支持的基础代码，包括对中文变体的回退处理。

测试：
- 扩展语言映射测试，覆盖繁体中文、区域性日语、德语、西班牙语和挪威语区域设置，以及源语言规范化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize DeepL locale mappings to use supported language codes and preserve accurate Traditional Chinese translation output.

Bug Fixes:
- Correct DeepL target-language mapping for regional locales by using supported base language codes.
- Preserve Traditional Chinese translations with the ZH-HANT target code and map Norwegian locales to NB.
- Normalize DeepL source-language requests to supported base codes, including fallback handling for Chinese variants.

Tests:
- Expand language mapping tests to cover Traditional Chinese, regional Japanese, German, Spanish, and Norwegian locales, plus source-language normalization.

</details>

</details>

</details>