### PR TITLE
fix(translation): 搜索描述翻译分批执行，失败批次不拖垮整页

### DIFF
--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -431,7 +431,7 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 		}
 
 		// 分批翻译，某批失败时保留已完成的批次，避免单个坏段拖垮整页
-		const translated: TranslationSegment[] = []
+		const translated: TranslationResponse['segments'] = []
 		let response: TranslationResponse
 		try {
 			response = await translateInBatches(request, (batch) => {

--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 
 import {
+	createTranslationBatches,
 	translateInBatches as executeTranslationBatches,
 	type TranslationRequest,
 	type TranslationResponse,
@@ -430,17 +431,21 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 			},
 		}
 
-		// 分批翻译，某批失败时保留已完成的批次，避免单个坏段拖垮整页
+		// 等所有批次结束（含失败批次）再决定：保留成功批次，全部失败才抛错
 		const translated: TranslationResponse['segments'] = []
-		let response: TranslationResponse
-		try {
-			response = await translateInBatches(request, (batch) => {
-				translated.push(...batch.segments)
-			})
-		} catch (error) {
-			if (translated.length === 0) throw error
-			response = { segments: translated }
+		const results = await Promise.allSettled(
+			createTranslationBatches(request.segments).map((batch) =>
+				translateInBatches(
+					{ ...request, segments: batch },
+					(batchResponse) => translated.push(...batchResponse.segments),
+				),
+			),
+		)
+		if (translated.length === 0) {
+			const failed = results.find((result) => result.status === 'rejected')
+			throw failed ? failed.reason : new Error('搜索描述翻译失败')
 		}
+		const response: TranslationResponse = { segments: translated }
 
 		const translatedHits = hits.map((hit) => {
 			const segment = response.segments.find(

--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -415,19 +415,32 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 	if (locale !== 'zh-CN') return hits
 
 	if (useServer) {
-		const response = await translate({
+		const segments: TranslationSegment[] = hits.map((hit) => ({
+			text: hit.description ?? hit.summary ?? '',
+			id: hit.project_id ?? hit.provider_project_id ?? '',
+			format: 'html',
+		}))
+		const request: TranslationRequest = {
 			target_language: 'zh-CN',
 			source_language: 'en',
-			segments: hits.map((hit) => ({
-				text: hit.description ?? hit.summary ?? '',
-				id: hit.project_id ?? hit.provider_project_id ?? '',
-				format: 'html',
-			})),
+			segments,
 			context: {
 				title: hits[0]?.title ?? '',
 				description: hits[0]?.description ?? hits[0]?.summary ?? '',
 			},
-		})
+		}
+
+		// 分批翻译，某批失败时保留已完成的批次，避免单个坏段拖垮整页
+		const translated: TranslationSegment[] = []
+		let response: TranslationResponse
+		try {
+			response = await translateInBatches(request, (batch) => {
+				translated.push(...batch.segments)
+			})
+		} catch (error) {
+			if (translated.length === 0) throw error
+			response = { segments: translated }
+		}
 
 		const translatedHits = hits.map((hit) => {
 			const segment = response.segments.find(


### PR DESCRIPTION
搜索页自动翻译（设置里开启 auto_translate 后）目前是把一页所有条目的 description 一次性丢给后端 translate()。只要其中一条描述太怪（超长、异常 HTML 之类），整个请求就失败，这一页 50 条全部保持原文，只有 debug 日志里有记录，用户看到的就是"翻译没生效"。

改法：useServer 路径改用已有的 translateInBatches() 分批翻译。已完成的批次照常上屏，某批失败时保留部分结果、失败批次维持原文（翻译失败降级为原文本来就是现有行为，这里只是不让一条坏数据拖垮整页）。搜索页 mcimirror 分支本来就是逐个 Promise.allSettled，这里让 server 路径行为与之对齐。

只改了 apps/app-frontend/src/helpers/translation.ts 一个文件，不涉及后端和共享逻辑；若所有批次都失败依旧按原来方式抛错，搜索页行为不变。

## Sourcery 总结

增强搜索描述翻译对单个批次失败的容错能力，同时保留成功的翻译结果，并对失败的批次回退到原始文本。

错误修复：
- 通过分批翻译描述并保留成功结果，避免单个格式错误的搜索描述导致整个服务端翻译请求失败。
- 当所有翻译批次均失败时，保留现有的错误行为。

改进：
- 使服务端搜索翻译行为与镜像路径中按条目处理部分失败的机制保持一致。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使搜索描述翻译能够适应部分批处理失败，同时不改变全部失败时的行为。

错误修复：
- 防止单个格式错误的搜索描述导致整个服务端翻译请求失败。
- 保留成功的翻译；对于失败的批次回退到原始文本，同时在所有批次都失败时保留现有的错误行为。

增强功能：
- 使服务端搜索翻译的容错机制与镜像路径中使用的逐项处理方式保持一致。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使服务器端搜索描述翻译能够应对部分批次失败，同时不改变全部失败时的行为。

错误修复：
- 防止单个格式错误的搜索描述导致整个服务器端翻译请求失败。
- 保留成功的翻译；对于失败的批次回退到原始文本，同时在所有批次均失败时保留现有的错误处理行为。

增强功能：
- 使服务器端搜索翻译的错误容忍度与镜像翻译路径保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make server-side search description translation resilient to partial batch failures without changing all-failure behavior.

Bug Fixes:
- Prevent a single malformed search description from causing the entire server-side translation request to fail.
- Preserve successful translations and fall back to original text for failed batches while retaining the existing error behavior when every batch fails.

Enhancements:
- Align server-side search translation error tolerance with the mirror translation path.

</details>

</details>

</details>