### PR TITLE
i18n: 补齐 zh-TW 缺失翻译（1016 + 141 条，基于 zh-CN 转换）

### DIFF
--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -11,24 +11,6 @@
 	"app.action-bar.downloads": {
 		"message": "下載"
 	},
-	"app.action-bar.install.cache-repair.action": {
-		"message": "清除專案快取並重試"
-	},
-	"app.action-bar.install.cache-repair.description": {
-		"message": "啟動器無法讀取本地 CurseForge 專案快取，安裝已停止。"
-	},
-	"app.action-bar.install.cache-repair.failed": {
-		"message": "專案快取清除失敗；尚未開始重試。"
-	},
-	"app.action-bar.install.cache-repair.in-progress": {
-		"message": "正在清除專案快取…"
-	},
-	"app.action-bar.install.cache-repair.title": {
-		"message": "專案後設資料快取異常"
-	},
-	"app.action-bar.install.deleted-instance": {
-		"message": "例項已刪除"
-	},
 	"app.action-bar.hide-more-running-instances": {
 		"message": "隱藏更多執行中的實例"
 	},
@@ -53,9 +35,6 @@
 	"app.action-bar.install.summary.bad-modpack-file": {
 		"message": "無法讀取模組包檔案"
 	},
-	"app.action-bar.install.summary.unrecognized-format": {
-		"message": "這似乎不是一個整合包文件，無法識別其格式"
-	},
 	"app.action-bar.install.summary.canceled": {
 		"message": "已取消"
 	},
@@ -73,6 +52,9 @@
 	},
 	"app.action-bar.install.summary.download-failed": {
 		"message": "下載未能完成"
+	},
+	"app.action-bar.install.summary.file-download-failed": {
+		"message": "無法下載 {file}"
 	},
 	"app.action-bar.install.summary.instance-not-found": {
 		"message": "找不到實例"
@@ -107,11 +89,11 @@
 	"app.action-bar.install.summary.pack-download-failed": {
 		"message": "無法下載模組包"
 	},
-	"app.action-bar.install.summary.file-download-failed": {
-		"message": "無法下載 {file}"
-	},
 	"app.action-bar.install.summary.unexpected-error": {
 		"message": "發生預期之外的錯誤"
+	},
+	"app.action-bar.install.summary.unrecognized-format": {
+		"message": "這似乎不是一個整合包文件，無法識別其格式"
 	},
 	"app.action-bar.install.unknown-instance": {
 		"message": "未知的實例"
@@ -197,6 +179,12 @@
 	"app.appearance-settings.advanced-rendering.title": {
 		"message": "進階繪製"
 	},
+	"app.appearance-settings.auto-hide-downloads-button.description": {
+		"message": "沒有進行中的下載任務時隱藏側邊欄中的下載按鈕，有任務時自動顯示。"
+	},
+	"app.appearance-settings.auto-hide-downloads-button.title": {
+		"message": "自動隱藏下載按鈕"
+	},
 	"app.appearance-settings.color-theme.description": {
 		"message": "請選擇你偏好的 Axolotl Launcher 色彩主題。"
 	},
@@ -254,6 +242,18 @@
 	"app.appearance-settings.hide-nametag.title": {
 		"message": "隱藏名牌"
 	},
+	"app.appearance-settings.home-layout.description": {
+		"message": "在資訊首頁和專注的實例啟動頁之間選擇。"
+	},
+	"app.appearance-settings.home-layout.minimal": {
+		"message": "極簡"
+	},
+	"app.appearance-settings.home-layout.standard": {
+		"message": "資訊"
+	},
+	"app.appearance-settings.home-layout.title": {
+		"message": "首頁布局"
+	},
 	"app.appearance-settings.minimize-launcher.description": {
 		"message": "當 Minecraft 處理程序啟動時最小化啟動器。"
 	},
@@ -271,18 +271,6 @@
 	},
 	"app.appearance-settings.native-decorations.title": {
 		"message": "原生視窗"
-	},
-	"app.appearance-settings.page-transitions.description": {
-		"message": "在啟動器頁面之間切換時播放過渡動畫。"
-	},
-	"app.appearance-settings.page-transitions.title": {
-		"message": "頁面切換過渡動畫"
-	},
-	"app.appearance-settings.auto-install-dependencies.description": {
-		"message": "安裝內容時自動下載所需前置。每次安裝前仍可在確認對話方塊中調整選擇。"
-	},
-	"app.appearance-settings.auto-install-dependencies.title": {
-		"message": "自動安裝前置"
 	},
 	"app.appearance-settings.select-option": {
 		"message": "選擇選項"
@@ -371,23 +359,14 @@
 	"app.browse.discover-content": {
 		"message": "探索內容"
 	},
-	"app.browse.discover-maps": {
-		"message": "發現地圖"
-	},
 	"app.browse.discover-servers": {
 		"message": "探索伺服器"
 	},
 	"app.browse.hide-added-servers": {
 		"message": "隱藏已新增的伺服器"
 	},
-	"app.browse.maps-unavailable": {
-		"message": "地圖不可用"
-	},
-	"app.browse.maps-unavailable-description": {
-		"message": "請配置 CurseForge API Key 以瀏覽和安裝地圖。"
-	},
-	"app.browse.maps-no-installable-file": {
-		"message": "所選 CurseForge 地圖沒有可安裝的檔案。"
+	"app.browse.project-type.datapacks": {
+		"message": "資料包"
 	},
 	"app.browse.project-type.modpacks": {
 		"message": "模組包"
@@ -398,17 +377,11 @@
 	"app.browse.project-type.resourcepacks": {
 		"message": "資源包"
 	},
-	"app.browse.project-type.datapacks": {
-		"message": "資料包"
-	},
-	"app.browse.project-type.maps": {
-		"message": "地圖"
+	"app.browse.project-type.servers": {
+		"message": "伺服器"
 	},
 	"app.browse.project-type.shaders": {
 		"message": "光影包"
-	},
-	"app.browse.project-type.servers": {
-		"message": "伺服器"
 	},
 	"app.browse.server-instance-content-warning": {
 		"message": "加入內容可能會導致加入伺服器時發生相容性問題。當你更新伺服器實例內容時，任何新增的內容也會遺失。"
@@ -446,107 +419,17 @@
 	"app.content-install.no-compatible-versions": {
 		"message": "沒有符合 {compatibilityLabel} 的可用版本。請選擇一個版本強制安裝。不會自動安裝相依模組。"
 	},
-	"app.content-install.dependencies-installed.notification-body": {
-		"message": "已自動安裝 {count, plural, other {# 個前置}}：{list}"
-	},
-	"app.content-install.dependencies-installed.notification-title": {
-		"message": "已安裝前置"
-	},
-	"app.content-install.dependencies-skipped.notification-body": {
-		"message": "以下前置未安裝：{list}"
-	},
-	"app.content-install.dependencies-skipped.notification-title": {
-		"message": "部分前置已跳過"
-	},
-	"app.content-install.preview.already-included": {
-		"message": "已包含"
-	},
-	"app.content-install.preview.already-installed": {
-		"message": "已安裝"
-	},
-	"app.content-install.preview.cancel": {
-		"message": "取消"
-	},
-	"app.content-install.preview.clear-all": {
-		"message": "全部取消"
-	},
-	"app.content-install.preview.dependencies-count": {
-		"message": "{count, number} 個前置"
-	},
-	"app.content-install.preview.dependencies-header": {
-		"message": "前置"
-	},
-	"app.content-install.preview.description": {
-		"message": "將在 {instance} 中為 {project} 自動安裝 {count, plural, other {# 個前置}}。"
-	},
-	"app.content-install.preview.header": {
-		"message": "確認安裝"
-	},
-	"app.content-install.preview.install": {
-		"message": "安裝"
-	},
-	"app.content-install.preview.only-checked": {
-		"message": "只會安裝勾選的前置。"
-	},
-	"app.content-install.preview.optional-dependencies-header": {
-		"message": "可選前置"
-	},
-	"app.content-install.preview.required-dependencies-header": {
-		"message": "必要前置"
-	},
-	"app.content-install.preview.required-by": {
-		"message": "被 {projects} 需要"
-	},
-	"app.content-install.preview.select-all": {
-		"message": "全選"
-	},
-	"app.content-install.preview.skip.already-installed": {
-		"message": "已安裝"
-	},
-	"app.content-install.preview.skip.conflicting-dependency": {
-		"message": "前置版本衝突"
-	},
-	"app.content-install.preview.skip.duplicate-project": {
-		"message": "已包含"
-	},
-	"app.content-install.preview.skip.embedded": {
-		"message": "已內建於專案中"
-	},
-	"app.content-install.preview.skip.excluded-by-user": {
-		"message": "已由使用者取消"
-	},
-	"app.content-install.preview.skip.incompatible": {
-		"message": "不相容的前置"
-	},
-	"app.content-install.preview.skip.missing-version": {
-		"message": "找不到引用的版本"
-	},
-	"app.content-install.preview.skip.no-compatible-version": {
-		"message": "找不到相容版本"
-	},
-	"app.content-install.preview.skip.optional": {
-		"message": "可選前置"
-	},
-	"app.content-install.preview.skip.quilt-fabric-api": {
-		"message": "已替換為 Quilt 版本"
-	},
-	"app.content-install.preview.skip.tool": {
-		"message": "開發工具，不安裝"
-	},
-	"app.content-install.preview.skip.unsupported-project-type": {
-		"message": "不支援的專案型別"
-	},
-	"app.content-install.preview.skipped-header": {
-		"message": "跳過"
-	},
-	"app.content-install.preview.version-mismatch": {
-		"message": "下載的版本可能與當前版本不相容。"
-	},
 	"app.content.add-from-file": {
 		"message": "從檔案新增"
 	},
 	"app.content.install-content": {
 		"message": "安裝內容"
+	},
+	"app.curseforge.automatic-downloads-failed.notification-body": {
+		"message": "重試後仍有 {failed, number} 個文件下載失敗（{list}）。可在“下載”中查看已記錄的錯誤。"
+	},
+	"app.curseforge.automatic-downloads-failed.notification-title": {
+		"message": "部分 CurseForge 文件下載失敗"
 	},
 	"app.curseforge.manual-downloads.all-imported": {
 		"message": "所有檔案均已匯入"
@@ -562,6 +445,9 @@
 	},
 	"app.curseforge.manual-downloads.checking-downloads": {
 		"message": "正在檢查監控匯入目錄..."
+	},
+	"app.curseforge.manual-downloads.choose-file": {
+		"message": "選擇本機檔案"
 	},
 	"app.curseforge.manual-downloads.downloads-unavailable": {
 		"message": "無法存取監控匯入目錄。"
@@ -611,6 +497,9 @@
 	"app.curseforge.manual-downloads.scanner-failed": {
 		"message": "自動匯入檢查失敗，正在重試。"
 	},
+	"app.curseforge.manual-downloads.state-changed": {
+		"message": "下載狀態已變更，正在等待同步。"
+	},
 	"app.curseforge.manual-downloads.view-instance": {
 		"message": "查看實例"
 	},
@@ -626,6 +515,9 @@
 	"app.curseforge.modpack-installed.title": {
 		"message": "CurseForge 模組包已安裝"
 	},
+	"app.downloads.action-needed": {
+		"message": "需要操作"
+	},
 	"app.downloads.all-sources": {
 		"message": "所有來源"
 	},
@@ -638,107 +530,14 @@
 	"app.downloads.cancel": {
 		"message": "取消"
 	},
-	"app.downloads.skip-missing-files": {
-		"message": "略過"
-	},
-	"app.downloads.complete-missing-files": {
-		"message": "補全缺失檔案"
-	},
-	"app.downloads.missing-content.header": {
-		"message": "補全缺失檔案"
-	},
-	"app.downloads.missing-content.body": {
-		"message": "本機檔案必須通過完整性驗證，才能取代實例中的目標檔案。"
-	},
-	"app.downloads.missing-content.remaining": {
-		"message": "還有 {count} 個檔案需要補全"
-	},
-	"app.downloads.missing-content.continuing": {
-		"message": "正在繼續安裝"
-	},
-	"app.downloads.missing-content.continuing-body": {
-		"message": "全部必要檔案已就緒。啟動器正在重新驗證並繼續安裝。"
-	},
-	"app.downloads.missing-content.expected-size": {
-		"message": "預期大小：{size}"
-	},
-	"app.downloads.missing-content.fallbacks": {
-		"message": "{count} 個備用連結"
-	},
-	"app.downloads.missing-content.retry": {
-		"message": "重新下載"
-	},
-	"app.downloads.missing-content.retry-all": {
-		"message": "重新嘗試全部缺失檔案"
-	},
-	"app.downloads.missing-content.browser-download": {
-		"message": "瀏覽器下載"
-	},
-	"app.downloads.missing-content.choose-file": {
-		"message": "選擇本機檔案"
-	},
-	"app.downloads.missing-content.attempts": {
-		"message": "第 {attempt}/{max} 次嘗試"
-	},
-	"app.downloads.missing-content.no-attempts": {
-		"message": "暫無嘗試資訊"
-	},
-	"app.downloads.missing-content.automatic-import": {
-		"message": "自動從監控目錄匯入"
-	},
-	"app.downloads.missing-content.automatic-import-disabled": {
-		"message": "自動匯入已關閉"
-	},
-	"app.downloads.missing-content.automatic-import-disabled-body": {
-		"message": "你仍可重新下載，或手動選擇每個缺少檔案。"
-	},
-	"app.downloads.missing-content.verifying-candidate": {
-		"message": "正在驗證下載檔案"
-	},
-	"app.downloads.missing-content.verifying-candidate-body": {
-		"message": "正在確認候選檔案是否與整合包要求的檔案一致。"
-	},
-	"app.downloads.missing-content.importing-candidate": {
-		"message": "正在匯入已驗證檔案"
-	},
-	"app.downloads.missing-content.importing-candidate-body": {
-		"message": "正在將已驗證檔案匯入實例..."
-	},
-	"app.downloads.missing-content.watching-downloads-title": {
-		"message": "正在監控匯入目錄"
-	},
-	"app.downloads.missing-content.watching-downloads-body": {
-		"message": "下載完成後將自動驗證並匯入。"
-	},
-	"app.downloads.missing-content.watching-downloads": {
-		"message": "正在監控 {path}。匹配檔案通過驗證後才會匯入。"
-	},
-	"app.downloads.missing-content.waiting-for-completion": {
-		"message": "偵測到下載檔案，正在等待寫入完成..."
-	},
-	"app.downloads.missing-content.downloads-unavailable": {
-		"message": "監控目錄無法使用，仍可手動選擇本機檔案。"
-	},
-	"app.downloads.missing-content.scanner-failed": {
-		"message": "自動檢查失敗，仍可手動選擇本機檔案。"
-	},
-	"app.downloads.missing-content.file-mismatch": {
-		"message": "發現同名候選檔案，但它不是整合包要求的檔案。"
-	},
-	"app.downloads.missing-content.file-mismatch-title": {
-		"message": "發現同名檔案，但檔案驗證未通過"
-	},
-	"app.downloads.missing-content.file-mismatch-body": {
-		"message": "啟動器會繼續等待正確檔案，你也可以手動選擇。"
-	},
-	"app.downloads.missing-content.imported-automatically": {
-		"message": "已自動匯入 {count} 個檔案，還有 {remaining} 個檔案需要補全。"
-	},
 	"app.downloads.clear-history": {
 		"message": "清除歷史紀錄"
 	},
 	"app.downloads.clear-history-title": {
 		"message": "清除下載歷史紀錄？"
+	},
+	"app.downloads.complete-missing-files": {
+		"message": "補全缺失檔案"
 	},
 	"app.downloads.confirm-clear": {
 		"message": "已完成、失敗、中斷和已取消的紀錄將被永久刪除。"
@@ -788,6 +587,9 @@
 	"app.downloads.in-progress": {
 		"message": "執行中"
 	},
+	"app.downloads.instance-deleted": {
+		"message": "實例已刪除"
+	},
 	"app.downloads.instance-target": {
 		"message": "目標實例：{instance}"
 	},
@@ -805,9 +607,6 @@
 	},
 	"app.downloads.item-status": {
 		"message": "狀態"
-	},
-	"app.downloads.manual-download-required": {
-		"message": "CurseForge 要求手動下載此檔案。"
 	},
 	"app.downloads.item-status.completed": {
 		"message": "已完成"
@@ -829,6 +628,102 @@
 	},
 	"app.downloads.local": {
 		"message": "本機"
+	},
+	"app.downloads.manual-download-required": {
+		"message": "CurseForge 要求手動下載此檔案。"
+	},
+	"app.downloads.missing-content.attempts": {
+		"message": "第 {attempt}/{max} 次嘗試"
+	},
+	"app.downloads.missing-content.automatic-import": {
+		"message": "自動從監控目錄匯入"
+	},
+	"app.downloads.missing-content.automatic-import-disabled": {
+		"message": "自動匯入已關閉"
+	},
+	"app.downloads.missing-content.automatic-import-disabled-body": {
+		"message": "你仍可重新下載，或手動選擇每個缺少檔案。"
+	},
+	"app.downloads.missing-content.body": {
+		"message": "本機檔案必須通過完整性驗證，才能取代實例中的目標檔案。"
+	},
+	"app.downloads.missing-content.browser-download": {
+		"message": "瀏覽器下載"
+	},
+	"app.downloads.missing-content.choose-file": {
+		"message": "選擇本機檔案"
+	},
+	"app.downloads.missing-content.continuing": {
+		"message": "正在繼續安裝"
+	},
+	"app.downloads.missing-content.continuing-body": {
+		"message": "全部必要檔案已就緒。啟動器正在重新驗證並繼續安裝。"
+	},
+	"app.downloads.missing-content.downloads-unavailable": {
+		"message": "監控目錄無法使用，仍可手動選擇本機檔案。"
+	},
+	"app.downloads.missing-content.expected-size": {
+		"message": "預期大小：{size}"
+	},
+	"app.downloads.missing-content.fallbacks": {
+		"message": "{count} 個備用連結"
+	},
+	"app.downloads.missing-content.file-mismatch": {
+		"message": "發現同名候選檔案，但它不是整合包要求的檔案。"
+	},
+	"app.downloads.missing-content.file-mismatch-body": {
+		"message": "啟動器會繼續等待正確檔案，你也可以手動選擇。"
+	},
+	"app.downloads.missing-content.file-mismatch-title": {
+		"message": "發現同名檔案，但檔案驗證未通過"
+	},
+	"app.downloads.missing-content.header": {
+		"message": "補全缺失檔案"
+	},
+	"app.downloads.missing-content.imported-automatically": {
+		"message": "已自動匯入 {count} 個檔案，還有 {remaining} 個檔案需要補全。"
+	},
+	"app.downloads.missing-content.importing-candidate": {
+		"message": "正在匯入已驗證檔案"
+	},
+	"app.downloads.missing-content.importing-candidate-body": {
+		"message": "正在將已驗證檔案匯入實例..."
+	},
+	"app.downloads.missing-content.no-attempts": {
+		"message": "暫無嘗試資訊"
+	},
+	"app.downloads.missing-content.remaining": {
+		"message": "還有 {count} 個檔案需要補全"
+	},
+	"app.downloads.missing-content.retry": {
+		"message": "重新下載"
+	},
+	"app.downloads.missing-content.retry-all": {
+		"message": "重新嘗試全部缺失檔案"
+	},
+	"app.downloads.missing-content.scanner-failed": {
+		"message": "自動檢查失敗，仍可手動選擇本機檔案。"
+	},
+	"app.downloads.missing-content.verifying-candidate": {
+		"message": "正在驗證下載檔案"
+	},
+	"app.downloads.missing-content.verifying-candidate-body": {
+		"message": "正在確認候選檔案是否與整合包要求的檔案一致。"
+	},
+	"app.downloads.missing-content.waiting-for-completion": {
+		"message": "偵測到下載檔案，正在等待寫入完成..."
+	},
+	"app.downloads.missing-content.watching-downloads": {
+		"message": "正在監控 {path}。匹配檔案通過驗證後才會匯入。"
+	},
+	"app.downloads.missing-content.watching-downloads-body": {
+		"message": "下載完成後將自動驗證並匯入。"
+	},
+	"app.downloads.missing-content.watching-downloads-title": {
+		"message": "正在監控匯入目錄"
+	},
+	"app.downloads.missing-required-content": {
+		"message": "已完成 {completed} / {total} 個必要檔案，還有 {missing} 個檔案需要補全。"
 	},
 	"app.downloads.more-active-requests": {
 		"message": "另有 {count} 個進行中的請求"
@@ -854,14 +749,8 @@
 	"app.downloads.open-instance": {
 		"message": "開啟實例"
 	},
-	"app.downloads.instance-deleted": {
-		"message": "實例已刪除"
-	},
 	"app.downloads.phase.downloading-content": {
 		"message": "正在下載內容"
-	},
-	"app.downloads.phase.verifying-downloaded-files": {
-		"message": "正在驗證並繼續安裝"
 	},
 	"app.downloads.phase.downloading-minecraft": {
 		"message": "正在下載 Minecraft"
@@ -899,20 +788,20 @@
 	"app.downloads.phase.running-loader-processors": {
 		"message": "正在安裝載入器"
 	},
+	"app.downloads.phase.verifying-downloaded-files": {
+		"message": "正在驗證並繼續安裝"
+	},
 	"app.downloads.progress": {
 		"message": "進度"
 	},
 	"app.downloads.retry": {
 		"message": "重試"
 	},
-	"app.downloads.action-needed": {
-		"message": "需要操作"
-	},
-	"app.downloads.missing-required-content": {
-		"message": "已完成 {completed} / {total} 個必要檔案，還有 {missing} 個檔案需要補全。"
-	},
 	"app.downloads.search": {
 		"message": "搜尋下載任務"
+	},
+	"app.downloads.skip-missing-files": {
+		"message": "略過"
 	},
 	"app.downloads.source.alternate": {
 		"message": "備用來源"
@@ -949,6 +838,153 @@
 	},
 	"app.downloads.status.waiting-for-user": {
 		"message": "需要操作"
+	},
+	"app.drop.content-installed-text": {
+		"message": "文件已安裝到實例。"
+	},
+	"app.drop.content-installed-title": {
+		"message": "內容已安裝"
+	},
+	"app.drop.error.multiple-files-text": {
+		"message": "一次只能拖放一個文件或文件夾。"
+	},
+	"app.drop.error.multiple-files-title": {
+		"message": "無法導入多個文件"
+	},
+	"app.drop.error.shortcut-text": {
+		"message": "無法解析到捷徑的目標。"
+	},
+	"app.drop.error.shortcut-title": {
+		"message": "捷徑解析失敗"
+	},
+	"app.drop.error.title": {
+		"message": "拖放錯誤"
+	},
+	"app.drop.error.unknown-depth-text": {
+		"message": "壓縮檔嵌套層級過深，無法分析。請先解壓到資料夾後重試。"
+	},
+	"app.drop.error.unknown-encrypted-text": {
+		"message": "壓縮檔包含加密檔案，無法分析。"
+	},
+	"app.drop.error.unknown-text": {
+		"message": "類型暫不支持"
+	},
+	"app.drop.error.unknown-title": {
+		"message": "未知文件類型"
+	},
+	"app.drop.extract-failed": {
+		"message": "壓縮檔解壓失敗"
+	},
+	"app.drop.import-completed-partial-text": {
+		"message": "已導入 {completed} / {total} 個實例（{failed} 個失敗）"
+	},
+	"app.drop.import-completed-text": {
+		"message": "成功導入 {count} 個實例"
+	},
+	"app.drop.import-completed-title": {
+		"message": "導入完成"
+	},
+	"app.drop.import-failed-text": {
+		"message": "導入 {name} 失敗：{error}"
+	},
+	"app.drop.import-failed-title": {
+		"message": "導入失敗"
+	},
+	"app.drop.import-progress-text": {
+		"message": "已導入 {current} / {total} 個實例"
+	},
+	"app.drop.import-progress-title": {
+		"message": "正在導入實例…"
+	},
+	"app.drop.install-failed-title": {
+		"message": "安裝失敗"
+	},
+	"app.drop.installing-file": {
+		"message": "正在安裝 {name}…"
+	},
+	"app.drop.instance-imported-text": {
+		"message": "{name} 導入成功。"
+	},
+	"app.drop.instance-imported-title": {
+		"message": "實例已導入"
+	},
+	"app.drop.mod-compatibility-title": {
+		"message": "版本不相符"
+	},
+	"app.drop.mod-compatibility-warning": {
+		"message": "{file} 的目標版本為 {modVersion}（{modLoader}），但實例的版本是 {instVersion}（{instLoader}）。"
+	},
+	"app.drop.modpack-install-failed": {
+		"message": "整合包安裝失敗"
+	},
+	"app.drop.modpack-installed-success": {
+		"message": "整合包安裝完成"
+	},
+	"app.drop.modpack-installing": {
+		"message": "正在安裝整合包..."
+	},
+	"app.drop.nested-unpack-button": {
+		"message": "繼續分析"
+	},
+	"app.drop.nested-unpack-text": {
+		"message": "此壓縮檔內含嵌套壓縮檔（{size}），需要解壓後才能分析，可能需要一些時間。是否繼續？"
+	},
+	"app.drop.nested-unpack-title": {
+		"message": "偵測到嵌套壓縮檔"
+	},
+	"app.drop.no-instances": {
+		"message": "未找到實例"
+	},
+	"app.drop.overlay-subtitle": {
+		"message": "Release to classify and import"
+	},
+	"app.drop.overlay-title": {
+		"message": "拖放以導入"
+	},
+	"app.drop.process-failed-title": {
+		"message": "處理檔案失敗"
+	},
+	"app.drop.processing": {
+		"message": "正在處理 {name}..."
+	},
+	"app.drop.scan-failed": {
+		"message": "實例掃描失敗"
+	},
+	"app.drop.scanning": {
+		"message": "正在掃描實例…"
+	},
+	"app.drop.temporary-file-text": {
+		"message": "檔案「{file}」似乎是暫存副本。請嘗試從檔案的原始位置拖入，而不是從瀏覽器、壓縮檔或雲端儲存。"
+	},
+	"app.drop.temporary-file-title": {
+		"message": "偵測到暫存檔案"
+	},
+	"app.drop.unexpected-type": {
+		"message": "意外的類型：{type}"
+	},
+	"app.drop.unknown-force-analysis-button": {
+		"message": "強力解析"
+	},
+	"app.drop.unknown-force-analysis-failed-text": {
+		"message": "深度分析後仍無法識別該檔案類型。"
+	},
+	"app.drop.unknown-force-analysis-failed-title": {
+		"message": "分析失敗"
+	},
+	"app.drop.unknown-force-analysis-text": {
+		"message": "該壓縮檔無法通過快速掃描識別，需要完整解壓後進行深度分析。此操作可能需要一些時間，是否繼續？"
+	},
+	"app.drop.unknown-force-analysis-title": {
+		"message": "無法識別檔案類型"
+	},
+	"app.drop.unknown-force-analyzing": {
+		"message": "正在強力解析壓縮檔..."
+	},
+	"app.drop.world-imported-text": {
+		"message": "存檔已成功導入。"
+	},
+	"app.drop.world-imported-title": {
+		"message": "存檔已導入"
 	},
 	"app.error.account-description": {
 		"message": "請確認登入的是正確帳號。你可能在另一個 Microsoft 帳號上擁有 Minecraft。"
@@ -1091,6 +1127,213 @@
 	"app.home.breadcrumb": {
 		"message": "首頁"
 	},
+	"app.home.calendar.next": {
+		"message": "下個月"
+	},
+	"app.home.calendar.no-activity": {
+		"message": "這一天沒有遊玩記錄。"
+	},
+	"app.home.calendar.play": {
+		"message": "啟動"
+	},
+	"app.home.calendar.played-on": {
+		"message": "{date}你遊玩了："
+	},
+	"app.home.calendar.previous": {
+		"message": "上個月"
+	},
+	"app.home.calendar.stop": {
+		"message": "停止"
+	},
+	"app.home.calendar.this-month": {
+		"message": "回到本月"
+	},
+	"app.home.calendar.title": {
+		"message": "日曆"
+	},
+	"app.home.challenge.easy": {
+		"message": "簡單"
+	},
+	"app.home.challenge.hard": {
+		"message": "困難"
+	},
+	"app.home.challenge.medium": {
+		"message": "中等"
+	},
+	"app.home.challenge.shuffle": {
+		"message": "換一個"
+	},
+	"app.home.challenge.title": {
+		"message": "每日小挑戰"
+	},
+	"app.home.greeting.afternoon": {
+		"message": "午後休息，時機正好。\n短短一局也可能很精彩。\n世界已準備好接住你的下一步。\n該去看看那座半成品建築了。\n一點探索就能走很遠。\n下一個生物群系正在呼喚。\n你的背包耐心等候很久了。\n村莊市場還沒關門。\n這一小時適合專心做個項目。\n紅石今天大概會聽話。\n你的鎬子準備開工。\n出生點外還有新路線。\n午後天生適合支線任務。\n要不要快速回世界看看？\n下一章從這裡開始。\n花一點時間，做點東西。"
+	},
+	"app.home.greeting.dawn": {
+		"message": "天剛亮，區塊正新。\n新的一天正在載入。\n日出增益已生效。\n清晨的世界總像全新的。\n先喝咖啡，再挖鑽石。\n你的基地想你一整晚了。\n從容開局，也能成就好冒險。\n主世界正在甦醒。\n新鮮空氣，新鮮資源包。\n今天很適合去探索。\n村莊已經開門交易了。\n安靜的早晨適合大工程。\n新的一天，新的坐標。\n苦力怕也不太像早起的人。\n先從小事開始，看看會去向何處。\n下一局已經準備好，等你出發。"
+	},
+	"app.home.greeting.evening": {
+		"message": "傍晚正是建造的黃金時間。\n白天將盡，世界剛剛展開。\n熟悉的世界是個好去處。\n該回到你最愛的項目了。\n從新塔上看日落更美。\n基地的燈正等著你。\n輕鬆玩一局正合適。\n村民很快要收攤了。\n你的下一座建築值得一層暮色。\n適合沒有計劃地四處走走。\n營火已經點好了。\n基地要不要再加一間房？\n地平線看起來格外誘人。\n安靜的夜晚從好世界開始。\n下一塊方塊該你放下。\n讓今晚的進度算數。"
+	},
+	"app.home.greeting.late-night": {
+		"message": "月亮還在加班。\n安靜的世界正等著你。\n夜班總能寫出好故事。\n黎明前再放一塊方塊？\n星光會看顧好你的伺服器。\n深夜時段，也能留下傳奇存檔。\n現在的火把光格外好看。\n下一場冒險還沒睡。\n午夜後的礦洞更安靜。\n和平的出生點在等你。\n耐心的建造者屬於夜晚。\n把音樂調低，把靈感調高。\n每一座好基地都從一塊方塊開始。\n終界可以等等，除非它等不了。\n短短一局也算數。\n這個世界已經為你保存好了。"
+	},
+	"app.home.greeting.minimal.afternoon": {
+		"message": "午安"
+	},
+	"app.home.greeting.minimal.dawn": {
+		"message": "清晨好"
+	},
+	"app.home.greeting.minimal.evening": {
+		"message": "傍晚好"
+	},
+	"app.home.greeting.minimal.late-night": {
+		"message": "夜深了"
+	},
+	"app.home.greeting.minimal.morning": {
+		"message": "早安"
+	},
+	"app.home.greeting.minimal.night": {
+		"message": "晚上好"
+	},
+	"app.home.greeting.minimal.with-player": {
+		"message": "{greeting}，{name}"
+	},
+	"app.home.greeting.morning": {
+		"message": "早安，冒險家。\n今天還有許多未探索的區塊。\n正適合重新開始。\n你的工具已為今天就緒。\n主世界有不少好計劃。\n造點未來的你會喜歡的東西。\n新的一局像一張乾淨畫布。\n太陽升起了，村民也是。\n讓今天多一點方塊感。\n礦井安靜得有點可疑。\n下一個項目只差一次啟動。\n好早晨，配好世界。\n總能再裝下一個新點子。\n工作台正在待命。\n地圖在等新的標記。\n坐穩，做點進度。"
+	},
+	"app.home.greeting.night": {
+		"message": "夜班準備好了。\n熟悉的世界適合這個夜晚。\n你最愛的實例就在附近。\n星星出來了，計劃也定好了。\n平靜的一局能好好結束今天。\n天黑後世界更安靜。\n該再放幾塊方塊了。\n遠處的基地正在發光。\n下一場冒險從日落開始。\n一個好存檔配得上一個好夜晚。\n不知何處，營火正噼啪作響。\n月光讓每座建築都更有戲劇感。\n明天之前來一點 Minecraft。\n你的世界隨時歡迎你回去。\n按區塊算，夜還很長。\n開始一段值得的遊戲時光吧。"
+	},
+	"app.home.greeting.with-player": {
+		"message": "{name}，{greeting}"
+	},
+	"app.home.insights.empty": {
+		"message": "開始遊玩後，這裡會顯示你的統計。"
+	},
+	"app.home.insights.streak": {
+		"message": "已連續遊玩 {days} 天"
+	},
+	"app.home.insights.this-week": {
+		"message": "本週遊玩 {duration}"
+	},
+	"app.home.insights.this-week-less": {
+		"message": "本週遊玩 {duration}（比上週少 {percent}%）"
+	},
+	"app.home.insights.this-week-more": {
+		"message": "本週遊玩 {duration}（比上週多 {percent}%）"
+	},
+	"app.home.insights.this-week-same": {
+		"message": "本週遊玩 {duration}（與上週持平）"
+	},
+	"app.home.insights.title": {
+		"message": "遊玩洞察"
+	},
+	"app.home.insights.week-top": {
+		"message": "本週常玩：{name}"
+	},
+	"app.home.instances.create": {
+		"message": "創建實例"
+	},
+	"app.home.instances.empty": {
+		"message": "還沒有實例"
+	},
+	"app.home.instances.pin": {
+		"message": "固定到首頁"
+	},
+	"app.home.instances.pinned": {
+		"message": "固定的實例"
+	},
+	"app.home.instances.pinned-empty": {
+		"message": "在實例卡片菜單或實例庫中選擇「固定到首頁」，實例就會顯示在這裡。"
+	},
+	"app.home.instances.unpin": {
+		"message": "取消固定"
+	},
+	"app.home.instances.view-all": {
+		"message": "查看全部實例"
+	},
+	"app.home.layout.switch-to-information": {
+		"message": "切換到資訊首頁"
+	},
+	"app.home.layout.switch-to-minimal": {
+		"message": "切換到極簡首頁"
+	},
+	"app.home.layout.toggle": {
+		"message": "極簡首頁"
+	},
+	"app.home.minimal.change-instance": {
+		"message": "更換首頁實例"
+	},
+	"app.home.minimal.choose-instance": {
+		"message": "選擇實例"
+	},
+	"app.home.minimal.picker.no-results": {
+		"message": "沒有匹配的實例"
+	},
+	"app.home.minimal.picker.search": {
+		"message": "搜索實例"
+	},
+	"app.home.minimal.picker.select": {
+		"message": "選擇 {name}"
+	},
+	"app.home.minimal.picker.title": {
+		"message": "選擇首頁實例"
+	},
+	"app.home.news.open-article": {
+		"message": "在 minecraft.net 上閱讀"
+	},
+	"app.home.news.title": {
+		"message": "Minecraft 新聞"
+	},
+	"app.home.playtime.hours-minutes": {
+		"message": "{hours} 小時 {minutes} 分鐘"
+	},
+	"app.home.playtime.minutes": {
+		"message": "{minutes} 分鐘"
+	},
+	"app.home.playtime.most-played": {
+		"message": "當天常玩：{name}"
+	},
+	"app.home.playtime.seconds": {
+		"message": "{seconds} 秒"
+	},
+	"app.home.playtime.sessions": {
+		"message": "成功啟動 {count} 次"
+	},
+	"app.home.recent.title": {
+		"message": "從最近的項目開始"
+	},
+	"app.home.servers.empty": {
+		"message": "將伺服器標記為收藏後，就會固定在這裡。"
+	},
+	"app.home.servers.join": {
+		"message": "加入伺服器"
+	},
+	"app.home.servers.more-options": {
+		"message": "更多選項"
+	},
+	"app.home.servers.offline": {
+		"message": "離線"
+	},
+	"app.home.servers.pinned": {
+		"message": "固定的伺服器"
+	},
+	"app.home.servers.players-online": {
+		"message": "{online}/{max} 人在線"
+	},
+	"app.home.servers.stop": {
+		"message": "停止"
+	},
+	"app.home.servers.unpin": {
+		"message": "取消固定"
+	},
+	"app.home.worlds.empty": {
+		"message": "將世界標記為收藏後，就會固定在這裡。"
+	},
+	"app.home.worlds.pinned": {
+		"message": "固定的世界"
+	},
 	"app.install.phase.downloading_content": {
 		"message": "正在下載內容"
 	},
@@ -1145,6 +1388,18 @@
 	"app.install.phase.running_loader_processors": {
 		"message": "正在執行載入器處理程式"
 	},
+	"app.instance-item.already-open": {
+		"message": "實例已經在運行"
+	},
+	"app.instance-item.loading-modpack": {
+		"message": "正在載入整合包……"
+	},
+	"app.instance-item.not-played-yet": {
+		"message": "還沒有遊玩過"
+	},
+	"app.instance-item.view-instance": {
+		"message": "查看實例"
+	},
 	"app.instance.back": {
 		"message": "返回實例"
 	},
@@ -1154,20 +1409,23 @@
 	"app.instance.confirm-delete.admonition-header": {
 		"message": "這項動作無法復原"
 	},
-	"app.instance.confirm-delete.delete-button": {
-		"message": "刪除實例"
+	"app.instance.confirm-delete.batch-admonition-body": {
+		"message": "將永久刪除 {count, plural, other {#}} 個實例，包括存檔、設定和所有已安裝內容。"
 	},
 	"app.instance.confirm-delete.batch-delete-button": {
 		"message": "刪除 {count, plural, other {#}} 個實例"
 	},
-	"app.instance.confirm-delete.header": {
-		"message": "刪除實例"
-	},
 	"app.instance.confirm-delete.batch-header": {
 		"message": "刪除實例"
 	},
-	"app.instance.confirm-delete.batch-admonition-body": {
-		"message": "將永久刪除 {count, plural, other {#}} 個實例，包括存檔、設定和所有已安裝內容。"
+	"app.instance.confirm-delete.delete-button": {
+		"message": "刪除實例"
+	},
+	"app.instance.confirm-delete.header": {
+		"message": "刪除實例"
+	},
+	"app.instance.confirm-delete.symlink-warning": {
+		"message": "這是一個連結到「{path}」的共用實例。只會刪除連結，原始檔案不會被刪除。"
 	},
 	"app.instance.copy-links": {
 		"message": "複製連結"
@@ -1199,6 +1457,9 @@
 	"app.instance.icon-picker.description": {
 		"message": "選擇內建的 Minecraft 圖示，或上傳自己的圖片。"
 	},
+	"app.instance.icon-picker.icon.anvil": {
+		"message": "鐵砧"
+	},
 	"app.instance.icon-picker.icon.bread": {
 		"message": "麵包"
 	},
@@ -1223,6 +1484,9 @@
 	"app.instance.icon-picker.icon.end-stone": {
 		"message": "終界石"
 	},
+	"app.instance.icon-picker.icon.fabric": {
+		"message": "Fabric"
+	},
 	"app.instance.icon-picker.icon.furnace": {
 		"message": "熔爐"
 	},
@@ -1244,11 +1508,17 @@
 	"app.instance.icon-picker.icon.item-frame": {
 		"message": "物品展示框"
 	},
+	"app.instance.icon-picker.icon.neoforge": {
+		"message": "NeoForge"
+	},
 	"app.instance.icon-picker.icon.netherrack": {
 		"message": "地獄石"
 	},
 	"app.instance.icon-picker.icon.oak-sapling": {
 		"message": "橡木樹苗"
+	},
+	"app.instance.icon-picker.icon.quilt": {
+		"message": "Quilt"
 	},
 	"app.instance.icon-picker.icon.stone": {
 		"message": "石頭"
@@ -1258,18 +1528,6 @@
 	},
 	"app.instance.icon-picker.icon.water-bucket": {
 		"message": "水桶"
-	},
-	"app.instance.icon-picker.icon.anvil": {
-		"message": "鐵砧"
-	},
-	"app.instance.icon-picker.icon.fabric": {
-		"message": "Fabric"
-	},
-	"app.instance.icon-picker.icon.neoforge": {
-		"message": "NeoForge"
-	},
-	"app.instance.icon-picker.icon.quilt": {
-		"message": "Quilt"
 	},
 	"app.instance.icon-picker.load-error": {
 		"message": "無法載入內建圖示。"
@@ -1319,59 +1577,17 @@
 	"app.instance.mods.content-refresh-warning.title": {
 		"message": "部分線上資訊暫時無法使用"
 	},
-	"app.instance.mods.pack-member-missing": {
-		"message": "此模組包檔案在本機缺失"
-	},
-	"app.instance.mods.pack-member-removed": {
-		"message": "此模組包檔案已在本機移除"
-	},
-	"app.instance.mods.restore-pack-default": {
-		"message": "還原模組包預設檔案"
-	},
 	"app.instance.mods.content-type-project": {
 		"message": "專案"
 	},
-	"app.instance.mods.orphaned-dependencies.body": {
-		"message": "以下前置已不再被其他內容需要，且不會被自動刪除：{list}"
+	"app.instance.mods.dismiss": {
+		"message": "知道了"
 	},
-	"app.instance.mods.orphaned-dependencies.title": {
-		"message": "前置已不再被需要"
+	"app.instance.mods.drag-drop-hint": {
+		"message": "釋放文件以安裝到當前實例"
 	},
-	"app.instance.mods.toggle-dependencies.apply": {
-		"message": "切換相關內容"
-	},
-	"app.instance.mods.toggle-dependencies.bulk-body": {
-		"message": "切換所選內容將同時影響 {count} 個其他內容。"
-	},
-	"app.instance.mods.toggle-dependencies.selected-only": {
-		"message": "僅切換所選"
-	},
-	"app.instance.mods.toggle-dependencies.single-body": {
-		"message": "切換 {project} 將同時影響 {count} 個其他內容。"
-	},
-	"app.instance.mods.toggle-dependencies.title": {
-		"message": "確認切換"
-	},
-	"app.instance.mods.toggle-dependencies.warning": {
-		"message": "是否自動應用這些相關更改？忽略它們可能導致遊戲無法正常執行。"
-	},
-	"app.instance.mods.toggle-dependencies.will-disable": {
-		"message": "以下內容將同時禁用："
-	},
-	"app.instance.mods.toggle-dependencies.will-enable": {
-		"message": "以下內容將同時啟用："
-	},
-	"app.instance.mods.project-was-added": {
-		"message": "已新增「{name}」"
-	},
-	"app.instance.mods.projects-were-added": {
-		"message": "已新增 {count} 個專案"
-	},
-	"app.instance.mods.share-text": {
-		"message": "快來看看我在模組包中使用的專案！"
-	},
-	"app.instance.mods.share-title": {
-		"message": "分享模組包內容"
+	"app.instance.mods.file-already-exists": {
+		"message": "添加失敗，該文件可能已存在"
 	},
 	"app.instance.mods.missing-files-warning.body": {
 		"message": "以下模組包必要檔案未能下載或已不在本機。可逐項還原；重新整理會再次掃描實例資料夾。"
@@ -1382,11 +1598,41 @@
 	"app.instance.mods.missing-files-warning.title": {
 		"message": "模組包檔案缺失"
 	},
+	"app.instance.mods.pack-member-missing": {
+		"message": "此模組包檔案在本機缺失"
+	},
+	"app.instance.mods.pack-member-removed": {
+		"message": "此模組包檔案已在本機移除"
+	},
+	"app.instance.mods.parse-failed": {
+		"message": "解析失敗，這可能不是一個整合包"
+	},
+	"app.instance.mods.parsing-files": {
+		"message": "正在解析，較大的文件可能會耗費一些時間"
+	},
+	"app.instance.mods.project-was-added": {
+		"message": "已新增「{name}」"
+	},
+	"app.instance.mods.projects-were-added": {
+		"message": "已新增 {count} 個專案"
+	},
+	"app.instance.mods.restore-pack-default": {
+		"message": "還原模組包預設檔案"
+	},
+	"app.instance.mods.share-text": {
+		"message": "快來看看我在模組包中使用的專案！"
+	},
+	"app.instance.mods.share-title": {
+		"message": "分享模組包內容"
+	},
 	"app.instance.mods.skipped-files-warning.body": {
 		"message": "由於網路原因或依模組開發者要求，安裝過程中已略過 {count, number} 個檔案。點擊檔案名稱下載；啟動器會自動驗證設定中的監控匯入目錄。也可以把下載後的檔案拖入此實例。開啟「補全缺失檔案」對話框時，啟動器會自動檢查監聽匯入資料夾。你也可以直接將下載的檔案拖入此實例。"
 	},
 	"app.instance.mods.skipped-files-warning.body-disabled": {
 		"message": "由於網路原因或依模組開發者要求，安裝過程中已略過 {count, number} 個檔案。請把下載後的檔案拖入此實例，或在資源管理設定中開啟自動匯入。監聽資料夾自動匯入功能已關閉，你可以在設定中開啟。"
+	},
+	"app.instance.mods.skipped-files-warning.complete": {
+		"message": "補齊缺失檔案"
 	},
 	"app.instance.mods.skipped-files-warning.more": {
 		"message": "另有 {count, number} 個檔案。"
@@ -1394,14 +1640,14 @@
 	"app.instance.mods.skipped-files-warning.title": {
 		"message": "部分模組包檔案需要手動安裝"
 	},
+	"app.instance.mods.successfully-uploaded": {
+		"message": "已成功上傳"
+	},
 	"app.instance.mods.update-added-content": {
 		"message": "更新後裝內容"
 	},
 	"app.instance.mods.update-added-content.description": {
 		"message": "僅更新模組包安裝後新增的內容，不會變更模組包內建檔案。"
-	},
-	"app.instance.mods.successfully-uploaded": {
-		"message": "已成功上傳"
 	},
 	"app.instance.never-played": {
 		"message": "從未遊玩"
@@ -1505,9 +1751,6 @@
 	"app.instance.worlds.add-server": {
 		"message": "新增伺服器"
 	},
-	"app.instance.worlds.browse-maps": {
-		"message": "瀏覽地圖"
-	},
 	"app.instance.worlds.browse-servers": {
 		"message": "瀏覽伺服器"
 	},
@@ -1556,14 +1799,44 @@
 	"app.instance.worlds.search-worlds-placeholder": {
 		"message": "搜尋 {count} 個世界..."
 	},
+	"app.settings.resources.curseforge-mirror-description": {
+		"message": "CurseForge 檔案下載。"
+	},
 	"app.instances.add-content": {
 		"message": "新增內容"
+	},
+	"app.instances.batch-edit-groups.apply": {
+		"message": "套用"
+	},
+	"app.instances.batch-edit-groups.create-group": {
+		"message": "建立新分組"
+	},
+	"app.instances.batch-edit-groups.description": {
+		"message": "為 {count} 個實例設定分組"
+	},
+	"app.instances.batch-edit-groups.enter-group-name": {
+		"message": "分組名稱"
+	},
+	"app.settings.resources.source.tianpao": {
+		"message": "Tianpao 鏡像"
+	},
+	"app.settings.resources.maximum-downloads": {
+		"message": "最大同時下載數"
+	},
+	"app.instances.batch-edit-groups.header": {
+		"message": "編輯分組"
 	},
 	"app.instances.copy-path": {
 		"message": "複製路徑"
 	},
+	"app.instances.deselect-all": {
+		"message": "取消全選"
+	},
 	"app.instances.duplicate-instance": {
 		"message": "複製實例"
+	},
+	"app.instances.edit-groups": {
+		"message": "編輯分組"
 	},
 	"app.instances.group-by": {
 		"message": "分組方式："
@@ -1580,14 +1853,20 @@
 	"app.instances.group.none": {
 		"message": "無"
 	},
-	"app.instances.group.ungrouped": {
-		"message": "無分組"
+	"app.instances.pin-to-home": {
+		"message": "固定到首頁"
 	},
 	"app.instances.search": {
 		"message": "搜尋"
 	},
 	"app.instances.select": {
 		"message": "請選擇..."
+	},
+	"app.instances.select-all": {
+		"message": "全選"
+	},
+	"app.instances.selected-count": {
+		"message": "已選擇 {count} 個"
 	},
 	"app.instances.sort.date-created": {
 		"message": "建立日期"
@@ -1600,6 +1879,9 @@
 	},
 	"app.instances.sort.name": {
 		"message": "名稱"
+	},
+	"app.instances.unpin-from-home": {
+		"message": "取消固定"
 	},
 	"app.instances.view-instance": {
 		"message": "查看實例"
@@ -1649,81 +1931,6 @@
 	"app.java.select-version": {
 		"message": "選擇 Java 版本"
 	},
-	"app.java-arguments.presets.applied": {
-		"message": "已應用"
-	},
-	"app.java-arguments.presets.arguments": {
-		"message": "引數"
-	},
-	"app.java-arguments.presets.auth-group-title": {
-		"message": "Mojang認證代理"
-	},
-	"app.java-arguments.presets.auth-mirror.description": {
-		"message": "來自 Fallen-Breath 搭建的 Mojang 認證伺服器 HTTP 轉發。"
-	},
-	"app.java-arguments.presets.auth-mirror.title": {
-		"message": "映象認證服務"
-	},
-	"app.java-arguments.presets.button": {
-		"message": "引數預設"
-	},
-	"app.java-arguments.presets.collapse-group": {
-		"message": "摺疊分組"
-	},
-	"app.java-arguments.presets.expand-group": {
-		"message": "展開分組"
-	},
-	"app.java-arguments.presets.gc-group-title": {
-		"message": "記憶體回收策略 (GC)"
-	},
-	"app.java-arguments.presets.gc.auto.description": {
-		"message": "自動為你的系統選擇最佳 GC 策略"
-	},
-	"app.java-arguments.presets.gc.auto.reason-chain": {
-		"message": "決策路徑：{chain}"
-	},
-	"app.java-arguments.presets.gc.auto.resolved": {
-		"message": "已解析 → {strategy}"
-	},
-	"app.java-arguments.presets.gc.auto.title": {
-		"message": "自動GC"
-	},
-	"app.java-arguments.presets.gc.g1gc-mojang.description": {
-		"message": "接近官方的 G1GC 調優"
-	},
-	"app.java-arguments.presets.gc.g1gc-mojang.title": {
-		"message": "Mojang G1GC"
-	},
-	"app.java-arguments.presets.gc.g1gc-pcl.description": {
-		"message": "PCL 啟動器使用的 Shenandoah（adaptive）調優"
-	},
-	"app.java-arguments.presets.gc.g1gc-pcl.title": {
-		"message": "PCL"
-	},
-	"app.java-arguments.presets.gc.shenandoah.description": {
-		"message": "自適應低停頓 Shenandoah，啟用大頁記憶體（如支援）"
-	},
-	"app.java-arguments.presets.gc.shenandoah.title": {
-		"message": "Shenandoah"
-	},
-	"app.java-arguments.presets.gc.zgc.description": {
-		"message": "面向高階系統的超低延遲 GC（Java 15+）"
-	},
-	"app.java-arguments.presets.gc.zgc.title": {
-		"message": "ZGC"
-	},
-	"app.java-arguments.presets.modal-title": {
-		"message": "Java 引數預設"
-	},
-	"app.java-arguments.presets.remove": {
-		"message": "移除預設"
-	},
-	"app.java-arguments.presets.use": {
-		"message": "使用預設"
-	},
-	"app.java.test-installation": {
-		"message": "測試 Java 安裝"
-	},
 	"app.java.table.actions": {
 		"message": "操作"
 	},
@@ -1732,6 +1939,699 @@
 	},
 	"app.java.table.version": {
 		"message": "版本"
+	},
+	"app.java.test-installation": {
+		"message": "測試 Java 安裝"
+	},
+	"app.lab.category.all": {
+		"message": "全部工具"
+	},
+	"app.lab.category.creation": {
+		"message": "創作"
+	},
+	"app.lab.category.maintenance": {
+		"message": "維護"
+	},
+	"app.lab.category.world": {
+		"message": "世界"
+	},
+	"app.lab.gradient-text.adapter.bbcode": {
+		"message": "BBCode"
+	},
+	"app.lab.gradient-text.adapter.chat-colors": {
+		"message": "聊天顏色"
+	},
+	"app.lab.gradient-text.adapter.cmi": {
+		"message": "CMI"
+	},
+	"app.lab.gradient-text.adapter.csv": {
+		"message": "CSV"
+	},
+	"app.lab.gradient-text.adapter.html": {
+		"message": "HTML"
+	},
+	"app.lab.gradient-text.adapter.json": {
+		"message": "JSON 文本組件"
+	},
+	"app.lab.gradient-text.adapter.minedown": {
+		"message": "MineDown"
+	},
+	"app.lab.gradient-text.adapter.minimessage": {
+		"message": "MiniMessage"
+	},
+	"app.lab.gradient-text.adapter.minimessage-gradient": {
+		"message": "MiniMessage 漸變"
+	},
+	"app.lab.gradient-text.adapter.motd": {
+		"message": "伺服器 MOTD"
+	},
+	"app.lab.gradient-text.adapter.rosegarden-gradient": {
+		"message": "RoseGarden 漸變"
+	},
+	"app.lab.gradient-text.adapter.snbt": {
+		"message": "字串化 NBT"
+	},
+	"app.lab.gradient-text.adapter.standard": {
+		"message": "標準 HEX"
+	},
+	"app.lab.gradient-text.adapter.taboolib": {
+		"message": "TabooLib"
+	},
+	"app.lab.gradient-text.adapter.taboolib-gradient": {
+		"message": "TabooLib 漸變"
+	},
+	"app.lab.gradient-text.adapter.terraria": {
+		"message": "泰拉瑞亞"
+	},
+	"app.lab.gradient-text.adapter.trchat": {
+		"message": "TrChat"
+	},
+	"app.lab.gradient-text.adapter.vanilla": {
+		"message": "原版"
+	},
+	"app.lab.gradient-text.adapter.vanilla-compatible": {
+		"message": "原版相容"
+	},
+	"app.lab.gradient-text.colors.add": {
+		"message": "添加顏色"
+	},
+	"app.lab.gradient-text.colors.import": {
+		"message": "導入顏色"
+	},
+	"app.lab.gradient-text.colors.import-placeholder": {
+		"message": "黏貼 HEX、RGB 或 CSS 漸變"
+	},
+	"app.lab.gradient-text.colors.invalid": {
+		"message": "請至少輸入一個有效顏色。"
+	},
+	"app.lab.gradient-text.colors.move-down": {
+		"message": "下移顏色"
+	},
+	"app.lab.gradient-text.colors.move-up": {
+		"message": "上移顏色"
+	},
+	"app.lab.gradient-text.colors.randomize": {
+		"message": "隨機生成顏色"
+	},
+	"app.lab.gradient-text.colors.remove": {
+		"message": "刪除顏色"
+	},
+	"app.lab.gradient-text.colors.stops": {
+		"message": "{count} 個顏色停靠點"
+	},
+	"app.lab.gradient-text.colors.title": {
+		"message": "顏色"
+	},
+	"app.lab.gradient-text.description": {
+		"message": "無需瀏覽器即可創建適用於 Minecraft 的漸變文字。"
+	},
+	"app.lab.gradient-text.format.bold": {
+		"message": "粗體"
+	},
+	"app.lab.gradient-text.format.italic": {
+		"message": "斜體"
+	},
+	"app.lab.gradient-text.format.obfuscated": {
+		"message": "混淆"
+	},
+	"app.lab.gradient-text.format.simplify": {
+		"message": "簡化漸變標籤"
+	},
+	"app.lab.gradient-text.format.strikethrough": {
+		"message": "刪除線"
+	},
+	"app.lab.gradient-text.format.title": {
+		"message": "輸出格式"
+	},
+	"app.lab.gradient-text.format.underlined": {
+		"message": "下劃線"
+	},
+	"app.lab.gradient-text.format.vanilla-character": {
+		"message": "顏色控制符"
+	},
+	"app.lab.gradient-text.input.placeholder": {
+		"message": "在此輸入 Minecraft 文本"
+	},
+	"app.lab.gradient-text.input.title": {
+		"message": "文本"
+	},
+	"app.lab.gradient-text.output.copied": {
+		"message": "已複製輸出"
+	},
+	"app.lab.gradient-text.output.copy": {
+		"message": "複製輸出"
+	},
+	"app.lab.gradient-text.output.export": {
+		"message": "導出輸出"
+	},
+	"app.lab.gradient-text.output.title": {
+		"message": "輸出"
+	},
+	"app.lab.gradient-text.presets.apply": {
+		"message": "應用預設"
+	},
+	"app.lab.gradient-text.presets.count": {
+		"message": "已保存 {count} 個"
+	},
+	"app.lab.gradient-text.presets.delete": {
+		"message": "刪除預設"
+	},
+	"app.lab.gradient-text.presets.export": {
+		"message": "導出預設"
+	},
+	"app.lab.gradient-text.presets.import": {
+		"message": "導入預設"
+	},
+	"app.lab.gradient-text.presets.imported": {
+		"message": "已導入 {count} 個預設"
+	},
+	"app.lab.gradient-text.presets.invalid-file": {
+		"message": "該文件不包含有效預設。"
+	},
+	"app.lab.gradient-text.presets.name": {
+		"message": "預設名稱"
+	},
+	"app.lab.gradient-text.presets.save": {
+		"message": "保存預設"
+	},
+	"app.lab.gradient-text.presets.template": {
+		"message": "下載模板"
+	},
+	"app.lab.gradient-text.presets.title": {
+		"message": "預設"
+	},
+	"app.lab.gradient-text.preview.title": {
+		"message": "預覽"
+	},
+	"app.lab.gradient-text.title": {
+		"message": "漸變文字生成器"
+	},
+	"app.lab.no-results": {
+		"message": "沒有匹配的工具。"
+	},
+	"app.lab.search": {
+		"message": "搜索工具"
+	},
+	"app.lab.seed-map.add-marker": {
+		"message": "添加標記"
+	},
+	"app.lab.seed-map.approximate": {
+		"message": "估算"
+	},
+	"app.lab.seed-map.biome-group.beach": {
+		"message": "沙灘"
+	},
+	"app.lab.seed-map.biome-group.cave": {
+		"message": "洞穴"
+	},
+	"app.lab.seed-map.biome-group.desert": {
+		"message": "沙漠"
+	},
+	"app.lab.seed-map.biome-group.end": {
+		"message": "終界"
+	},
+	"app.lab.seed-map.biome-group.forest": {
+		"message": "森林"
+	},
+	"app.lab.seed-map.biome-group.ice": {
+		"message": "冰雪群系"
+	},
+	"app.lab.seed-map.biome-group.jungle": {
+		"message": "叢林"
+	},
+	"app.lab.seed-map.biome-group.mesa": {
+		"message": "惡地"
+	},
+	"app.lab.seed-map.biome-group.mountains": {
+		"message": "山地"
+	},
+	"app.lab.seed-map.biome-group.mushroom": {
+		"message": "蘑菇島"
+	},
+	"app.lab.seed-map.biome-group.nether": {
+		"message": "下界"
+	},
+	"app.lab.seed-map.biome-group.ocean": {
+		"message": "海洋"
+	},
+	"app.lab.seed-map.biome-group.plains": {
+		"message": "平原"
+	},
+	"app.lab.seed-map.biome-group.river": {
+		"message": "河流"
+	},
+	"app.lab.seed-map.biome-group.savanna": {
+		"message": "熱帶草原"
+	},
+	"app.lab.seed-map.biome-group.swamp": {
+		"message": "沼澤"
+	},
+	"app.lab.seed-map.biome-group.taiga": {
+		"message": "針葉林"
+	},
+	"app.lab.seed-map.biome-highlight": {
+		"message": "群系高亮"
+	},
+	"app.lab.seed-map.biome-selection-count": {
+		"message": "已選 {selected} / {total}"
+	},
+	"app.lab.seed-map.biome-tag": {
+		"message": "生物群系"
+	},
+	"app.lab.seed-map.center-spawn": {
+		"message": "居中顯示出生點"
+	},
+	"app.lab.seed-map.choose-biome": {
+		"message": "選擇群系"
+	},
+	"app.lab.seed-map.chunk-coordinates": {
+		"message": "區塊坐標"
+	},
+	"app.lab.seed-map.clear": {
+		"message": "清除"
+	},
+	"app.lab.seed-map.clear-history": {
+		"message": "清空歷史"
+	},
+	"app.lab.seed-map.clear-ruler": {
+		"message": "清除測距"
+	},
+	"app.lab.seed-map.close-panel": {
+		"message": "關閉面板"
+	},
+	"app.lab.seed-map.collapse-layers": {
+		"message": "收起圖層"
+	},
+	"app.lab.seed-map.completed": {
+		"message": "已完成"
+	},
+	"app.lab.seed-map.contours": {
+		"message": "等高線"
+	},
+	"app.lab.seed-map.coordinates": {
+		"message": "坐標"
+	},
+	"app.lab.seed-map.copy-teleport": {
+		"message": "複製 /tp"
+	},
+	"app.lab.seed-map.copyright.disclaimer-body": {
+		"message": "Minecraft 是 Mojang Synergies AB 的商標。Axolotl Launcher 與 Mojang 或 MinecraftSearch 均無隸屬關係，也未獲得其認可。"
+	},
+	"app.lab.seed-map.copyright.disclaimer-heading": {
+		"message": "非官方工具"
+	},
+	"app.lab.seed-map.copyright.engine-body": {
+		"message": "群系、地形、出生點與結構數據由 cubiomes 和 Axolotl 原生集成在本地生成。cubiomes 版權所有 (c) 2020 Cubitect，並依據 MIT 許可證提供。"
+	},
+	"app.lab.seed-map.copyright.engine-heading": {
+		"message": "本地地圖引擎"
+	},
+	"app.lab.seed-map.copyright.icons-body": {
+		"message": "本工具使用的部分結構與群系圖示取自 MinecraftSearch。相關圖稿的權利仍歸 MinecraftSearch 及相應創作者所有。"
+	},
+	"app.lab.seed-map.copyright.icons-heading": {
+		"message": "地圖圖稿"
+	},
+	"app.lab.seed-map.copyright.open": {
+		"message": "版權與來源說明"
+	},
+	"app.lab.seed-map.copyright.title": {
+		"message": "版權與來源說明"
+	},
+	"app.lab.seed-map.copyright.view-cubiomes": {
+		"message": "查看 cubiomes"
+	},
+	"app.lab.seed-map.copyright.visit-minecraft-search": {
+		"message": "訪問 MinecraftSearch"
+	},
+	"app.lab.seed-map.description": {
+		"message": "在本地查看 Minecraft 種子的群系、結構和保存的標記。"
+	},
+	"app.lab.seed-map.dimension": {
+		"message": "維度"
+	},
+	"app.lab.seed-map.dimension.end": {
+		"message": "終界"
+	},
+	"app.lab.seed-map.dimension.nether": {
+		"message": "下界"
+	},
+	"app.lab.seed-map.dimension.overworld": {
+		"message": "主世界"
+	},
+	"app.lab.seed-map.distance": {
+		"message": "{distance} 格"
+	},
+	"app.lab.seed-map.edition": {
+		"message": "版本類型"
+	},
+	"app.lab.seed-map.edition.java": {
+		"message": "Java 版"
+	},
+	"app.lab.seed-map.edition.java-large-biomes": {
+		"message": "Java 版：大型生物群系"
+	},
+	"app.lab.seed-map.elevation": {
+		"message": "群系高度"
+	},
+	"app.lab.seed-map.elevation-locked": {
+		"message": "開啟地形估算時自動採用估算的地表高度"
+	},
+	"app.lab.seed-map.exit-fullscreen": {
+		"message": "退出全螢幕"
+	},
+	"app.lab.seed-map.expand-layers": {
+		"message": "展開圖層"
+	},
+	"app.lab.seed-map.feature.ancient-city": {
+		"message": "遠古城市"
+	},
+	"app.lab.seed-map.feature.bastion": {
+		"message": "堡壘遺跡"
+	},
+	"app.lab.seed-map.feature.buried-treasure": {
+		"message": "埋藏的寶藏"
+	},
+	"app.lab.seed-map.feature.desert-pyramid": {
+		"message": "沙漠神殿"
+	},
+	"app.lab.seed-map.feature.desert-well": {
+		"message": "沙漠水井"
+	},
+	"app.lab.seed-map.feature.end-city": {
+		"message": "終界城"
+	},
+	"app.lab.seed-map.feature.end-city-with-ship": {
+		"message": "終界城（有終界船）"
+	},
+	"app.lab.seed-map.feature.end-city-without-ship": {
+		"message": "終界城（無終界船）"
+	},
+	"app.lab.seed-map.feature.end-gateway": {
+		"message": "終界折躍門"
+	},
+	"app.lab.seed-map.feature.fortress": {
+		"message": "下界要塞"
+	},
+	"app.lab.seed-map.feature.geode": {
+		"message": "紫晶洞"
+	},
+	"app.lab.seed-map.feature.igloo": {
+		"message": "雪屋"
+	},
+	"app.lab.seed-map.feature.jungle-temple": {
+		"message": "叢林神廟"
+	},
+	"app.lab.seed-map.feature.mansion": {
+		"message": "林地府邸"
+	},
+	"app.lab.seed-map.feature.mineshaft": {
+		"message": "廢棄礦井"
+	},
+	"app.lab.seed-map.feature.monument": {
+		"message": "海底神殿"
+	},
+	"app.lab.seed-map.feature.ocean-ruin": {
+		"message": "海底廢墟"
+	},
+	"app.lab.seed-map.feature.outpost": {
+		"message": "掠奪者前哨站"
+	},
+	"app.lab.seed-map.feature.ruined-portal": {
+		"message": "廢棄傳送門"
+	},
+	"app.lab.seed-map.feature.shipwreck": {
+		"message": "沉船"
+	},
+	"app.lab.seed-map.feature.slime-chunk": {
+		"message": "史萊姆區塊"
+	},
+	"app.lab.seed-map.feature.stronghold": {
+		"message": "要塞"
+	},
+	"app.lab.seed-map.feature.swamp-hut": {
+		"message": "沼澤小屋"
+	},
+	"app.lab.seed-map.feature.trail-ruins": {
+		"message": "古蹟廢墟"
+	},
+	"app.lab.seed-map.feature.trial-chambers": {
+		"message": "試煉密室"
+	},
+	"app.lab.seed-map.feature.village": {
+		"message": "村莊"
+	},
+	"app.lab.seed-map.fullscreen": {
+		"message": "全螢幕"
+	},
+	"app.lab.seed-map.go": {
+		"message": "前往"
+	},
+	"app.lab.seed-map.hide-layer-names": {
+		"message": "隱藏圖層名稱"
+	},
+	"app.lab.seed-map.history": {
+		"message": "種子歷史記錄"
+	},
+	"app.lab.seed-map.history-empty": {
+		"message": "查看過的種子會出現在這裡"
+	},
+	"app.lab.seed-map.history-source.manual": {
+		"message": "手動輸入"
+	},
+	"app.lab.seed-map.history-source.random": {
+		"message": "隨機種子"
+	},
+	"app.lab.seed-map.history-source.share": {
+		"message": "分享連結"
+	},
+	"app.lab.seed-map.import-from-instance": {
+		"message": "從實例導入"
+	},
+	"app.lab.seed-map.import-world.back": {
+		"message": "返回實例列表"
+	},
+	"app.lab.seed-map.import-world.choose-instance": {
+		"message": "選擇包含該世界的實例"
+	},
+	"app.lab.seed-map.import-world.choose-world": {
+		"message": "選擇一個單人世界"
+	},
+	"app.lab.seed-map.import-world.last-played": {
+		"message": "{ago}遊玩過"
+	},
+	"app.lab.seed-map.import-world.never-played": {
+		"message": "尚未遊玩"
+	},
+	"app.lab.seed-map.import-world.no-instances": {
+		"message": "未找到實例，請先安裝一個實例。"
+	},
+	"app.lab.seed-map.import-world.no-worlds": {
+		"message": "該實例還沒有單人世界。"
+	},
+	"app.lab.seed-map.import-world.title": {
+		"message": "從實例世界載入種子"
+	},
+	"app.lab.seed-map.invert-selection": {
+		"message": "反選"
+	},
+	"app.lab.seed-map.layers": {
+		"message": "地圖圖層"
+	},
+	"app.lab.seed-map.loading": {
+		"message": "載入中"
+	},
+	"app.lab.seed-map.location": {
+		"message": "位置"
+	},
+	"app.lab.seed-map.map-failed": {
+		"message": "地圖生成失敗"
+	},
+	"app.lab.seed-map.map-scale": {
+		"message": "1 像素 = {scale} 格"
+	},
+	"app.lab.seed-map.marker-color": {
+		"message": "標記顏色"
+	},
+	"app.lab.seed-map.marker-name": {
+		"message": "標記名稱"
+	},
+	"app.lab.seed-map.marker-saved": {
+		"message": "標記已保存"
+	},
+	"app.lab.seed-map.markers": {
+		"message": "標記"
+	},
+	"app.lab.seed-map.mined": {
+		"message": "已挖掘"
+	},
+	"app.lab.seed-map.mode.ores": {
+		"message": "礦物"
+	},
+	"app.lab.seed-map.mode.structures": {
+		"message": "結構"
+	},
+	"app.lab.seed-map.no-markers": {
+		"message": "暫無保存的標記"
+	},
+	"app.lab.seed-map.no-matching-biomes": {
+		"message": "沒有匹配的群系"
+	},
+	"app.lab.seed-map.no-ores-in-end": {
+		"message": "終界不支持礦物掃描"
+	},
+	"app.lab.seed-map.ore-coverage": {
+		"message": "Y {min} 到 {max}"
+	},
+	"app.lab.seed-map.ore-layers": {
+		"message": "礦物圖層"
+	},
+	"app.lab.seed-map.ore-likely": {
+		"message": "可能存在"
+	},
+	"app.lab.seed-map.ore-max-y": {
+		"message": "最高 Y"
+	},
+	"app.lab.seed-map.ore-min-y": {
+		"message": "最低 Y"
+	},
+	"app.lab.seed-map.ore-precision": {
+		"message": "精度 {precision}%"
+	},
+	"app.lab.seed-map.ore-scan-failed": {
+		"message": "礦物掃描失敗，請刷新地圖後重試。"
+	},
+	"app.lab.seed-map.ore-verified": {
+		"message": "已驗證"
+	},
+	"app.lab.seed-map.ore-y-range": {
+		"message": "Y 範圍"
+	},
+	"app.lab.seed-map.ore.coal": {
+		"message": "煤礦石"
+	},
+	"app.lab.seed-map.ore.copper": {
+		"message": "銅礦石"
+	},
+	"app.lab.seed-map.ore.copper-vein": {
+		"message": "銅礦脈"
+	},
+	"app.lab.seed-map.ore.diamond": {
+		"message": "鑽石礦石"
+	},
+	"app.lab.seed-map.ore.gold": {
+		"message": "金礦石"
+	},
+	"app.lab.seed-map.ore.iron": {
+		"message": "鐵礦石"
+	},
+	"app.lab.seed-map.ore.iron-vein": {
+		"message": "鐵礦脈"
+	},
+	"app.lab.seed-map.ore.lapis": {
+		"message": "青金石礦石"
+	},
+	"app.lab.seed-map.ore.netherite": {
+		"message": "遠古遺骸"
+	},
+	"app.lab.seed-map.ore.redstone": {
+		"message": "紅石礦石"
+	},
+	"app.lab.seed-map.ores-require-modern": {
+		"message": "礦物預測需要 Java 版 1.18 或更新版本"
+	},
+	"app.lab.seed-map.random-seed": {
+		"message": "隨機種子"
+	},
+	"app.lab.seed-map.remove-history-entry": {
+		"message": "從歷史中移除"
+	},
+	"app.lab.seed-map.remove-marker": {
+		"message": "刪除標記"
+	},
+	"app.lab.seed-map.reset": {
+		"message": "重設"
+	},
+	"app.lab.seed-map.reset-y-range": {
+		"message": "重設 Y 範圍"
+	},
+	"app.lab.seed-map.ruler": {
+		"message": "測量距離"
+	},
+	"app.lab.seed-map.scanning-ores": {
+		"message": "正在掃描礦物 {processed}/{total}"
+	},
+	"app.lab.seed-map.search-biomes": {
+		"message": "搜索群系"
+	},
+	"app.lab.seed-map.search-nearby": {
+		"message": "搜索附近"
+	},
+	"app.lab.seed-map.seed": {
+		"message": "種子"
+	},
+	"app.lab.seed-map.seed-placeholder": {
+		"message": "輸入數字或文本種子"
+	},
+	"app.lab.seed-map.select-all": {
+		"message": "全選"
+	},
+	"app.lab.seed-map.selected-biomes": {
+		"message": "已選擇 {count} 個群系"
+	},
+	"app.lab.seed-map.settings": {
+		"message": "地圖設定"
+	},
+	"app.lab.seed-map.share": {
+		"message": "複製地圖連結"
+	},
+	"app.lab.seed-map.share-copied": {
+		"message": "已複製地圖連結"
+	},
+	"app.lab.seed-map.show-grid": {
+		"message": "顯示網格"
+	},
+	"app.lab.seed-map.show-layer-names": {
+		"message": "顯示圖層名稱"
+	},
+	"app.lab.seed-map.spawn-point": {
+		"message": "出生點"
+	},
+	"app.lab.seed-map.teleport-copied": {
+		"message": "已複製傳送命令"
+	},
+	"app.lab.seed-map.terrain": {
+		"message": "地形估算"
+	},
+	"app.lab.seed-map.title": {
+		"message": "種子地圖"
+	},
+	"app.lab.seed-map.version": {
+		"message": "遊戲版本"
+	},
+	"app.lab.seed-map.world-seed-loaded": {
+		"message": "已載入世界 {world} 的種子"
+	},
+	"app.lab.seed-map.zoom-in": {
+		"message": "放大"
+	},
+	"app.lab.seed-map.zoom-out": {
+		"message": "縮小"
+	},
+	"app.lab.seed-map.zoom-to-scan-ores": {
+		"message": "放大地圖以掃描礦物"
+	},
+	"app.lab.seed-map.zoom-to-show": {
+		"message": "放大以顯示{layer}"
+	},
+	"app.lab.title": {
+		"message": "實驗室"
+	},
+	"app.lab.tool-count": {
+		"message": "{count} 個工具"
+	},
+	"app.lab.tool-count-plural": {
+		"message": "{count} 個工具"
 	},
 	"app.library.create-instance": {
 		"message": "建立新實例"
@@ -1759,6 +2659,36 @@
 	},
 	"app.library.title": {
 		"message": "實例庫"
+	},
+	"app.memory-display.available": {
+		"message": "可用 {memory}"
+	},
+	"app.memory-display.game": {
+		"message": "遊戲分配"
+	},
+	"app.memory-display.optimization-description": {
+		"message": "釋放 Windows 中未使用的工作集和待機記憶體。"
+	},
+	"app.memory-display.optimize": {
+		"message": "記憶體最佳化"
+	},
+	"app.memory-display.optimized": {
+		"message": "記憶體最佳化完成"
+	},
+	"app.memory-display.optimizing": {
+		"message": "正在最佳化……"
+	},
+	"app.memory-display.reclaimed": {
+		"message": "已釋放 {memory} 記憶體。"
+	},
+	"app.memory-display.remaining": {
+		"message": "分配後剩餘"
+	},
+	"app.memory-display.unsupported": {
+		"message": "記憶體最佳化僅支持 Windows。"
+	},
+	"app.memory-display.used": {
+		"message": "已使用記憶體"
 	},
 	"app.minecraft-auth.contact-support": {
 		"message": "聯絡支援"
@@ -1796,65 +2726,17 @@
 	"app.minecraft-auth.unknown-error": {
 		"message": "未知錯誤"
 	},
-	"app.ai-log-analysis.analyzing": {
-		"message": "正在AI分析日誌……這可能需要等待半分鐘"
-	},
-	"app.ai-log-analysis.cancel": {
-		"message": "取消"
-	},
-	"app.ai-log-analysis.close": {
-		"message": "關閉"
-	},
-	"app.ai-log-analysis.copy-link": {
-		"message": "複製連結"
-	},
-	"app.ai-log-analysis.copy-result": {
-		"message": "複製結果"
-	},
-	"app.ai-log-analysis.error": {
-		"message": "AI 分析失敗：{message}"
-	},
-	"app.ai-log-analysis.link-copied": {
-		"message": "連結已複製到剪貼簿"
-	},
-	"app.ai-log-analysis.logshare-unavailable": {
-		"message": "LogShare.CN 無法訪問，AI 分析不可用（mclo.gs 不支援 AI 分析）。{message}"
-	},
-	"app.ai-log-analysis.privacy": {
-		"message": "你的日誌內容將被上傳第三方 AI 服務進行分析, 請勿上傳包含敏感資訊的日誌。\n 感謝logshare.cn提供的日誌分享與分析服務。"
-	},
-	"app.ai-log-analysis.result-copied": {
-		"message": "分析結果已複製到剪貼簿"
-	},
-	"app.ai-log-analysis.title": {
-		"message": "AI 日誌分析"
-	},
-	"app.ai-log-analysis.upload-failed": {
-		"message": "上傳失敗，正在直接分析日誌內容（無分享連結）。"
-	},
-	"app.ai-log-analysis.uploading": {
-		"message": "正在上傳日誌……"
-	},
 	"app.minecraft-auth.warning": {
 		"message": "無法登入你的 Microsoft 帳號，原因可能是帳號限制或地區限制。"
 	},
 	"app.minecraft-auth.what-happened": {
 		"message": "我們推測的原因"
 	},
-	"app.minecraft-crash.ai-analyze": {
-		"message": "AI 分析"
-	},
-	"app.minecraft-crash.ai-unavailable": {
-		"message": "當前日誌服務（mclo.gs）不支援 AI 分析，請在設定中切換到 LogShare.CN。"
-	},
 	"app.minecraft-crash.analyzing": {
 		"message": "正在分析本次啟動留下的日誌……"
 	},
 	"app.minecraft-crash.body": {
 		"message": "尋求幫助時不要發送此窗口截圖。請導出錯誤報告，這樣對方才能同時檢查崩潰報告、遊戲日誌、除錯日誌和 JVM 資訊。"
-	},
-	"app.minecraft-crash.copy-link": {
-		"message": "複製連結"
 	},
 	"app.minecraft-crash.diagnosis.forge-java.action": {
 		"message": "可以嘗試使用此 Forge 版本所需的 Java，或更新 Forge。"
@@ -1934,29 +2816,11 @@
 	"app.minecraft-crash.launch-failure-hint": {
 		"message": "打開 Minecraft 日誌可以查看已捕獲的 Java 輸出。尋求幫助時，請導出並發送完整的 Minecraft 診斷包。"
 	},
-	"app.minecraft-crash.no-log-content": {
-		"message": "沒有找到可分享或分析的日誌內容，請確認例項中有最近幾分鐘內生成的日誌。"
-	},
 	"app.minecraft-crash.preparation-timed-out": {
 		"message": "啟動準備在 60 秒內未能完成，現已取消。請檢查 Java 路徑、啟動前命令、包裝器命令和網路連接，然後重試。"
 	},
 	"app.minecraft-crash.preview-instance": {
 		"message": "Minecraft 測試實例"
-	},
-	"app.minecraft-crash.share-copied": {
-		"message": "診斷連結已複製到剪貼簿"
-	},
-	"app.minecraft-crash.share-diagnostic": {
-		"message": "匯出分享"
-	},
-	"app.minecraft-crash.share-failed": {
-		"message": "匯出分享失敗"
-	},
-	"app.minecraft-crash.share-truncated": {
-		"message": "診斷日誌過大，已自動擷取最後 9MB 上傳。"
-	},
-	"app.minecraft-crash.sharing-diagnostic": {
-		"message": "正在匯出分享……"
 	},
 	"app.minecraft-crash.summary": {
 		"message": "Minecraft 意外停止運行。"
@@ -2015,6 +2879,195 @@
 	"app.modpack.version-supports": {
 		"message": "支援"
 	},
+	"app.multiplayer.back": {
+		"message": "返回"
+	},
+	"app.multiplayer.binary-not-found": {
+		"message": "未找到陶瓦聯機程序，請放置於："
+	},
+	"app.multiplayer.check-network": {
+		"message": "檢查網路連接"
+	},
+	"app.multiplayer.connecting": {
+		"message": "連線中..."
+	},
+	"app.multiplayer.copy-room-code": {
+		"message": "複製房間碼"
+	},
+	"app.multiplayer.disconnect": {
+		"message": "斷開連接"
+	},
+	"app.multiplayer.download-progress": {
+		"message": "下載進度"
+	},
+	"app.multiplayer.download-terracotta": {
+		"message": "下載陶瓦聯機"
+	},
+	"app.multiplayer.error.install": {
+		"message": "安裝錯誤"
+	},
+	"app.multiplayer.error.network": {
+		"message": "網路錯誤"
+	},
+	"app.multiplayer.error.os": {
+		"message": "系統錯誤"
+	},
+	"app.multiplayer.error.terracotta": {
+		"message": "陶瓦聯機錯誤"
+	},
+	"app.multiplayer.error.unknown": {
+		"message": "未知錯誤"
+	},
+	"app.multiplayer.export-error-report": {
+		"message": "匯出錯誤報告"
+	},
+	"app.multiplayer.extracting": {
+		"message": "正在解壓..."
+	},
+	"app.multiplayer.guest-label": {
+		"message": "訪客"
+	},
+	"app.multiplayer.host": {
+		"message": "創建房間"
+	},
+	"app.multiplayer.host-description": {
+		"message": "創建虛擬區域網路房間，讓好友直接連接到你的遊戲。"
+	},
+	"app.multiplayer.host-label": {
+		"message": "房主"
+	},
+	"app.multiplayer.installing": {
+		"message": "正在安裝..."
+	},
+	"app.multiplayer.join": {
+		"message": "加入房間"
+	},
+	"app.multiplayer.join-description": {
+		"message": "輸入房間碼加入好友的虛擬區域網路房間。"
+	},
+	"app.multiplayer.join-room": {
+		"message": "加入房間"
+	},
+	"app.multiplayer.lan-hint": {
+		"message": "請打開 Minecraft 進入世界，按 ESC → 對區域網路開放 → 選擇一個埠，陶瓦聯機會自動檢測。"
+	},
+	"app.multiplayer.loading": {
+		"message": "初始化中..."
+	},
+	"app.multiplayer.no-players": {
+		"message": "暫無玩家"
+	},
+	"app.multiplayer.not-running": {
+		"message": "聯機服務未運行。請創建房間或加入房間以開始聯機。"
+	},
+	"app.multiplayer.not-running-title": {
+		"message": "開始聯機會話"
+	},
+	"app.multiplayer.platform-info": {
+		"message": "當前平台：{platform}"
+	},
+	"app.multiplayer.player-name": {
+		"message": "玩家名"
+	},
+	"app.multiplayer.players": {
+		"message": "玩家"
+	},
+	"app.multiplayer.players-in-room": {
+		"message": "{count} 位玩家在房間中"
+	},
+	"app.multiplayer.powered-by-terracotta": {
+		"message": "由 Terracotta | 陶瓦聯機 強力驅動"
+	},
+	"app.multiplayer.retry": {
+		"message": "重試"
+	},
+	"app.multiplayer.room-code": {
+		"message": "房間碼"
+	},
+	"app.multiplayer.room-code-invalid": {
+		"message": "請輸入 U/XXXX-XXXX-XXXX-XXXX 格式的房間碼。"
+	},
+	"app.multiplayer.room-code-placeholder": {
+		"message": "例如 U/ABCD-EFGH-IJKL-MNOP"
+	},
+	"app.multiplayer.server-address": {
+		"message": "備用連接地址"
+	},
+	"app.multiplayer.share-code": {
+		"message": "將此代碼分享給好友："
+	},
+	"app.multiplayer.start-description": {
+		"message": "啟動聯機服務以創建房間或加入好友的房間。"
+	},
+	"app.multiplayer.start-hosting": {
+		"message": "創建房間"
+	},
+	"app.multiplayer.start-terracotta": {
+		"message": "啟動陶瓦聯機"
+	},
+	"app.multiplayer.status.downloading": {
+		"message": "下載中..."
+	},
+	"app.multiplayer.status.error": {
+		"message": "錯誤"
+	},
+	"app.multiplayer.status.fatal": {
+		"message": "嚴重錯誤"
+	},
+	"app.multiplayer.status.guest-connecting": {
+		"message": "正在加入..."
+	},
+	"app.multiplayer.status.guest-ready": {
+		"message": "已連接到房間"
+	},
+	"app.multiplayer.status.guest-starting": {
+		"message": "正在連接..."
+	},
+	"app.multiplayer.status.host-ready": {
+		"message": "房間已就緒"
+	},
+	"app.multiplayer.status.host-scanning": {
+		"message": "正在掃描..."
+	},
+	"app.multiplayer.status.host-starting": {
+		"message": "正在啟動主機..."
+	},
+	"app.multiplayer.status.idle": {
+		"message": "未連接"
+	},
+	"app.multiplayer.status.starting": {
+		"message": "啟動中..."
+	},
+	"app.multiplayer.status.waiting": {
+		"message": "等待中..."
+	},
+	"app.multiplayer.terracotta.public-node-invalid": {
+		"message": "節點 URI 無效：{node}。請使用 http、https、tcp、tls、udp、ws 或 wss。"
+	},
+	"app.multiplayer.terracotta.public-nodes": {
+		"message": "陶瓦公共節點"
+	},
+	"app.multiplayer.terracotta.public-nodes-description": {
+		"message": "每行輸入一個節點 URI。變更將在下次建立或加入房間時生效。留空則僅使用陶瓦內建節點。"
+	},
+	"app.multiplayer.terracotta.public-nodes-placeholder": {
+		"message": "wss://center.node.1tmc.top"
+	},
+	"app.multiplayer.terracotta.public-nodes-saved": {
+		"message": "陶瓦公共節點已儲存"
+	},
+	"app.multiplayer.terracotta.save-public-nodes": {
+		"message": "儲存節點"
+	},
+	"app.multiplayer.title": {
+		"message": "多人遊戲"
+	},
+	"app.multiplayer.unknown-player-role": {
+		"message": "未知身份"
+	},
+	"app.multiplayer.verifying": {
+		"message": "驗證中..."
+	},
 	"app.navigation.create-instance": {
 		"message": "建立新實例"
 	},
@@ -2024,14 +3077,17 @@
 	"app.navigation.downloads": {
 		"message": "下載"
 	},
-	"app.navigation.edit-world": {
-		"message": "編輯存檔"
-	},
 	"app.navigation.home": {
 		"message": "首頁"
 	},
+	"app.navigation.lab": {
+		"message": "實驗室"
+	},
 	"app.navigation.library": {
 		"message": "實例庫"
+	},
+	"app.navigation.multiplayer": {
+		"message": "多人遊戲"
 	},
 	"app.navigation.skin-selector": {
 		"message": "外觀選擇器"
@@ -2063,6 +3119,9 @@
 	"app.onboarding.action.click-downloads": {
 		"message": "點擊下載，繼續"
 	},
+	"app.onboarding.action.click-lab": {
+		"message": "點擊實驗室，繼續"
+	},
 	"app.onboarding.action.click-library": {
 		"message": "點擊實例庫，繼續"
 	},
@@ -2080,6 +3139,15 @@
 	},
 	"app.onboarding.action.finish-area": {
 		"message": "點擊任意位置，收工"
+	},
+	"app.onboarding.action.open-gradient-text": {
+		"message": "打開漸變文字生成器，繼續"
+	},
+	"app.onboarding.action.open-seed-map": {
+		"message": "打開種子地圖，繼續"
+	},
+	"app.onboarding.action.return-lab": {
+		"message": "點擊實驗室，查看另一個項目"
 	},
 	"app.onboarding.action.skip": {
 		"message": "先不逛了"
@@ -2105,12 +3173,6 @@
 	"app.onboarding.create.title": {
 		"message": "開個新檔"
 	},
-	"app.onboarding.creation.description": {
-		"message": "Custom setup, modpack, or import. The choices are yours; I am just here for the subtitles."
-	},
-	"app.onboarding.creation.title": {
-		"message": "選條路"
-	},
 	"app.onboarding.creation-confirm.description": {
 		"message": "這裡會按你的選擇創建實例。我堅持不替你按確認。"
 	},
@@ -2134,6 +3196,12 @@
 	},
 	"app.onboarding.creation-version.title": {
 		"message": "定下遊戲版本"
+	},
+	"app.onboarding.creation.description": {
+		"message": "Custom setup, modpack, or import. The choices are yours; I am just here for the subtitles."
+	},
+	"app.onboarding.creation.title": {
+		"message": "選條路"
 	},
 	"app.onboarding.defaults.description": {
 		"message": "新實例會繼承這些選擇，省得你每次重做作業。"
@@ -2159,6 +3227,12 @@
 	"app.onboarding.downloads.title": {
 		"message": "下載指揮室"
 	},
+	"app.onboarding.home-layout.description": {
+		"message": "隨時使用這個懸浮按鈕，在資訊首頁和極簡首頁之間切換。"
+	},
+	"app.onboarding.home-layout.title": {
+		"message": "切換資訊密度"
+	},
 	"app.onboarding.instance-actions.description": {
 		"message": "從實例頁頭部啟動、停止、修復、配置、導出或打開這個實例。"
 	},
@@ -2177,11 +3251,44 @@
 	"app.onboarding.java.title": {
 		"message": "Java，在後台"
 	},
+	"app.onboarding.lab-editor.description": {
+		"message": "編輯文本、選擇顏色、即時預覽，並複製適用於 Minecraft 配置的格式。"
+	},
+	"app.onboarding.lab-editor.title": {
+		"message": "在同一處編輯和複製"
+	},
+	"app.onboarding.lab-seed-map.description": {
+		"message": "輸入種子或從實例載入，然後在本地地圖中查看群系、結構與礦物圖層。"
+	},
+	"app.onboarding.lab-seed-map.title": {
+		"message": "載入世界前先找到它"
+	},
+	"app.onboarding.lab-tools.description": {
+		"message": "生成帶格式的漸變文字，或用本地種子地圖探索 Java 世界。"
+	},
+	"app.onboarding.lab-tools.title": {
+		"message": "首批兩個項目"
+	},
+	"app.onboarding.lab.description": {
+		"message": "實驗室將本地 Minecraft 工具放進啟動器，無需打開其他網站或註冊額外帳號。"
+	},
+	"app.onboarding.lab.title": {
+		"message": "內建的實用工具"
+	},
 	"app.onboarding.language.description": {
 		"message": "在這裡選擇啟動器語言和管理翻譯。不需要翻譯腔。"
 	},
 	"app.onboarding.language.title": {
 		"message": "說你的語言"
+	},
+	"app.settings.resources.modrinth-mirror": {
+		"message": "Modrinth"
+	},
+	"app.settings.resources.modrinth-mirror-description": {
+		"message": "Modrinth 檔案下載。"
+	},
+	"app.settings.resources.concurrency.manual": {
+		"message": "手動"
 	},
 	"app.onboarding.library-page.description": {
 		"message": "按整合包、伺服器或自訂配置篩選，再打開任意實例管理。"
@@ -2255,14 +3362,14 @@
 	"app.project.install-button.already-installed": {
 		"message": "這個專案已安裝"
 	},
+	"app.downloads.source.tianpao": {
+		"message": "Tianpao 鏡像"
+	},
 	"app.project.install-button.switch-version": {
 		"message": "切換版本"
 	},
 	"app.project.install-context.back-to-browse": {
 		"message": "返回瀏覽"
-	},
-	"app.project.install-context.back-to-instance-content": {
-		"message": "返回例項內容"
 	},
 	"app.project.install-context.install-content-to-instance": {
 		"message": "將內容安裝至實例"
@@ -2366,6 +3473,9 @@
 	"app.settings.about.preview-minecraft-crash-modal": {
 		"message": "預覽 Minecraft 崩潰窗口"
 	},
+	"app.settings.about.preview-privacy-consent-modal": {
+		"message": "預覽隱私與安全彈窗"
+	},
 	"app.settings.about.product-title": {
 		"message": "關於 {productName}"
 	},
@@ -2390,6 +3500,12 @@
 	"app.settings.about.repository": {
 		"message": "原始碼"
 	},
+	"app.settings.about.survey": {
+		"message": "調查問卷"
+	},
+	"app.settings.about.survey-description": {
+		"message": "幫助我們改進 Axolotl Launcher"
+	},
 	"app.settings.about.test-error": {
 		"message": "觸發測試錯誤"
 	},
@@ -2407,6 +3523,12 @@
 	},
 	"app.settings.about.version": {
 		"message": "版本 {version}"
+	},
+	"app.settings.defaults.automatic-memory": {
+		"message": "啟動時自動分配記憶體"
+	},
+	"app.settings.defaults.automatic-memory-description": {
+		"message": "根據可用記憶體和已安裝的模組，在每次啟動時動態調整記憶體。"
 	},
 	"app.settings.defaults.environment-variables": {
 		"message": "環境變數"
@@ -2438,50 +3560,8 @@
 	"app.settings.defaults.memory": {
 		"message": "分配記憶體"
 	},
-	"app.settings.defaults.automatic-memory": {
-		"message": "啟動時自動分配記憶體"
-	},
-	"app.settings.defaults.automatic-memory-description": {
-		"message": "根據可用記憶體和已安裝的模組，在每次啟動時動態調整記憶體。"
-	},
 	"app.settings.defaults.memory-description": {
 		"message": "分配給每個實例的記憶體。"
-	},
-	"app.settings.defaults.optimize-memory-before-launch": {
-		"message": "啟動遊戲前最佳化記憶體"
-	},
-	"app.settings.defaults.optimize-memory-before-launch-description": {
-		"message": "等待 Windows 記憶體最佳化完成後再啟動遊戲。"
-	},
-	"app.memory-display.available": {
-		"message": "可用 {memory}"
-	},
-	"app.memory-display.game": {
-		"message": "遊戲分配"
-	},
-	"app.memory-display.optimize": {
-		"message": "記憶體最佳化"
-	},
-	"app.memory-display.optimized": {
-		"message": "記憶體最佳化完成"
-	},
-	"app.memory-display.optimizing": {
-		"message": "正在最佳化……"
-	},
-	"app.memory-display.optimization-description": {
-		"message": "釋放 Windows 中未使用的工作集和待機記憶體。"
-	},
-	"app.memory-display.remaining": {
-		"message": "分配後剩餘"
-	},
-	"app.memory-display.reclaimed": {
-		"message": "已釋放 {memory} 記憶體。"
-	},
-	"app.memory-display.unsupported": {
-		"message": "記憶體最佳化僅支持 Windows。"
-	},
-	"app.memory-display.used": {
-		"message": "已使用記憶體"
 	},
 	"app.settings.defaults.post-exit-description": {
 		"message": "在遊戲關閉後執行。"
@@ -2528,9 +3608,6 @@
 	"app.settings.feature-flags.reset-to-default": {
 		"message": "恢復預設值"
 	},
-	"settings.feature-flags.title": {
-		"message": "功能開關"
-	},
 	"app.settings.java.auto-high-performance-mode": {
 		"message": "自動為 Java 使用高性能顯示卡"
 	},
@@ -2548,6 +3625,30 @@
 	},
 	"app.settings.java.download-java": {
 		"message": "下載 Java"
+	},
+	"app.settings.java.download.back": {
+		"message": "返回發行版列表"
+	},
+	"app.settings.java.download.loading": {
+		"message": "載入中……"
+	},
+	"app.settings.java.download.no-vendors": {
+		"message": "沒有可用的發行版。"
+	},
+	"app.settings.java.download.no-versions": {
+		"message": "沒有可用的版本。"
+	},
+	"app.settings.java.download.select-vendor": {
+		"message": "選擇發行版："
+	},
+	"app.settings.java.download.select-version-feed": {
+		"message": "選擇 {vendor} 的版本："
+	},
+	"app.settings.java.download.title": {
+		"message": "下載 Java"
+	},
+	"app.settings.java.download.version-label": {
+		"message": "Java {version}"
 	},
 	"app.settings.java.find-java": {
 		"message": "尋找 Java"
@@ -2576,8 +3677,8 @@
 	"app.settings.java.scanning": {
 		"message": "掃描中……"
 	},
-	"app.settings.java.table.version": {
-		"message": "版本"
+	"app.settings.java.table.actions": {
+		"message": ""
 	},
 	"app.settings.java.table.distribution": {
 		"message": "發行版"
@@ -2585,35 +3686,11 @@
 	"app.settings.java.table.path": {
 		"message": "路徑"
 	},
-	"app.settings.java.table.actions": {
-		"message": ""
+	"app.settings.java.table.version": {
+		"message": "版本"
 	},
 	"app.settings.java.view-installed": {
 		"message": "查看已安裝 Java"
-	},
-	"app.settings.java.download.select-vendor": {
-		"message": "選擇發行版："
-	},
-	"app.settings.java.download.no-vendors": {
-		"message": "沒有可用的發行版。"
-	},
-	"app.settings.java.download.select-version-feed": {
-		"message": "選擇 {vendor} 的版本："
-	},
-	"app.settings.java.download.version-label": {
-		"message": "Java {version}"
-	},
-	"app.settings.java.download.back": {
-		"message": "返回發行版列表"
-	},
-	"app.settings.java.download.loading": {
-		"message": "載入中……"
-	},
-	"app.settings.java.download.no-versions": {
-		"message": "沒有可用的版本。"
-	},
-	"app.settings.java.download.title": {
-		"message": "下載 Java"
 	},
 	"app.settings.resources.app-cache": {
 		"message": "應用程式快取"
@@ -2630,71 +3707,14 @@
 	"app.settings.resources.app-directory-description-portable": {
 		"message": "正在以便攜模式運行，所有數據已固定在程序目錄下，無法修改。"
 	},
+	"app.settings.resources.curseforge-mirror": {
+		"message": "CurseForge 服務"
+	},
 	"app.settings.resources.database-backups": {
 		"message": "應用程式資料庫備份"
 	},
 	"app.settings.resources.database-backups-description": {
 		"message": "重要應用程式的資料備份保存在這裡，以便日後需要時復原。"
-	},
-	"app.settings.resources.download-mirrors": {
-		"message": "下載來源"
-	},
-	"app.settings.resources.download-mirrors-description": {
-		"message": "為每項服務選擇下載來源。當鏡像來源請求失敗時，將自動退回至官方來源。"
-	},
-	"app.settings.resources.minecraft-metadata-source": {
-		"message": "Minecraft 元數據"
-	},
-	"app.settings.resources.minecraft-metadata-source-description": {
-		"message": "Minecraft 與受支援模組載入器的版本清單和元數據。"
-	},
-	"app.settings.resources.minecraft-file-source": {
-		"message": "Minecraft 文件、載入器與 Java"
-	},
-	"app.settings.resources.minecraft-file-source-description": {
-		"message": "遊戲文件、資源、依賴庫、模組載入器和 Java 運行時。"
-	},
-	"app.settings.resources.curseforge-mirror": {
-		"message": "CurseForge 服務"
-	},
-	"app.settings.resources.curseforge-mirror-description": {
-		"message": "CurseForge 檔案下載。"
-	},
-	"app.settings.resources.curseforge-restriction-bypass": {
-		"message": "自動下載受限的 CurseForge 檔案"
-	},
-	"app.settings.resources.curseforge-restriction-bypass-description": {
-		"message": "當 CurseForge 不提供下載地址時，根據檔案資訊推導其 CDN 地址並嘗試自動下載。關閉後將使用手動下載流程。"
-	},
-	"app.settings.resources.mojang-auth-service": {
-		"message": "Mojang 認證服務"
-	},
-	"app.settings.resources.mojang-auth-service-description": {
-		"message": "Mojang 登入、資料、皮膚、披風、會話驗證等。"
-	},
-	"app.settings.resources.concurrency.manual": {
-		"message": "手動"
-	},
-	"app.settings.resources.source.automatic": {
-		"message": "自動（推薦）"
-	},
-	"app.settings.resources.source.official-preferred": {
-		"message": "優先官方來源"
-	},
-	"app.settings.resources.source.official-only": {
-		"message": "僅原始來源（不使用鏡像）"
-	},
-	"app.settings.resources.source.open-bmcl-api": {
-		"message": "OpenBMCLAPI 鏡像"
-	},
-	"app.settings.resources.source.mojang-mirror-preferred": {
-		"message": "優先 Fallen Proxy"
-	},
-	"app.settings.resources.source.mojang-official-only": {
-		"message": "僅官方源"
-	},
-	"app.settings.resources.source.mojang-official-preferred": {
-		"message": "優先官方源"
 	},
 	"app.settings.resources.download-engine": {
 		"message": "下載引擎"
@@ -2708,8 +3728,11 @@
 	"app.settings.resources.download-engine.xmcl": {
 		"message": "XMCL 相容"
 	},
-	"app.settings.resources.maximum-downloads": {
-		"message": "最大同時下載數"
+	"app.settings.resources.download-mirrors": {
+		"message": "下載來源"
+	},
+	"app.settings.resources.download-mirrors-description": {
+		"message": "為每項服務選擇下載來源。當鏡像來源請求失敗時，將自動退回至官方來源。"
 	},
 	"app.settings.resources.maximum-downloads-description": {
 		"message": "啟動器同時下載檔案的最大數量。網路連線較差時請降低此值；變更需要重新啟動應用程式後生效。"
@@ -2719,6 +3742,18 @@
 	},
 	"app.settings.resources.maximum-writes-description": {
 		"message": "啟動器同時寫入磁碟的最大檔案數。如果經常出現 I/O 錯誤，請降低此值；變更將在重新啟動應用程式後生效。"
+	},
+	"app.settings.resources.minecraft-file-source": {
+		"message": "Minecraft 文件、載入器與 Java"
+	},
+	"app.settings.resources.minecraft-file-source-description": {
+		"message": "遊戲文件、資源、依賴庫、模組載入器和 Java 運行時。"
+	},
+	"app.settings.resources.minecraft-metadata-source": {
+		"message": "Minecraft 元數據"
+	},
+	"app.settings.resources.minecraft-metadata-source-description": {
+		"message": "Minecraft 與受支援模組載入器的版本清單和元數據。"
 	},
 	"app.settings.resources.missing-content-auto-import": {
 		"message": "自動匯入缺少的整合包檔案"
@@ -2732,15 +3767,6 @@
 	"app.settings.resources.missing-content-import-directory-description": {
 		"message": "未選擇自訂目錄時使用系統 Downloads 資料夾。不會掃描子目錄。"
 	},
-	"app.settings.resources.system-downloads-directory": {
-		"message": "系統 Downloads 資料夾"
-	},
-	"app.settings.resources.select-import-directory": {
-		"message": "選擇監控目錄"
-	},
-	"app.settings.resources.reset-import-directory": {
-		"message": "使用系統 Downloads 資料夾"
-	},
 	"app.settings.resources.open-backups-folder": {
 		"message": "開啟備份資料夾"
 	},
@@ -2753,8 +3779,41 @@
 	"app.settings.resources.purge-confirm-title": {
 		"message": "確定要清除快取嗎？"
 	},
+	"app.settings.resources.reset-import-directory": {
+		"message": "使用系統 Downloads 資料夾"
+	},
 	"app.settings.resources.select-directory": {
 		"message": "選擇新的應用程式目錄"
+	},
+	"app.settings.resources.select-import-directory": {
+		"message": "選擇監控目錄"
+	},
+	"app.settings.resources.source.automatic": {
+		"message": "自動（推薦）"
+	},
+	"app.settings.resources.source.official-only": {
+		"message": "僅原始來源（不使用鏡像）"
+	},
+	"app.settings.resources.source.official-preferred": {
+		"message": "優先官方來源"
+	},
+	"app.settings.resources.source.open-bmcl-api": {
+		"message": "OpenBMCLAPI 鏡像"
+	},
+	"app.settings.resources.system-downloads-directory": {
+		"message": "系統 Downloads 資料夾"
+	},
+	"app.settings.updates.announcements.description": {
+		"message": "查看當前版本的更新內容和歷史版本公告。"
+	},
+	"app.settings.updates.announcements.empty": {
+		"message": "當前沒有內建的更新公告。"
+	},
+	"app.settings.updates.announcements.history": {
+		"message": "歷史版本"
+	},
+	"app.settings.updates.announcements.title": {
+		"message": "更新公告"
 	},
 	"app.settings.updates.available": {
 		"message": "發現可用更新。"
@@ -2771,32 +3830,20 @@
 	"app.settings.updates.description": {
 		"message": "選擇 Axolotl 檢查啟動器更新的管道。"
 	},
-	"app.settings.updates.announcements.description": {
-		"message": "查看當前版本的更新內容和歷史版本公告。"
-	},
-	"app.settings.updates.announcements.empty": {
-		"message": "當前沒有內建的更新公告。"
-	},
-	"app.settings.updates.announcements.history": {
-		"message": "歷史版本"
-	},
-	"app.settings.updates.announcements.title": {
-		"message": "更新公告"
-	},
 	"app.settings.updates.disabled": {
 		"message": "此組建已停用更新功能。"
 	},
 	"app.settings.updates.failed": {
 		"message": "無法檢查更新。"
 	},
-	"app.settings.updates.portable": {
-		"message": "便攜模式暫時無法更新，請去GitHub手動更新。"
-	},
 	"app.settings.updates.github": {
 		"message": "GitHub 管道"
 	},
 	"app.settings.updates.offline": {
 		"message": "請連線至網際網路後再檢查更新。"
+	},
+	"app.settings.updates.portable": {
+		"message": "便攜模式暫時無法更新，請去GitHub手動更新。"
 	},
 	"app.settings.updates.preview-announcement": {
 		"message": "預覽更新公告彈出視窗"
@@ -2809,144 +3856,6 @@
 	},
 	"app.settings.updates.up-to-date": {
 		"message": "Axolotl 已是最新版本。"
-	},
-	"app.settings.logs.description": {
-		"message": "選擇用於分析和分享 Minecraft 日誌的服務。優先使用 LogShare.CN，不可用時自動回退到 mclo.gs，確保分享始終可用。"
-	},
-	"app.settings.logs.provider.auto": {
-		"message": "自動（推薦）"
-	},
-	"app.settings.groups.common": {
-		"message": "通用"
-	},
-	"app.settings.groups.minecraft": {
-		"message": "我的世界"
-	},
-	"app.settings.groups.system": {
-		"message": "系統"
-	},
-	"app.settings.groups.launcher": {
-		"message": "啟動器"
-	},
-	"app.settings.groups.game": {
-		"message": "遊戲"
-	},
-	"app.settings.groups.data-privacy": {
-		"message": "資料與隱私"
-	},
-	"app.settings.groups.support": {
-		"message": "應用與支援"
-	},
-	"app.settings.groups.developer": {
-		"message": "開發者"
-	},
-	"app.settings.tabs.appearance": {
-		"message": "外觀"
-	},
-	"app.settings.tabs.interface": {
-		"message": "介面與外觀"
-	},
-	"app.settings.tabs.home-navigation": {
-		"message": "首頁與導航"
-	},
-	"app.settings.tabs.language-translation": {
-		"message": "語言與翻譯"
-	},
-	"app.settings.tabs.java-performance": {
-		"message": "Java 與效能"
-	},
-	"app.settings.tabs.launch-defaults": {
-		"message": "啟動與例項預設值"
-	},
-	"app.settings.tabs.content-downloads": {
-		"message": "內容與下載"
-	},
-	"app.settings.tabs.network-multiplayer": {
-		"message": "網路與多人遊戲"
-	},
-	"app.settings.tabs.storage-backups": {
-		"message": "儲存與備份"
-	},
-	"app.settings.tabs.privacy-data": {
-		"message": "隱私與資料共享"
-	},
-	"app.settings.tabs.language": {
-		"message": "語言"
-	},
-	"app.settings.tabs.translation": {
-		"message": "翻譯"
-	},
-	"app.settings.tabs.ai": {
-		"message": "AI"
-	},
-	"app.settings.tabs.privacy-security": {
-		"message": "隱私與安全"
-	},
-	"app.settings.tabs.java-installations": {
-		"message": "Java 安裝"
-	},
-	"app.settings.tabs.default-instance-options": {
-		"message": "預設實例選項"
-	},
-	"app.settings.tabs.resource-management": {
-		"message": "資源管理"
-	},
-	"app.settings.tabs.multiplayer": {
-		"message": "多人聯機"
-	},
-	"app.settings.tabs.updates": {
-		"message": "更新"
-	},
-	"app.settings.tabs.about": {
-		"message": "關於"
-	},
-	"app.settings.logs.provider.auto-description": {
-		"message": "優先使用 LogShare.CN，不可用時自動切換到 mclo.gs。"
-	},
-	"app.settings.logs.provider.logshare": {
-		"message": "LogShare.CN"
-	},
-	"app.settings.logs.provider.logshare-description": {
-		"message": "使用 LogShare.CN 進行分析和分享（支援 AI 分析），不可用時回退到 mclo.gs。"
-	},
-	"app.settings.logs.provider.mclogs": {
-		"message": "mclo.gs"
-	},
-	"app.settings.logs.provider.mclogs-description": {
-		"message": "使用 mclo.gs 進行分析和分享，不支援 AI 分析。"
-	},
-	"app.settings.logs.title": {
-		"message": "日誌分析服務"
-	},
-	"app.settings.search.clear": {
-		"message": "清除設定搜尋"
-	},
-	"app.settings.search.empty": {
-		"message": "沒有與搜尋匹配的設定。"
-	},
-	"app.settings.search.placeholder": {
-		"message": "搜尋設定"
-	},
-	"app.settings.search.results": {
-		"message": "搜尋結果"
-	},
-	"app.settings.save-status.error": {
-		"message": "無法儲存"
-	},
-	"app.settings.save-status.retry": {
-		"message": "重試"
-	},
-	"app.settings.save-status.saved": {
-		"message": "已儲存"
-	},
-	"app.settings.save-status.saving": {
-		"message": "正在儲存…"
-	},
-	"app.sidebar.collapse": {
-		"message": "收起邊欄"
-	},
-	"app.sidebar.expand": {
-		"message": "展開邊欄"
 	},
 	"app.skins.add-button": {
 		"message": "新增外觀"
@@ -3029,18 +3938,6 @@
 	"app.skins.offline-account.compatibility-title": {
 		"message": "離線外觀相容性"
 	},
-	"app.skins.third-party-account.description": {
-		"message": "此帳號的外觀由其 Yggdrasil 驗證服務管理。請前往對應服務的網站更換外觀或披風。"
-	},
-	"app.skins.third-party-account.title": {
-		"message": "第三方外觀管理"
-	},
-	"app.skins.tabs.saved": {
-		"message": "已保存皮膚"
-	},
-	"app.skins.tabs.default": {
-		"message": "官方皮膚"
-	},
 	"app.skins.preview.edit-button": {
 		"message": "編輯外觀"
 	},
@@ -3095,17 +3992,29 @@
 	"app.skins.section.tiny-takeover": {
 		"message": "小鬼當家"
 	},
+	"app.skins.sign-in.axolotl-alt": {
+		"message": "Axolotl Launcher"
+	},
 	"app.skins.sign-in.button": {
 		"message": "登入"
 	},
 	"app.skins.sign-in.description": {
 		"message": "請登入你的 Minecraft 帳號以使用 Axolotl Launcher 的外觀管理功能。"
 	},
-	"app.skins.sign-in.axolotl-alt": {
-		"message": "Axolotl Launcher"
-	},
 	"app.skins.sign-in.title": {
 		"message": "請登入"
+	},
+	"app.skins.tabs.default": {
+		"message": "官方皮膚"
+	},
+	"app.skins.tabs.saved": {
+		"message": "已保存皮膚"
+	},
+	"app.skins.third-party-account.description": {
+		"message": "此帳號的外觀由其 Yggdrasil 驗證服務管理。請前往對應服務的網站更換外觀或披風。"
+	},
+	"app.skins.third-party-account.title": {
+		"message": "第三方外觀管理"
 	},
 	"app.skins.title": {
 		"message": "外觀選擇工具"
@@ -3115,6 +4024,30 @@
 	},
 	"app.splash.updating-app-directory": {
 		"message": "正在更新應用程式目錄……"
+	},
+	"app.symlink-capability.unsupported": {
+		"message": "系統不支持軟連結。"
+	},
+	"app.symlink-capability.unsupported.title": {
+		"message": "軟連結不支持"
+	},
+	"app.symlink-warning.delete.body": {
+		"message": "刪除此實例只會移除啟動器條目。「{path}」中的原始檔案將保留。"
+	},
+	"app.symlink-warning.delete.header": {
+		"message": "共享實例"
+	},
+	"app.symlink-warning.dismiss-permanently": {
+		"message": "Don"
+	},
+	"app.symlink-warning.shared-badge": {
+		"message": "共享"
+	},
+	"app.symlink-warning.write.body": {
+		"message": "此實例連結到「{path}」。此處的變更也會影響原始檔案。"
+	},
+	"app.symlink-warning.write.header": {
+		"message": "共享實例"
 	},
 	"app.translation-settings.auto-translate": {
 		"message": "自動翻譯專案頁面"
@@ -3164,17 +4097,8 @@
 	"app.translation-settings.style.background": {
 		"message": "背景色"
 	},
-	"app.translation-settings.style.blockquote": {
-		"message": "引用塊"
-	},
-	"app.translation-settings.style.blur": {
-		"message": "模糊"
-	},
 	"app.translation-settings.style.border": {
 		"message": "左邊框"
-	},
-	"app.translation-settings.style.dashed-line": {
-		"message": "虛線下劃線"
 	},
 	"app.translation-settings.style.default": {
 		"message": "預設"
@@ -3188,11 +4112,14 @@
 	"app.translation-settings.style.preview-text": {
 		"message": "在 Modrinth 上探索高品質的 Minecraft 內容。"
 	},
-	"app.translation-settings.style.text-color": {
-		"message": "文字顏色"
-	},
 	"app.translation-settings.style.weakened": {
 		"message": "弱化"
+	},
+	"app.translation-settings.system-prompt": {
+		"message": "系統提示詞"
+	},
+	"app.translation-settings.system-prompt-description": {
+		"message": "輸入你的自訂系統提示詞，留空則使用預設提示詞。"
 	},
 	"app.translation-settings.target-language": {
 		"message": "目標語言"
@@ -3295,6 +4222,1710 @@
 	},
 	"app.url-install.version": {
 		"message": "正在安裝版本 {version}"
+	},
+	"app.warning.running-as-admin": {
+		"message": "Axolotl 正在以系統管理員身分執行。此模式無法拖曳匯入檔案，請以一般權限重新啟動啟動器。"
+	},
+	"app.world.server-modal.placeholder-address": {
+		"message": "example.modrinth.gg"
+	},
+	"app.world.server-modal.select-an-option": {
+		"message": "選擇選項"
+	},
+	"app.world.world-item.incompatible-version": {
+		"message": "不相容的版本 {version}"
+	},
+	"app.world.world-item.not-played-yet": {
+		"message": "尚未遊玩"
+	},
+	"app.world.world-item.offline": {
+		"message": "離線"
+	},
+	"app.world.world-item.players-online": {
+		"message": "{count} 人在線上"
+	},
+	"app.worlds.title": {
+		"message": "世界"
+	},
+	"create.back": {
+		"message": "返回庫"
+	},
+	"create.import.description": {
+		"message": "從其他啟動器導入實例，或安裝整合包。"
+	},
+	"create.import.title": {
+		"message": "導入已有"
+	},
+	"create.new.description": {
+		"message": "創建一個新的 Minecraft 實例，自選模組載入器。"
+	},
+	"create.new.title": {
+		"message": "全新創建"
+	},
+	"create.subtitle": {
+		"message": "實例是帶有特定載入器、遊戲版本和模組的一套 Minecraft 配置。"
+	},
+	"create.title": {
+		"message": "創建實例"
+	},
+	"drop.help.instances-desc": {
+		"message": "從其他啟動器（MultiMC、Prism Launcher等）拖放文件夾來導入 Minecraft 實例。或者拖入 HMCL、PCL、PCL-CE 的啟動器"
+	},
+	"drop.help.instances-formats": {
+		"message": "（MultiMC / Prism Launcher / PolyMC） 實例文件夾或直接放入 （HMCL / PCL / PCL-CE ）啟動器。"
+	},
+	"drop.help.instances-title": {
+		"message": "啟動器實例"
+	},
+	"drop.help.modpacks-desc": {
+		"message": "拖放整合包 ZIP/MRPACK 文件來導入整合包。"
+	},
+	"drop.help.modpacks-formats": {
+		"message": "格式：.mrpack / .zip"
+	},
+	"drop.help.modpacks-title": {
+		"message": "整合包"
+	},
+	"drop.help.mods-desc": {
+		"message": "拖放模組 JAR 文件來安裝到 Minecraft 實例。"
+	},
+	"drop.help.mods-formats": {
+		"message": "格式：.jar"
+	},
+	"drop.help.mods-title": {
+		"message": "模組"
+	},
+	"drop.help.resource-packs-desc": {
+		"message": "拖放資源包 ZIP 文件來安裝到實例。"
+	},
+	"drop.help.resource-packs-formats": {
+		"message": "格式：.zip"
+	},
+	"drop.help.resource-packs-title": {
+		"message": "資源包"
+	},
+	"drop.help.schematics-desc": {
+		"message": "拖放 .litematic 文件來導入投影。"
+	},
+	"drop.help.schematics-formats": {
+		"message": "格式：.litematic"
+	},
+	"drop.help.schematics-title": {
+		"message": "投影"
+	},
+	"drop.help.shader-packs-desc": {
+		"message": "拖放光影包 ZIP 文件來安裝到實例。"
+	},
+	"drop.help.shader-packs-formats": {
+		"message": "格式：.zip"
+	},
+	"drop.help.shader-packs-title": {
+		"message": "光影包"
+	},
+	"drop.help.title": {
+		"message": "我可以拖入什麼到 Axolotl？"
+	},
+	"drop.help.worlds-desc": {
+		"message": "拖放存檔文件夾來導入到實例。"
+	},
+	"drop.help.worlds-formats": {
+		"message": "Minecraft 存檔文件夾。"
+	},
+	"drop.help.worlds-title": {
+		"message": "存檔"
+	},
+	"friends.action.add-friend": {
+		"message": "新增好友"
+	},
+	"friends.action.view-friend-requests": {
+		"message": "{count} 個好友{count, plural, other {邀請}}"
+	},
+	"friends.add-friend.submit": {
+		"message": "送出好友邀請"
+	},
+	"friends.add-friend.title": {
+		"message": "新增好友"
+	},
+	"friends.add-friend.username.description": {
+		"message": "這可能與對方的 Minecraft 使用者名稱不同！"
+	},
+	"friends.add-friend.username.placeholder": {
+		"message": "輸入 Modrinth 使用者名稱..."
+	},
+	"friends.add-friend.username.title": {
+		"message": "你好友的 Modrinth 使用者名稱是什麼？"
+	},
+	"friends.add-friends-to-share": {
+		"message": "<link>新增好友</link>即可查看他們正在玩什麼！"
+	},
+	"friends.friend.cancel-request": {
+		"message": "取消請求"
+	},
+	"friends.friend.remove-friend": {
+		"message": "移除好友"
+	},
+	"friends.friend.request-sent": {
+		"message": "已送出好友邀請"
+	},
+	"friends.friend.view-profile": {
+		"message": "查看個人檔案"
+	},
+	"friends.heading": {
+		"message": "好友"
+	},
+	"friends.heading.active": {
+		"message": "活躍中"
+	},
+	"friends.heading.offline": {
+		"message": "離線"
+	},
+	"friends.heading.online": {
+		"message": "線上"
+	},
+	"friends.heading.pending": {
+		"message": "待處理"
+	},
+	"friends.no-friends-match": {
+		"message": "找不到相符「{query}」的好友"
+	},
+	"friends.requests.accept": {
+		"message": "接受"
+	},
+	"friends.requests.cancel": {
+		"message": "取消"
+	},
+	"friends.requests.ignore": {
+		"message": "略過"
+	},
+	"friends.requests.incoming": {
+		"message": "{username} 向你送出了好友邀請"
+	},
+	"friends.requests.none": {
+		"message": "暫無待處理的好友邀請 :C"
+	},
+	"friends.requests.outgoing": {
+		"message": "你向 {username} 送出了好友邀請"
+	},
+	"friends.requests.title": {
+		"message": "查看好友邀請"
+	},
+	"friends.search-friends-placeholder": {
+		"message": "搜尋好友..."
+	},
+	"friends.section.heading": {
+		"message": "{title} — {count}"
+	},
+	"friends.sign-in-to-add-friends": {
+		"message": "<link>登入 Modrinth 帳號</link>即可新增好友並查看他們正在玩什麼！"
+	},
+	"instance.add-server.add-and-play": {
+		"message": "新增並遊玩"
+	},
+	"instance.add-server.add-server": {
+		"message": "新增伺服器"
+	},
+	"instance.add-server.resource-pack.disabled": {
+		"message": "已停用"
+	},
+	"instance.add-server.resource-pack.enabled": {
+		"message": "已啟用"
+	},
+	"instance.add-server.resource-pack.prompt": {
+		"message": "提示"
+	},
+	"instance.add-server.title": {
+		"message": "新增伺服器"
+	},
+	"instance.edit-server.title": {
+		"message": "編輯伺服器"
+	},
+	"instance.files.adding-files": {
+		"message": "正在新增檔案 ({completed}/{total})"
+	},
+	"instance.files.save-as": {
+		"message": "另存新檔..."
+	},
+	"instance.logs.delete.latest-running": {
+		"message": "實例執行時無法刪除 latest.log"
+	},
+	"instance.logs.source.live": {
+		"message": "即時日誌"
+	},
+	"instance.logs.source.numbered": {
+		"message": "日誌 {index}"
+	},
+	"instance.logs.source.unknown": {
+		"message": "未知"
+	},
+	"instance.server-modal.address": {
+		"message": "位址"
+	},
+	"instance.server-modal.name": {
+		"message": "名稱"
+	},
+	"instance.server-modal.placeholder-name": {
+		"message": "Minecraft 伺服器"
+	},
+	"instance.server-modal.resource-pack": {
+		"message": "資源包"
+	},
+	"instance.settings.tabs.general": {
+		"message": "一般"
+	},
+	"instance.settings.tabs.general.delete": {
+		"message": "刪除實例"
+	},
+	"instance.settings.tabs.general.delete.button": {
+		"message": "刪除實例"
+	},
+	"instance.settings.tabs.general.delete.description": {
+		"message": "這將從裝置上永久刪除實例，包含你的世界、設定與所有已安裝內容。請注意，一旦刪除，將無法復原。"
+	},
+	"instance.settings.tabs.general.deleting.button": {
+		"message": "刪除中..."
+	},
+	"instance.settings.tabs.general.duplicate-button": {
+		"message": "複製"
+	},
+	"instance.settings.tabs.general.duplicate-button.tooltip.installing": {
+		"message": "安裝時無法複製。"
+	},
+	"instance.settings.tabs.general.duplicate-instance": {
+		"message": "複製實例"
+	},
+	"instance.settings.tabs.general.duplicate-instance.description": {
+		"message": "建立這個實例的副本，包含世界、設定、模組等。"
+	},
+	"instance.settings.tabs.general.edit-icon": {
+		"message": "編輯圖示"
+	},
+	"instance.settings.tabs.general.edit-icon.remove": {
+		"message": "移除圖示"
+	},
+	"instance.settings.tabs.general.edit-icon.replace": {
+		"message": "取代圖示"
+	},
+	"instance.settings.tabs.general.edit-icon.select": {
+		"message": "選擇圖示"
+	},
+	"instance.settings.tabs.general.icon": {
+		"message": "圖示"
+	},
+	"instance.settings.tabs.general.name": {
+		"message": "名稱"
+	},
+	"instance.settings.tabs.general.update-channel": {
+		"message": "更新通道"
+	},
+	"instance.settings.tabs.general.update-channel.alpha": {
+		"message": "Alpha 版"
+	},
+	"instance.settings.tabs.general.update-channel.alpha.description": {
+		"message": "相容的正式版、Beta 版和 Alpha 版本都會顯示在可用更新中。"
+	},
+	"instance.settings.tabs.general.update-channel.beta": {
+		"message": "Beta 版"
+	},
+	"instance.settings.tabs.general.update-channel.beta.description": {
+		"message": "相容的正式版和 Beta 版本都會顯示在可用更新中。"
+	},
+	"instance.settings.tabs.general.update-channel.release": {
+		"message": "正式版"
+	},
+	"instance.settings.tabs.general.update-channel.release.description": {
+		"message": "僅有正式版會顯示在可用更新中。"
+	},
+	"instance.settings.tabs.general.update-channel.select": {
+		"message": "選擇更新通道"
+	},
+	"instance.settings.tabs.hooks": {
+		"message": "啟動掛鉤"
+	},
+	"instance.settings.tabs.hooks.custom-hooks": {
+		"message": "自訂啟動掛鉤"
+	},
+	"instance.settings.tabs.hooks.description": {
+		"message": "掛鉤讓進階使用者能在遊戲啟動前和啟動後執行特定的系統指令。"
+	},
+	"instance.settings.tabs.hooks.post-exit": {
+		"message": "結束後"
+	},
+	"instance.settings.tabs.hooks.post-exit.description": {
+		"message": "遊戲關閉後執行。"
+	},
+	"instance.settings.tabs.hooks.post-exit.enter": {
+		"message": "輸入結束後指令..."
+	},
+	"instance.settings.tabs.hooks.pre-launch": {
+		"message": "啟動前"
+	},
+	"instance.settings.tabs.hooks.pre-launch.description": {
+		"message": "實例啟動前執行。"
+	},
+	"instance.settings.tabs.hooks.pre-launch.enter": {
+		"message": "輸入啟動前指令..."
+	},
+	"instance.settings.tabs.hooks.title": {
+		"message": "遊戲啟動掛鉤"
+	},
+	"instance.settings.tabs.hooks.wrapper": {
+		"message": "包裝器指令"
+	},
+	"instance.settings.tabs.hooks.wrapper.description": {
+		"message": "用於啟動 Minecraft 的包裝器指令。"
+	},
+	"instance.settings.tabs.hooks.wrapper.enter": {
+		"message": "輸入包裝器指令..."
+	},
+	"instance.settings.tabs.installation": {
+		"message": "安裝"
+	},
+	"instance.settings.tabs.installation.loader-version": {
+		"message": "{loader} 版本"
+	},
+	"instance.settings.tabs.java": {
+		"message": "Java 和記憶體"
+	},
+	"instance.settings.tabs.java.automatic-memory": {
+		"message": "啟動時自動分配記憶體"
+	},
+	"instance.settings.tabs.java.custom-environment-variables": {
+		"message": "自訂環境變數"
+	},
+	"instance.settings.tabs.java.custom-java-arguments": {
+		"message": "自訂 Java 參數"
+	},
+	"instance.settings.tabs.java.custom-java-installation": {
+		"message": "為此實例使用自訂 Java"
+	},
+	"instance.settings.tabs.java.custom-memory-allocation": {
+		"message": "自訂記憶體分配"
+	},
+	"instance.settings.tabs.java.enter-environment-variables": {
+		"message": "輸入環境變數..."
+	},
+	"instance.settings.tabs.java.enter-java-arguments": {
+		"message": "輸入 Java 參數..."
+	},
+	"instance.settings.tabs.java.environment-variables": {
+		"message": "環境變數"
+	},
+	"instance.settings.tabs.java.java-arguments": {
+		"message": "Java 參數"
+	},
+	"instance.settings.tabs.java.java-installation": {
+		"message": "Java 安裝"
+	},
+	"instance.settings.tabs.java.java-memory": {
+		"message": "記憶體配置"
+	},
+	"instance.settings.tabs.java.java-path-placeholder": {
+		"message": "/path/to/java"
+	},
+	"instance.settings.tabs.window": {
+		"message": "視窗"
+	},
+	"instance.settings.tabs.window.custom-window-settings": {
+		"message": "自訂視窗設定"
+	},
+	"instance.settings.tabs.window.fullscreen": {
+		"message": "全螢幕"
+	},
+	"instance.settings.tabs.window.fullscreen.description": {
+		"message": "使遊戲啟動時進入全螢幕模式（透過 options.txt）。"
+	},
+	"instance.settings.tabs.window.height": {
+		"message": "高度"
+	},
+	"instance.settings.tabs.window.height.description": {
+		"message": "遊戲啟動時的視窗高度。"
+	},
+	"instance.settings.tabs.window.height.enter": {
+		"message": "輸入高度..."
+	},
+	"instance.settings.tabs.window.width": {
+		"message": "寬度"
+	},
+	"instance.settings.tabs.window.width.description": {
+		"message": "遊戲啟動時的視窗寬度。"
+	},
+	"instance.settings.tabs.window.width.enter": {
+		"message": "輸入寬度..."
+	},
+	"instance.worlds.a_minecraft_server": {
+		"message": "Minecraft 伺服器"
+	},
+	"instance.worlds.cant_connect": {
+		"message": "無法連線到伺服器"
+	},
+	"instance.worlds.copy_address": {
+		"message": "複製位址"
+	},
+	"instance.worlds.create_shortcut": {
+		"message": "建立捷徑"
+	},
+	"instance.worlds.game_already_open": {
+		"message": "實例已經開啟"
+	},
+	"instance.worlds.hardcore": {
+		"message": "極限模式"
+	},
+	"instance.worlds.incompatible_server": {
+		"message": "伺服器不相容"
+	},
+	"instance.worlds.linked_server": {
+		"message": "由伺服器專案管理"
+	},
+	"instance.worlds.no_contact": {
+		"message": "伺服器沒有回應"
+	},
+	"instance.worlds.no_server_quick_play": {
+		"message": "你只能在 Minecraft Alpha 1.0.5 以上版本直接加入伺服器"
+	},
+	"instance.worlds.no_singleplayer_quick_play": {
+		"message": "你只能在 Minecraft 1.20 以上版本直接進入單人遊戲世界"
+	},
+	"instance.worlds.play_instance": {
+		"message": "遊玩實例"
+	},
+	"instance.worlds.view_instance": {
+		"message": "檢視實例"
+	},
+	"instance.worlds.world_in_use": {
+		"message": "世界正在使用中"
+	},
+	"minecraft-account.add-microsoft-account": {
+		"message": "新增 Microsoft 帳號"
+	},
+	"minecraft-account.add-offline-account": {
+		"message": "新增離線帳號"
+	},
+	"minecraft-account.add-third-party-account": {
+		"message": "新增第三方帳號"
+	},
+	"minecraft-account.label": {
+		"message": "Minecraft 帳號"
+	},
+	"minecraft-account.not-signed-in": {
+		"message": "未登入"
+	},
+	"minecraft-account.offline-account": {
+		"message": "Minecraft 離線帳號"
+	},
+	"minecraft-account.offline-badge": {
+		"message": "離線"
+	},
+	"minecraft-account.offline-modal.chinese-username-warning": {
+		"message": "Minecraft 1.18 及以上版本可能會拒絕中文使用者名稱，導致無法進入單人世界或伺服器。請在舊版本中使用此帳號，或在新版本改用英文使用者名稱。"
+	},
+	"minecraft-account.offline-modal.create": {
+		"message": "建立帳號"
+	},
+	"minecraft-account.offline-modal.description": {
+		"message": "設定離線帳號的使用者名稱。此帳號僅能加入未啟用正版驗證的伺服器。"
+	},
+	"minecraft-account.offline-modal.title": {
+		"message": "新增離線帳號"
+	},
+	"minecraft-account.offline-modal.username-label": {
+		"message": "Minecraft 使用者名稱"
+	},
+	"minecraft-account.offline-modal.username-placeholder": {
+		"message": "輸入使用者名稱"
+	},
+	"minecraft-account.offline-modal.username-validation": {
+		"message": "請輸入 1–16 個字母、數字或底線，支援中文。"
+	},
+	"minecraft-account.offline-mode": {
+		"message": "離線模式"
+	},
+	"minecraft-account.offline-mode.description": {
+		"message": "僅可使用離線帳號，並且只能啟動已完整下載的實例。"
+	},
+	"minecraft-account.offline-mode.refresh": {
+		"message": "刷新連接狀態"
+	},
+	"minecraft-account.remove-account": {
+		"message": "移除帳號"
+	},
+	"minecraft-account.select-account": {
+		"message": "選擇帳號"
+	},
+	"minecraft-account.sign-in": {
+		"message": "登入 Minecraft"
+	},
+	"minecraft-account.third-party-account": {
+		"message": "Minecraft 第三方帳號"
+	},
+	"minecraft-account.third-party-badge": {
+		"message": "第三方"
+	},
+	"minecraft-account.third-party-modal.account": {
+		"message": "帳號或電子郵件"
+	},
+	"minecraft-account.third-party-modal.account-placeholder": {
+		"message": "請輸入帳號或電子郵件"
+	},
+	"minecraft-account.third-party-modal.api-root": {
+		"message": "Yggdrasil API 網址"
+	},
+	"minecraft-account.third-party-modal.api-root-placeholder": {
+		"message": "https://example.com/api/yggdrasil"
+	},
+	"minecraft-account.third-party-modal.description": {
+		"message": "使用 LittleSkin 或其他相容的 Yggdrasil 外掛登入服務。"
+	},
+	"minecraft-account.third-party-modal.littleskin": {
+		"message": "使用 LittleSkin"
+	},
+	"minecraft-account.third-party-modal.password": {
+		"message": "密碼"
+	},
+	"minecraft-account.third-party-modal.remember-password": {
+		"message": "在此裝置上儲存登入資訊"
+	},
+	"minecraft-account.third-party-modal.remove-saved-login": {
+		"message": "刪除已儲存的登入紀錄"
+	},
+	"minecraft-account.third-party-modal.saved-logins": {
+		"message": "已儲存的登入紀錄"
+	},
+	"minecraft-account.third-party-modal.sign-in": {
+		"message": "登入"
+	},
+	"minecraft-account.third-party-modal.title": {
+		"message": "登入第三方帳號"
+	},
+	"minecraft-account.third-party-profile.description": {
+		"message": "請選擇此帳號要使用的 Minecraft 角色。"
+	},
+	"minecraft-account.third-party-profile.title": {
+		"message": "選擇角色"
+	},
+	"project.description.title": {
+		"message": "簡介"
+	},
+	"project.gallery.title": {
+		"message": "圖庫"
+	},
+	"project.versions.title": {
+		"message": "版本"
+	},
+	"search.filter.locked.instance": {
+		"message": "由該實例提供"
+	},
+	"search.filter.locked.instance-game-version.title": {
+		"message": "遊戲版本由實例提供"
+	},
+	"search.filter.locked.instance-loader.title": {
+		"message": "載入器版本由實例提供"
+	},
+	"search.filter.locked.instance.sync": {
+		"message": "與實例同步"
+	},
+	"search.filter.locked.server": {
+		"message": "由伺服器提供"
+	},
+	"search.filter.locked.server-environment.title": {
+		"message": "只有用戶端模組可以被加到伺服器實例"
+	},
+	"search.filter.locked.server-game-version.title": {
+		"message": "遊戲版本由伺服器提供"
+	},
+	"search.filter.locked.server-loader.title": {
+		"message": "載入器由伺服器提供"
+	},
+	"unknown-pack-warning-modal.body": {
+		"message": "只有上傳至 Modrinth 的檔案才會經過審查，無論其檔案格式為何（包含 .mrpack）。"
+	},
+	"unknown-pack-warning-modal.dont-show-again": {
+		"message": "不要再顯示這則警告"
+	},
+	"unknown-pack-warning-modal.header": {
+		"message": "確認安裝"
+	},
+	"unknown-pack-warning-modal.install-anyway": {
+		"message": "仍要安裝"
+	},
+	"unknown-pack-warning-modal.malware-statement": {
+		"message": "惡意軟體經常透過 Discord 等平臺分享模組包檔案來進行傳播。"
+	},
+	"unknown-pack-warning-modal.warning.body": {
+		"message": "我們在 Modrinth 上找不到這個檔案。強烈建議你僅安裝來自信任來源的檔案。"
+	},
+	"unknown-pack-warning-modal.warning.title": {
+		"message": "未知檔案警告"
+	},
+	"app.translation-settings.provider.deepl": {
+		"message": "DeepL 翻譯"
+	},
+	"app.translation-settings.deepl-api-key-placeholder": {
+		"message": "輸入你的 DeepL API 金鑰"
+	},
+	"app.translation-settings.deepl-api-key-hint": {
+		"message": "在 deepl.com/pro-api 免費取得金鑰"
+	},
+	"app.translation-settings.deepl-api-key": {
+		"message": "API 金鑰"
+	},
+	"app.translation-settings.deepl-api-endpoint-placeholder": {
+		"message": "https://api-free.deepl.com/v2/translate"
+	},
+	"app.translation-settings.deepl-api-endpoint": {
+		"message": "API 端點"
+	},
+	"app.survey-promotion.title": {
+		"message": "調查問卷"
+	},
+	"app.survey-promotion.reward": {
+		"message": "我們將從填寫問卷的使用者中抽取幸運使用者，贈送 Minecraft 正版帳號（可折現）。"
+	},
+	"app.survey-promotion.intro": {
+		"message": "為了更好地改進 Axolotl Launcher，我們準備了一份簡短的調查問卷，期待聽到你的回饋。"
+	},
+	"app.survey-promotion.fill-survey": {
+		"message": "填寫問卷"
+	},
+	"app.survey-promotion.defer-hint": {
+		"message": "關閉此彈窗後，你仍可以隨時在「設定 → 關於」頁面中找到並填寫問卷。"
+	},
+	"app.instances.exit-select-mode": {
+		"message": "退出"
+	},
+	"app.servers.action.open-folder": {
+		"message": "開啟資料夾"
+	},
+	"app.servers.action.share": {
+		"message": "分享至公開網路"
+	},
+	"app.servers.action.start": {
+		"message": "啟動"
+	},
+	"app.servers.action.stop": {
+		"message": "停止"
+	},
+	"app.servers.card.port": {
+		"message": "連接埠 {port}"
+	},
+	"app.servers.card.type": {
+		"message": "{type} · {version}"
+	},
+	"app.servers.console.command-echo": {
+		"message": "> {command}"
+	},
+	"app.servers.console.not-running": {
+		"message": "伺服器未執行"
+	},
+	"app.servers.count": {
+		"message": "{count, plural, =0 {還沒有伺服器} other {共 # 個伺服器}}"
+	},
+	"app.servers.create.title": {
+		"message": "建立伺服器"
+	},
+	"app.servers.detail.back": {
+		"message": "伺服器"
+	},
+	"app.servers.detail.console": {
+		"message": "主控台"
+	},
+	"app.servers.detail.files": {
+		"message": "檔案"
+	},
+	"app.servers.detail.not-found": {
+		"message": "該伺服器已不存在。"
+	},
+	"app.servers.detail.settings": {
+		"message": "設定"
+	},
+	"app.servers.empty.description": {
+		"message": "在啟動器中建立伺服器，與好友一起遊玩。"
+	},
+	"app.servers.empty.heading": {
+		"message": "還沒有伺服器"
+	},
+	"app.servers.eula.accept": {
+		"message": "同意並繼續"
+	},
+	"app.servers.eula.decline": {
+		"message": "取消"
+	},
+	"app.servers.eula.description": {
+		"message": "伺服器啟動前需要同意 Minecraft 最終使用者授權條款（EULA）。請查看以下內容："
+	},
+	"app.servers.eula.title": {
+		"message": "Minecraft EULA"
+	},
+	"app.servers.loading": {
+		"message": "載入中"
+	},
+	"app.servers.files.busy-tooltip": {
+		"message": "停止伺服器後才能修改檔案"
+	},
+	"app.servers.files.save-as": {
+		"message": "另存為..."
+	},
+	"app.servers.icon.change": {
+		"message": "變更圖示"
+	},
+	"app.servers.icon.edit": {
+		"message": "編輯圖示"
+	},
+	"app.servers.icon.remove": {
+		"message": "移除圖示"
+	},
+	"app.servers.icon.select": {
+		"message": "選擇圖示"
+	},
+	"app.servers.port.change": {
+		"message": "修改連接埠"
+	},
+	"app.servers.port.conflict-description": {
+		"message": "{process} 正在佔用此連接埠，伺服器無法啟動。建議修改伺服器連接埠，也可以強制結束佔用程序後再啟動。"
+	},
+	"app.servers.port.conflict-title": {
+		"message": "連接埠 {port} 已被佔用"
+	},
+	"app.servers.port.force-quit": {
+		"message": "強制結束佔用程序"
+	},
+	"app.servers.port.force-quit-failed": {
+		"message": "結束佔用連接埠的程序失敗"
+	},
+	"app.servers.port.recheck": {
+		"message": "重新偵測"
+	},
+	"app.servers.port.unknown-process": {
+		"message": "未知程序（PID {pid}）"
+	},
+	"app.servers.properties.field.accepts-transfers": {
+		"message": "接受玩家轉移"
+	},
+	"app.servers.properties.field.allow-end": {
+		"message": "允許終界"
+	},
+	"app.servers.properties.field.allow-flight": {
+		"message": "允許飛行"
+	},
+	"app.servers.properties.field.allow-nether": {
+		"message": "允許地獄"
+	},
+	"app.servers.properties.field.announce-player-achievements": {
+		"message": "廣播玩家成就"
+	},
+	"app.servers.properties.field.broadcast-console-to-ops": {
+		"message": "向管理員廣播主控台訊息"
+	},
+	"app.servers.properties.field.broadcast-rcon-to-ops": {
+		"message": "向管理員廣播 RCON 訊息"
+	},
+	"app.servers.properties.field.bug-report-link": {
+		"message": "Bug 回報連結"
+	},
+	"app.servers.properties.field.chat-spam-threshold-seconds": {
+		"message": "聊天洗版門檻（秒）"
+	},
+	"app.servers.properties.field.command-spam-threshold-seconds": {
+		"message": "指令洗版門檻（秒）"
+	},
+	"app.servers.properties.field.difficulty": {
+		"message": "難度"
+	},
+	"app.servers.properties.field.enable-code-of-conduct": {
+		"message": "啟用行為準則"
+	},
+	"app.servers.properties.field.enable-command-block": {
+		"message": "啟用指令方塊"
+	},
+	"app.servers.properties.field.enable-jmx-monitoring": {
+		"message": "啟用 JMX 監控"
+	},
+	"app.servers.properties.field.enable-lan": {
+		"message": "啟用區域網路"
+	},
+	"app.servers.properties.field.enable-query": {
+		"message": "啟用查詢"
+	},
+	"app.servers.properties.field.enable-rcon": {
+		"message": "啟用 RCON"
+	},
+	"app.servers.properties.field.enable-status": {
+		"message": "啟用伺服器狀態"
+	},
+	"app.servers.properties.field.enforce-secure-profile": {
+		"message": "強制安全設定檔"
+	},
+	"app.servers.properties.field.enforce-whitelist": {
+		"message": "強制白名單"
+	},
+	"app.servers.properties.field.entity-broadcast-range-percentage": {
+		"message": "實體廣播範圍百分比"
+	},
+	"app.servers.properties.field.force-gamemode": {
+		"message": "強制遊戲模式"
+	},
+	"app.servers.properties.field.function-permission-level": {
+		"message": "函式權限等級"
+	},
+	"app.servers.properties.field.gamemode": {
+		"message": "遊戲模式"
+	},
+	"app.servers.properties.field.generate-structures": {
+		"message": "生成結構"
+	},
+	"app.servers.properties.field.generator-settings": {
+		"message": "生成器設定"
+	},
+	"app.servers.properties.field.hardcore": {
+		"message": "核心模式"
+	},
+	"app.servers.properties.field.hide-online-players": {
+		"message": "隱藏線上玩家"
+	},
+	"app.servers.properties.field.initial-disabled-packs": {
+		"message": "初始停用的資料包"
+	},
+	"app.servers.properties.field.initial-enabled-packs": {
+		"message": "初始啟用的資料包"
+	},
+	"app.servers.properties.field.level-name": {
+		"message": "世界名稱"
+	},
+	"app.servers.properties.field.level-seed": {
+		"message": "世界種子"
+	},
+	"app.servers.properties.field.level-type": {
+		"message": "世界類型"
+	},
+	"app.servers.properties.field.log-ips": {
+		"message": "記錄 IP"
+	},
+	"app.servers.properties.field.management-server-allowed-origins": {
+		"message": "管理伺服器允許的來源"
+	},
+	"app.servers.properties.field.management-server-enabled": {
+		"message": "啟用管理伺服器"
+	},
+	"app.servers.properties.field.management-server-host": {
+		"message": "管理伺服器主機"
+	},
+	"app.servers.properties.field.management-server-port": {
+		"message": "管理伺服器連接埠"
+	},
+	"app.servers.properties.field.management-server-secret": {
+		"message": "管理伺服器金鑰"
+	},
+	"app.servers.properties.field.management-server-tls-enabled": {
+		"message": "管理伺服器啟用 TLS"
+	},
+	"app.servers.properties.field.management-server-tls-keystore": {
+		"message": "管理伺服器 TLS 金鑰儲存庫"
+	},
+	"app.servers.properties.field.management-server-tls-keystore-password": {
+		"message": "管理伺服器 TLS 金鑰儲存庫密碼"
+	},
+	"app.servers.properties.field.max-chained-neighbor-updates": {
+		"message": "最大連鎖鄰近更新次數"
+	},
+	"app.servers.properties.field.max-players": {
+		"message": "最大玩家數"
+	},
+	"app.servers.properties.field.max-tick-time": {
+		"message": "最大單 Tick 時間"
+	},
+	"app.servers.properties.field.max-world-size": {
+		"message": "最大世界大小"
+	},
+	"app.servers.properties.field.motd": {
+		"message": "伺服器標語（MOTD）"
+	},
+	"app.servers.properties.field.network-compression-threshold": {
+		"message": "網路壓縮門檻"
+	},
+	"app.servers.properties.field.online-mode": {
+		"message": "正版驗證"
+	},
+	"app.servers.properties.field.op-permission-level": {
+		"message": "管理員權限等級"
+	},
+	"app.servers.properties.field.pause-when-empty-seconds": {
+		"message": "空服暫停（秒）"
+	},
+	"app.servers.properties.field.player-idle-timeout": {
+		"message": "玩家閒置逾時"
+	},
+	"app.servers.properties.field.prevent-proxy-connections": {
+		"message": "禁止代理連線"
+	},
+	"app.servers.properties.field.pvp": {
+		"message": "玩家對戰（PvP）"
+	},
+	"app.servers.properties.field.query.port": {
+		"message": "查詢連接埠"
+	},
+	"app.servers.properties.field.rate-limit": {
+		"message": "頻率限制"
+	},
+	"app.servers.properties.field.rcon.password": {
+		"message": "RCON 密碼"
+	},
+	"app.servers.properties.field.rcon.port": {
+		"message": "RCON 連接埠"
+	},
+	"app.servers.properties.field.region-file-compression": {
+		"message": "區域檔案壓縮方式"
+	},
+	"app.servers.properties.field.require-resource-pack": {
+		"message": "強制資源包"
+	},
+	"app.servers.properties.field.resource-pack": {
+		"message": "資源包"
+	},
+	"app.servers.properties.field.resource-pack-id": {
+		"message": "資源包 ID"
+	},
+	"app.servers.properties.field.resource-pack-prompt": {
+		"message": "資源包提示"
+	},
+	"app.servers.properties.field.resource-pack-sha1": {
+		"message": "資源包 SHA-1"
+	},
+	"app.servers.properties.field.server-ip": {
+		"message": "伺服器 IP"
+	},
+	"app.servers.properties.field.server-port": {
+		"message": "伺服器連接埠"
+	},
+	"app.servers.properties.field.simulation-distance": {
+		"message": "模擬距離"
+	},
+	"app.servers.properties.field.spawn-animals": {
+		"message": "生成動物"
+	},
+	"app.servers.properties.field.spawn-monsters": {
+		"message": "生成怪物"
+	},
+	"app.servers.properties.field.spawn-npcs": {
+		"message": "生成 NPC"
+	},
+	"app.servers.properties.field.spawn-protection": {
+		"message": "重生點保護範圍"
+	},
+	"app.servers.properties.field.status-heartbeat-interval": {
+		"message": "狀態心跳間隔"
+	},
+	"app.servers.properties.field.sync-chunk-writes": {
+		"message": "同步區塊寫入"
+	},
+	"app.servers.properties.field.text-filtering-config": {
+		"message": "文字過濾設定"
+	},
+	"app.servers.properties.field.text-filtering-version": {
+		"message": "文字過濾版本"
+	},
+	"app.servers.properties.field.use-native-transport": {
+		"message": "使用原生傳輸"
+	},
+	"app.servers.properties.field.view-distance": {
+		"message": "繪製距離"
+	},
+	"app.servers.properties.field.white-list": {
+		"message": "白名單"
+	},
+	"app.servers.properties.load-failed": {
+		"message": "載入伺服器設定失敗。"
+	},
+	"app.servers.properties.missing": {
+		"message": "啟動一次伺服器即可產生此檔案。"
+	},
+	"app.servers.properties.mode.form": {
+		"message": "表單"
+	},
+	"app.servers.properties.mode.text": {
+		"message": "文字"
+	},
+	"app.servers.properties.save": {
+		"message": "儲存變更"
+	},
+	"app.servers.properties.saved": {
+		"message": "伺服器設定已儲存"
+	},
+	"app.servers.properties.section.advanced": {
+		"message": "進階"
+	},
+	"app.servers.properties.section.content": {
+		"message": "資源與內容"
+	},
+	"app.servers.properties.section.gameplay": {
+		"message": "遊戲玩法"
+	},
+	"app.servers.properties.section.network": {
+		"message": "網路與安全"
+	},
+	"app.servers.properties.section.others": {
+		"message": "其他"
+	},
+	"app.servers.properties.section.world": {
+		"message": "世界"
+	},
+	"app.servers.properties.title": {
+		"message": "伺服器屬性"
+	},
+	"app.servers.refresh": {
+		"message": "重新整理"
+	},
+	"app.servers.settings.cancel": {
+		"message": "取消"
+	},
+	"app.servers.settings.config": {
+		"message": "設定檔"
+	},
+	"app.servers.settings.delete": {
+		"message": "刪除伺服器"
+	},
+	"app.servers.settings.delete-confirm": {
+		"message": "刪除 {name} 及其所有檔案？此操作無法復原。"
+	},
+	"app.servers.settings.delete-hint": {
+		"message": "永久刪除該伺服器及其所有檔案。"
+	},
+	"app.servers.settings.delete-proceed": {
+		"message": "刪除"
+	},
+	"app.servers.settings.general": {
+		"message": "一般"
+	},
+	"app.servers.settings.icon": {
+		"message": "圖示"
+	},
+	"app.servers.settings.java": {
+		"message": "Java"
+	},
+	"app.servers.settings.java-none": {
+		"message": "系統預設"
+	},
+	"app.servers.settings.jvm-args": {
+		"message": "JVM 參數"
+	},
+	"app.servers.settings.jvm-args-hint": {
+		"message": "以空格分隔的參數，例如 -XX:+UseG1GC"
+	},
+	"app.servers.settings.memory": {
+		"message": "記憶體"
+	},
+	"app.servers.settings.name": {
+		"message": "伺服器名稱"
+	},
+	"app.servers.settings.running-hint": {
+		"message": "您的變更在下次啟動伺服器後才會生效。"
+	},
+	"app.servers.settings.running-title": {
+		"message": "伺服器執行中"
+	},
+	"app.servers.settings.save": {
+		"message": "儲存變更"
+	},
+	"app.servers.settings.saved": {
+		"message": "伺服器設定已儲存"
+	},
+	"app.servers.status.crashed": {
+		"message": "已崩潰"
+	},
+	"app.servers.status.created": {
+		"message": "未設定"
+	},
+	"app.servers.status.eula-pending": {
+		"message": "待同意 EULA"
+	},
+	"app.servers.status.ready": {
+		"message": "就緒"
+	},
+	"app.servers.status.running": {
+		"message": "執行中"
+	},
+	"app.servers.status.starting": {
+		"message": "啟動中"
+	},
+	"app.servers.wizard.configure-heading": {
+		"message": "調整伺服器設定，或直接完成，稍後再編輯。"
+	},
+	"app.servers.wizard.configure-title": {
+		"message": "設定"
+	},
+	"app.servers.wizard.done": {
+		"message": "伺服器已就緒"
+	},
+	"app.servers.wizard.downloading": {
+		"message": "正在下載伺服器端檔案…"
+	},
+	"app.servers.wizard.eula-wait": {
+		"message": "等待確認 EULA"
+	},
+	"app.servers.wizard.failed": {
+		"message": "建立失敗"
+	},
+	"app.servers.wizard.finish": {
+		"message": "完成"
+	},
+	"app.servers.wizard.first-run": {
+		"message": "正在首次啟動…"
+	},
+	"app.servers.wizard.game-version": {
+		"message": "遊戲版本"
+	},
+	"app.servers.wizard.install-title": {
+		"message": "安裝"
+	},
+	"app.servers.wizard.loader-version": {
+		"message": "載入器版本"
+	},
+	"app.servers.wizard.log": {
+		"message": "輸出"
+	},
+	"app.servers.wizard.memory-value": {
+		"message": "{value} MB"
+	},
+	"app.servers.wizard.name": {
+		"message": "伺服器名稱"
+	},
+	"app.servers.wizard.name-placeholder": {
+		"message": "生存服"
+	},
+	"app.servers.wizard.next": {
+		"message": "下一步"
+	},
+	"app.servers.wizard.retry": {
+		"message": "重試"
+	},
+	"app.servers.wizard.setup-title": {
+		"message": "設定"
+	},
+	"app.servers.wizard.show-snapshots": {
+		"message": "顯示快照版本"
+	},
+	"app.servers.wizard.type-heading": {
+		"message": "選擇伺服器端類型"
+	},
+	"app.servers.wizard.type-title": {
+		"message": "伺服器端類型"
+	},
+	"app.settings.resources.source.mcim": {
+		"message": "MCIM 鏡像"
+	},
+	"app.settings.tabs.about": {
+		"message": "關於"
+	},
+	"app.settings.tabs.appearance": {
+		"message": "外觀"
+	},
+	"app.settings.tabs.default-instance-options": {
+		"message": "預設實例選項"
+	},
+	"app.settings.tabs.java-installations": {
+		"message": "Java 安裝"
+	},
+	"app.settings.tabs.language": {
+		"message": "語言"
+	},
+	"app.settings.tabs.multiplayer": {
+		"message": "多人聯機"
+	},
+	"app.settings.tabs.resource-management": {
+		"message": "資源管理"
+	},
+	"app.settings.tabs.translation": {
+		"message": "翻譯"
+	},
+	"app.settings.tabs.updates": {
+		"message": "更新"
+	},
+	"app.translation-settings.provider.microsoft": {
+		"message": "Microsoft 翻譯（無法使用）"
+	},
+	"instance.settings.tabs.general.library-groups": {
+		"message": "遊戲庫群組"
+	},
+	"instance.settings.tabs.general.library-groups.create": {
+		"message": "建立新的群組"
+	},
+	"instance.settings.tabs.general.library-groups.description": {
+		"message": "遊戲庫群組讓你可以將實例整理到遊戲庫中的不同分類。"
+	},
+	"instance.settings.tabs.general.library-groups.enter-name": {
+		"message": "輸入群組名稱"
+	},
+	"app.action-bar.install.cache-repair.action": {
+		"message": "清除專案快取並重試"
+	},
+	"app.action-bar.install.cache-repair.description": {
+		"message": "啟動器無法讀取本地 CurseForge 專案快取，安裝已停止。"
+	},
+	"app.action-bar.install.cache-repair.failed": {
+		"message": "專案快取清除失敗；尚未開始重試。"
+	},
+	"app.action-bar.install.cache-repair.in-progress": {
+		"message": "正在清除專案快取…"
+	},
+	"app.action-bar.install.cache-repair.title": {
+		"message": "專案後設資料快取異常"
+	},
+	"app.action-bar.install.deleted-instance": {
+		"message": "例項已刪除"
+	},
+	"app.appearance-settings.page-transitions.description": {
+		"message": "在啟動器頁面之間切換時播放過渡動畫。"
+	},
+	"app.appearance-settings.page-transitions.title": {
+		"message": "頁面切換過渡動畫"
+	},
+	"app.appearance-settings.auto-install-dependencies.description": {
+		"message": "安裝內容時自動下載所需前置。每次安裝前仍可在確認對話方塊中調整選擇。"
+	},
+	"app.appearance-settings.auto-install-dependencies.title": {
+		"message": "自動安裝前置"
+	},
+	"app.browse.discover-maps": {
+		"message": "發現地圖"
+	},
+	"app.browse.maps-unavailable": {
+		"message": "地圖不可用"
+	},
+	"app.browse.maps-unavailable-description": {
+		"message": "請配置 CurseForge API Key 以瀏覽和安裝地圖。"
+	},
+	"app.browse.maps-no-installable-file": {
+		"message": "所選 CurseForge 地圖沒有可安裝的檔案。"
+	},
+	"app.browse.project-type.maps": {
+		"message": "地圖"
+	},
+	"app.content-install.dependencies-installed.notification-body": {
+		"message": "已自動安裝 {count, plural, other {# 個前置}}：{list}"
+	},
+	"app.content-install.dependencies-installed.notification-title": {
+		"message": "已安裝前置"
+	},
+	"app.content-install.dependencies-skipped.notification-body": {
+		"message": "以下前置未安裝：{list}"
+	},
+	"app.content-install.dependencies-skipped.notification-title": {
+		"message": "部分前置已跳過"
+	},
+	"app.content-install.preview.already-included": {
+		"message": "已包含"
+	},
+	"app.content-install.preview.already-installed": {
+		"message": "已安裝"
+	},
+	"app.content-install.preview.cancel": {
+		"message": "取消"
+	},
+	"app.content-install.preview.clear-all": {
+		"message": "全部取消"
+	},
+	"app.content-install.preview.dependencies-count": {
+		"message": "{count, number} 個前置"
+	},
+	"app.content-install.preview.dependencies-header": {
+		"message": "前置"
+	},
+	"app.content-install.preview.description": {
+		"message": "將在 {instance} 中為 {project} 自動安裝 {count, plural, other {# 個前置}}。"
+	},
+	"app.content-install.preview.header": {
+		"message": "確認安裝"
+	},
+	"app.content-install.preview.install": {
+		"message": "安裝"
+	},
+	"app.content-install.preview.only-checked": {
+		"message": "只會安裝勾選的前置。"
+	},
+	"app.content-install.preview.optional-dependencies-header": {
+		"message": "可選前置"
+	},
+	"app.content-install.preview.required-dependencies-header": {
+		"message": "必要前置"
+	},
+	"app.content-install.preview.required-by": {
+		"message": "被 {projects} 需要"
+	},
+	"app.content-install.preview.select-all": {
+		"message": "全選"
+	},
+	"app.content-install.preview.skip.already-installed": {
+		"message": "已安裝"
+	},
+	"app.content-install.preview.skip.conflicting-dependency": {
+		"message": "前置版本衝突"
+	},
+	"app.content-install.preview.skip.duplicate-project": {
+		"message": "已包含"
+	},
+	"app.content-install.preview.skip.embedded": {
+		"message": "已內建於專案中"
+	},
+	"app.content-install.preview.skip.excluded-by-user": {
+		"message": "已由使用者取消"
+	},
+	"app.content-install.preview.skip.incompatible": {
+		"message": "不相容的前置"
+	},
+	"app.content-install.preview.skip.missing-version": {
+		"message": "找不到引用的版本"
+	},
+	"app.content-install.preview.skip.no-compatible-version": {
+		"message": "找不到相容版本"
+	},
+	"app.content-install.preview.skip.optional": {
+		"message": "可選前置"
+	},
+	"app.content-install.preview.skip.quilt-fabric-api": {
+		"message": "已替換為 Quilt 版本"
+	},
+	"app.content-install.preview.skip.tool": {
+		"message": "開發工具，不安裝"
+	},
+	"app.content-install.preview.skip.unsupported-project-type": {
+		"message": "不支援的專案型別"
+	},
+	"app.content-install.preview.skipped-header": {
+		"message": "跳過"
+	},
+	"app.content-install.preview.version-mismatch": {
+		"message": "下載的版本可能與當前版本不相容。"
+	},
+	"app.instance.mods.orphaned-dependencies.body": {
+		"message": "以下前置已不再被其他內容需要，且不會被自動刪除：{list}"
+	},
+	"app.instance.mods.orphaned-dependencies.title": {
+		"message": "前置已不再被需要"
+	},
+	"app.instance.mods.toggle-dependencies.apply": {
+		"message": "切換相關內容"
+	},
+	"app.instance.mods.toggle-dependencies.bulk-body": {
+		"message": "切換所選內容將同時影響 {count} 個其他內容。"
+	},
+	"app.instance.mods.toggle-dependencies.selected-only": {
+		"message": "僅切換所選"
+	},
+	"app.instance.mods.toggle-dependencies.single-body": {
+		"message": "切換 {project} 將同時影響 {count} 個其他內容。"
+	},
+	"app.instance.mods.toggle-dependencies.title": {
+		"message": "確認切換"
+	},
+	"app.instance.mods.toggle-dependencies.warning": {
+		"message": "是否自動應用這些相關更改？忽略它們可能導致遊戲無法正常執行。"
+	},
+	"app.instance.mods.toggle-dependencies.will-disable": {
+		"message": "以下內容將同時禁用："
+	},
+	"app.instance.mods.toggle-dependencies.will-enable": {
+		"message": "以下內容將同時啟用："
+	},
+	"app.instance.worlds.browse-maps": {
+		"message": "瀏覽地圖"
+	},
+	"app.instances.group.ungrouped": {
+		"message": "無分組"
+	},
+	"app.java-arguments.presets.applied": {
+		"message": "已應用"
+	},
+	"app.java-arguments.presets.arguments": {
+		"message": "引數"
+	},
+	"app.java-arguments.presets.auth-group-title": {
+		"message": "Mojang認證代理"
+	},
+	"app.java-arguments.presets.auth-mirror.description": {
+		"message": "來自 Fallen-Breath 搭建的 Mojang 認證伺服器 HTTP 轉發。"
+	},
+	"app.java-arguments.presets.auth-mirror.title": {
+		"message": "映象認證服務"
+	},
+	"app.java-arguments.presets.button": {
+		"message": "引數預設"
+	},
+	"app.java-arguments.presets.collapse-group": {
+		"message": "摺疊分組"
+	},
+	"app.java-arguments.presets.expand-group": {
+		"message": "展開分組"
+	},
+	"app.java-arguments.presets.gc-group-title": {
+		"message": "記憶體回收策略 (GC)"
+	},
+	"app.java-arguments.presets.gc.auto.description": {
+		"message": "自動為你的系統選擇最佳 GC 策略"
+	},
+	"app.java-arguments.presets.gc.auto.reason-chain": {
+		"message": "決策路徑：{chain}"
+	},
+	"app.java-arguments.presets.gc.auto.resolved": {
+		"message": "已解析 → {strategy}"
+	},
+	"app.java-arguments.presets.gc.auto.title": {
+		"message": "自動GC"
+	},
+	"app.java-arguments.presets.gc.g1gc-mojang.description": {
+		"message": "接近官方的 G1GC 調優"
+	},
+	"app.java-arguments.presets.gc.g1gc-mojang.title": {
+		"message": "Mojang G1GC"
+	},
+	"app.java-arguments.presets.gc.g1gc-pcl.description": {
+		"message": "PCL 啟動器使用的 Shenandoah（adaptive）調優"
+	},
+	"app.java-arguments.presets.gc.g1gc-pcl.title": {
+		"message": "PCL"
+	},
+	"app.java-arguments.presets.gc.shenandoah.description": {
+		"message": "自適應低停頓 Shenandoah，啟用大頁記憶體（如支援）"
+	},
+	"app.java-arguments.presets.gc.shenandoah.title": {
+		"message": "Shenandoah"
+	},
+	"app.java-arguments.presets.gc.zgc.description": {
+		"message": "面向高階系統的超低延遲 GC（Java 15+）"
+	},
+	"app.java-arguments.presets.gc.zgc.title": {
+		"message": "ZGC"
+	},
+	"app.java-arguments.presets.modal-title": {
+		"message": "Java 引數預設"
+	},
+	"app.java-arguments.presets.remove": {
+		"message": "移除預設"
+	},
+	"app.java-arguments.presets.use": {
+		"message": "使用預設"
+	},
+	"app.ai-log-analysis.analyzing": {
+		"message": "正在AI分析日誌……這可能需要等待半分鐘"
+	},
+	"app.ai-log-analysis.cancel": {
+		"message": "取消"
+	},
+	"app.ai-log-analysis.close": {
+		"message": "關閉"
+	},
+	"app.ai-log-analysis.copy-link": {
+		"message": "複製連結"
+	},
+	"app.ai-log-analysis.copy-result": {
+		"message": "複製結果"
+	},
+	"app.ai-log-analysis.error": {
+		"message": "AI 分析失敗：{message}"
+	},
+	"app.ai-log-analysis.link-copied": {
+		"message": "連結已複製到剪貼簿"
+	},
+	"app.ai-log-analysis.logshare-unavailable": {
+		"message": "LogShare.CN 無法訪問，AI 分析不可用（mclo.gs 不支援 AI 分析）。{message}"
+	},
+	"app.ai-log-analysis.privacy": {
+		"message": "你的日誌內容將被上傳第三方 AI 服務進行分析, 請勿上傳包含敏感資訊的日誌。\n 感謝logshare.cn提供的日誌分享與分析服務。"
+	},
+	"app.ai-log-analysis.result-copied": {
+		"message": "分析結果已複製到剪貼簿"
+	},
+	"app.ai-log-analysis.title": {
+		"message": "AI 日誌分析"
+	},
+	"app.ai-log-analysis.upload-failed": {
+		"message": "上傳失敗，正在直接分析日誌內容（無分享連結）。"
+	},
+	"app.ai-log-analysis.uploading": {
+		"message": "正在上傳日誌……"
+	},
+	"app.minecraft-crash.ai-analyze": {
+		"message": "AI 分析"
+	},
+	"app.minecraft-crash.ai-unavailable": {
+		"message": "當前日誌服務（mclo.gs）不支援 AI 分析，請在設定中切換到 LogShare.CN。"
+	},
+	"app.minecraft-crash.copy-link": {
+		"message": "複製連結"
+	},
+	"app.minecraft-crash.no-log-content": {
+		"message": "沒有找到可分享或分析的日誌內容，請確認例項中有最近幾分鐘內生成的日誌。"
+	},
+	"app.minecraft-crash.share-copied": {
+		"message": "診斷連結已複製到剪貼簿"
+	},
+	"app.minecraft-crash.share-diagnostic": {
+		"message": "匯出分享"
+	},
+	"app.minecraft-crash.share-failed": {
+		"message": "匯出分享失敗"
+	},
+	"app.minecraft-crash.share-truncated": {
+		"message": "診斷日誌過大，已自動擷取最後 9MB 上傳。"
+	},
+	"app.minecraft-crash.sharing-diagnostic": {
+		"message": "正在匯出分享……"
+	},
+	"app.navigation.edit-world": {
+		"message": "編輯存檔"
+	},
+	"app.project.install-context.back-to-instance-content": {
+		"message": "返回例項內容"
+	},
+	"app.settings.defaults.optimize-memory-before-launch": {
+		"message": "啟動遊戲前最佳化記憶體"
+	},
+	"app.settings.defaults.optimize-memory-before-launch-description": {
+		"message": "等待 Windows 記憶體最佳化完成後再啟動遊戲。"
+	},
+	"settings.feature-flags.title": {
+		"message": "功能開關"
+	},
+	"app.settings.resources.curseforge-restriction-bypass": {
+		"message": "自動下載受限的 CurseForge 檔案"
+	},
+	"app.settings.resources.curseforge-restriction-bypass-description": {
+		"message": "當 CurseForge 不提供下載地址時，根據檔案資訊推導其 CDN 地址並嘗試自動下載。關閉後將使用手動下載流程。"
+	},
+	"app.settings.resources.mojang-auth-service": {
+		"message": "Mojang 認證服務"
+	},
+	"app.settings.resources.mojang-auth-service-description": {
+		"message": "Mojang 登入、資料、皮膚、披風、會話驗證等。"
+	},
+	"app.settings.resources.source.mojang-mirror-preferred": {
+		"message": "優先 Fallen Proxy"
+	},
+	"app.settings.resources.source.mojang-official-only": {
+		"message": "僅官方源"
+	},
+	"app.settings.resources.source.mojang-official-preferred": {
+		"message": "優先官方源"
+	},
+	"app.settings.logs.description": {
+		"message": "選擇用於分析和分享 Minecraft 日誌的服務。優先使用 LogShare.CN，不可用時自動回退到 mclo.gs，確保分享始終可用。"
+	},
+	"app.settings.logs.provider.auto": {
+		"message": "自動（推薦）"
+	},
+	"app.settings.groups.common": {
+		"message": "通用"
+	},
+	"app.settings.groups.minecraft": {
+		"message": "我的世界"
+	},
+	"app.settings.groups.system": {
+		"message": "系統"
+	},
+	"app.settings.groups.launcher": {
+		"message": "啟動器"
+	},
+	"app.settings.groups.game": {
+		"message": "遊戲"
+	},
+	"app.settings.groups.data-privacy": {
+		"message": "資料與隱私"
+	},
+	"app.settings.groups.support": {
+		"message": "應用與支援"
+	},
+	"app.settings.groups.developer": {
+		"message": "開發者"
+	},
+	"app.settings.tabs.interface": {
+		"message": "介面與外觀"
+	},
+	"app.settings.tabs.home-navigation": {
+		"message": "首頁與導航"
+	},
+	"app.settings.tabs.language-translation": {
+		"message": "語言與翻譯"
+	},
+	"app.settings.tabs.java-performance": {
+		"message": "Java 與效能"
+	},
+	"app.settings.tabs.launch-defaults": {
+		"message": "啟動與例項預設值"
+	},
+	"app.settings.tabs.content-downloads": {
+		"message": "內容與下載"
+	},
+	"app.settings.tabs.network-multiplayer": {
+		"message": "網路與多人遊戲"
+	},
+	"app.settings.tabs.storage-backups": {
+		"message": "儲存與備份"
+	},
+	"app.settings.tabs.privacy-data": {
+		"message": "隱私與資料共享"
+	},
+	"app.settings.tabs.ai": {
+		"message": "AI"
+	},
+	"app.settings.tabs.privacy-security": {
+		"message": "隱私與安全"
+	},
+	"app.settings.logs.provider.auto-description": {
+		"message": "優先使用 LogShare.CN，不可用時自動切換到 mclo.gs。"
+	},
+	"app.settings.logs.provider.logshare": {
+		"message": "LogShare.CN"
+	},
+	"app.settings.logs.provider.logshare-description": {
+		"message": "使用 LogShare.CN 進行分析和分享（支援 AI 分析），不可用時回退到 mclo.gs。"
+	},
+	"app.settings.logs.provider.mclogs": {
+		"message": "mclo.gs"
+	},
+	"app.settings.logs.provider.mclogs-description": {
+		"message": "使用 mclo.gs 進行分析和分享，不支援 AI 分析。"
+	},
+	"app.settings.logs.title": {
+		"message": "日誌分析服務"
+	},
+	"app.settings.search.clear": {
+		"message": "清除設定搜尋"
+	},
+	"app.settings.search.empty": {
+		"message": "沒有與搜尋匹配的設定。"
+	},
+	"app.settings.search.placeholder": {
+		"message": "搜尋設定"
+	},
+	"app.settings.search.results": {
+		"message": "搜尋結果"
+	},
+	"app.settings.save-status.error": {
+		"message": "無法儲存"
+	},
+	"app.settings.save-status.retry": {
+		"message": "重試"
+	},
+	"app.settings.save-status.saved": {
+		"message": "已儲存"
+	},
+	"app.settings.save-status.saving": {
+		"message": "正在儲存…"
+	},
+	"app.sidebar.collapse": {
+		"message": "收起邊欄"
+	},
+	"app.sidebar.expand": {
+		"message": "展開邊欄"
+	},
+	"app.translation-settings.style.blockquote": {
+		"message": "引用塊"
+	},
+	"app.translation-settings.style.blur": {
+		"message": "模糊"
+	},
+	"app.translation-settings.style.dashed-line": {
+		"message": "虛線下劃線"
+	},
+	"app.translation-settings.style.text-color": {
+		"message": "文字顏色"
 	},
 	"app.world-editor.allow-commands.label": {
 		"message": "允許作弊"
@@ -3626,24 +6257,6 @@
 	"app.world-editor.unsaved-modal.title": {
 		"message": "放棄未儲存的更改？"
 	},
-	"app.world.server-modal.placeholder-address": {
-		"message": "example.modrinth.gg"
-	},
-	"app.world.server-modal.select-an-option": {
-		"message": "選擇選項"
-	},
-	"app.world.world-item.incompatible-version": {
-		"message": "不相容的版本 {version}"
-	},
-	"app.world.world-item.not-played-yet": {
-		"message": "尚未遊玩"
-	},
-	"app.world.world-item.offline": {
-		"message": "離線"
-	},
-	"app.world.world-item.players-online": {
-		"message": "{count} 人在線上"
-	},
 	"app.worlds.install-map.invalid-project": {
 		"message": "所選專案不是 CurseForge 地圖。"
 	},
@@ -3653,134 +6266,8 @@
 	"app.worlds.install-map.unknown-instance": {
 		"message": "所選例項已不可用。"
 	},
-	"app.worlds.title": {
-		"message": "世界"
-	},
-	"friends.action.add-friend": {
-		"message": "新增好友"
-	},
-	"friends.action.view-friend-requests": {
-		"message": "{count} 個好友{count, plural, other {邀請}}"
-	},
-	"friends.add-friend.submit": {
-		"message": "送出好友邀請"
-	},
-	"friends.add-friend.title": {
-		"message": "新增好友"
-	},
-	"friends.add-friend.username.description": {
-		"message": "這可能與對方的 Minecraft 使用者名稱不同！"
-	},
-	"friends.add-friend.username.placeholder": {
-		"message": "輸入 Modrinth 使用者名稱..."
-	},
-	"friends.add-friend.username.title": {
-		"message": "你好友的 Modrinth 使用者名稱是什麼？"
-	},
-	"friends.add-friends-to-share": {
-		"message": "<link>新增好友</link>即可查看他們正在玩什麼！"
-	},
-	"friends.friend.cancel-request": {
-		"message": "取消請求"
-	},
-	"friends.friend.remove-friend": {
-		"message": "移除好友"
-	},
-	"friends.friend.request-sent": {
-		"message": "已送出好友邀請"
-	},
-	"friends.friend.view-profile": {
-		"message": "查看個人檔案"
-	},
-	"friends.heading": {
-		"message": "好友"
-	},
-	"friends.heading.active": {
-		"message": "活躍中"
-	},
-	"friends.heading.offline": {
-		"message": "離線"
-	},
-	"friends.heading.online": {
-		"message": "線上"
-	},
-	"friends.heading.pending": {
-		"message": "待處理"
-	},
-	"friends.no-friends-match": {
-		"message": "找不到相符「{query}」的好友"
-	},
-	"friends.requests.accept": {
-		"message": "接受"
-	},
-	"friends.requests.cancel": {
-		"message": "取消"
-	},
-	"friends.requests.ignore": {
-		"message": "略過"
-	},
-	"friends.requests.incoming": {
-		"message": "{username} 向你送出了好友邀請"
-	},
-	"friends.requests.none": {
-		"message": "暫無待處理的好友邀請 :C"
-	},
-	"friends.requests.outgoing": {
-		"message": "你向 {username} 送出了好友邀請"
-	},
-	"friends.requests.title": {
-		"message": "查看好友邀請"
-	},
-	"friends.search-friends-placeholder": {
-		"message": "搜尋好友..."
-	},
-	"friends.section.heading": {
-		"message": "{title} — {count}"
-	},
-	"friends.sign-in-to-add-friends": {
-		"message": "<link>登入 Modrinth 帳號</link>即可新增好友並查看他們正在玩什麼！"
-	},
-	"instance.logs.delete.latest-running": {
-		"message": "實例執行時無法刪除 latest.log"
-	},
-	"instance.logs.source.live": {
-		"message": "即時日誌"
-	},
-	"instance.logs.source.numbered": {
-		"message": "日誌 {index}"
-	},
-	"instance.logs.source.unknown": {
-		"message": "未知"
-	},
-	"instance.add-server.add-and-play": {
-		"message": "新增並遊玩"
-	},
-	"instance.add-server.add-server": {
-		"message": "新增伺服器"
-	},
-	"instance.add-server.resource-pack.disabled": {
-		"message": "已停用"
-	},
-	"instance.add-server.resource-pack.enabled": {
-		"message": "已啟用"
-	},
-	"instance.add-server.resource-pack.prompt": {
-		"message": "提示"
-	},
-	"instance.add-server.title": {
-		"message": "新增伺服器"
-	},
-	"instance.edit-server.title": {
-		"message": "編輯伺服器"
-	},
-	"instance.files.adding-files": {
-		"message": "正在新增檔案 ({completed}/{total})"
-	},
 	"instance.files.open-studio": {
 		"message": "開啟 Studio"
-	},
-	"instance.files.save-as": {
-		"message": "另存新檔..."
 	},
 	"instance.files.studio.back-to-files": {
 		"message": "退出"
@@ -3881,281 +6368,17 @@
 	"instance.files.studio.title": {
 		"message": "Studio"
 	},
-	"instance.server-modal.address": {
-		"message": "位址"
-	},
-	"instance.server-modal.name": {
-		"message": "名稱"
-	},
-	"instance.server-modal.placeholder-name": {
-		"message": "Minecraft 伺服器"
-	},
-	"instance.server-modal.resource-pack": {
-		"message": "資源包"
-	},
-	"instance.settings.tabs.general": {
-		"message": "一般"
-	},
-	"instance.settings.tabs.general.delete": {
-		"message": "刪除實例"
-	},
-	"instance.settings.tabs.general.delete.button": {
-		"message": "刪除實例"
-	},
-	"instance.settings.tabs.general.delete.description": {
-		"message": "這將從裝置上永久刪除實例，包含你的世界、設定與所有已安裝內容。請注意，一旦刪除，將無法復原。"
-	},
-	"instance.settings.tabs.general.deleting.button": {
-		"message": "刪除中..."
-	},
-	"instance.settings.tabs.general.duplicate-button": {
-		"message": "複製"
-	},
-	"instance.settings.tabs.general.duplicate-button.tooltip.installing": {
-		"message": "安裝時無法複製。"
-	},
-	"instance.settings.tabs.general.duplicate-instance": {
-		"message": "複製實例"
-	},
-	"instance.settings.tabs.general.duplicate-instance.description": {
-		"message": "建立這個實例的副本，包含世界、設定、模組等。"
-	},
-	"instance.settings.tabs.general.edit-icon": {
-		"message": "編輯圖示"
-	},
-	"instance.settings.tabs.general.edit-icon.remove": {
-		"message": "移除圖示"
-	},
-	"instance.settings.tabs.general.edit-icon.replace": {
-		"message": "取代圖示"
-	},
-	"instance.settings.tabs.general.edit-icon.select": {
-		"message": "選擇圖示"
-	},
-	"instance.settings.tabs.general.icon": {
-		"message": "圖示"
-	},
-	"instance.settings.tabs.general.name": {
-		"message": "名稱"
-	},
-	"instance.settings.tabs.general.update-channel": {
-		"message": "更新通道"
-	},
-	"instance.settings.tabs.general.update-channel.alpha": {
-		"message": "Alpha 版"
-	},
-	"instance.settings.tabs.general.update-channel.alpha.description": {
-		"message": "相容的正式版、Beta 版和 Alpha 版本都會顯示在可用更新中。"
-	},
-	"instance.settings.tabs.general.update-channel.beta": {
-		"message": "Beta 版"
-	},
-	"instance.settings.tabs.general.update-channel.beta.description": {
-		"message": "相容的正式版和 Beta 版本都會顯示在可用更新中。"
-	},
-	"instance.settings.tabs.general.update-channel.release": {
-		"message": "正式版"
-	},
-	"instance.settings.tabs.general.update-channel.release.description": {
-		"message": "僅有正式版會顯示在可用更新中。"
-	},
-	"instance.settings.tabs.general.update-channel.select": {
-		"message": "選擇更新通道"
-	},
-	"instance.settings.tabs.hooks": {
-		"message": "啟動掛鉤"
-	},
-	"instance.settings.tabs.hooks.custom-hooks": {
-		"message": "自訂啟動掛鉤"
-	},
-	"instance.settings.tabs.hooks.description": {
-		"message": "掛鉤讓進階使用者能在遊戲啟動前和啟動後執行特定的系統指令。"
-	},
-	"instance.settings.tabs.hooks.post-exit": {
-		"message": "結束後"
-	},
-	"instance.settings.tabs.hooks.post-exit.description": {
-		"message": "遊戲關閉後執行。"
-	},
-	"instance.settings.tabs.hooks.post-exit.enter": {
-		"message": "輸入結束後指令..."
-	},
-	"instance.settings.tabs.hooks.pre-launch": {
-		"message": "啟動前"
-	},
-	"instance.settings.tabs.hooks.pre-launch.description": {
-		"message": "實例啟動前執行。"
-	},
-	"instance.settings.tabs.hooks.pre-launch.enter": {
-		"message": "輸入啟動前指令..."
-	},
-	"instance.settings.tabs.hooks.title": {
-		"message": "遊戲啟動掛鉤"
-	},
-	"instance.settings.tabs.hooks.wrapper": {
-		"message": "包裝器指令"
-	},
-	"instance.settings.tabs.hooks.wrapper.description": {
-		"message": "用於啟動 Minecraft 的包裝器指令。"
-	},
-	"instance.settings.tabs.hooks.wrapper.enter": {
-		"message": "輸入包裝器指令..."
-	},
-	"instance.settings.tabs.installation": {
-		"message": "安裝"
-	},
-	"instance.settings.tabs.installation.loader-version": {
-		"message": "{loader} 版本"
-	},
-	"instance.settings.tabs.java": {
-		"message": "Java 和記憶體"
-	},
-	"instance.settings.tabs.java.custom-environment-variables": {
-		"message": "自訂環境變數"
-	},
-	"instance.settings.tabs.java.custom-java-arguments": {
-		"message": "自訂 Java 參數"
-	},
-	"instance.settings.tabs.java.custom-java-installation": {
-		"message": "為此實例使用自訂 Java"
-	},
-	"instance.settings.tabs.java.custom-memory-allocation": {
-		"message": "自訂記憶體分配"
-	},
-	"instance.settings.tabs.java.automatic-memory": {
-		"message": "啟動時自動分配記憶體"
-	},
-	"instance.settings.tabs.java.enter-environment-variables": {
-		"message": "輸入環境變數..."
-	},
-	"instance.settings.tabs.java.enter-java-arguments": {
-		"message": "輸入 Java 參數..."
-	},
-	"instance.settings.tabs.java.environment-variables": {
-		"message": "環境變數"
-	},
-	"instance.settings.tabs.java.java-arguments": {
-		"message": "Java 參數"
-	},
-	"instance.settings.tabs.java.java-installation": {
-		"message": "Java 安裝"
-	},
-	"instance.settings.tabs.java.java-memory": {
-		"message": "記憶體配置"
-	},
-	"instance.settings.tabs.java.java-path-placeholder": {
-		"message": "/path/to/java"
-	},
 	"instance.settings.tabs.java.optimize-memory-before-launch": {
 		"message": "啟動遊戲前最佳化記憶體"
 	},
 	"instance.settings.tabs.java.optimize-memory-before-launch-description": {
 		"message": "等待 Windows 記憶體最佳化完成後再啟動遊戲。"
 	},
-	"instance.settings.tabs.window": {
-		"message": "視窗"
-	},
-	"instance.settings.tabs.window.custom-window-settings": {
-		"message": "自訂視窗設定"
-	},
-	"instance.settings.tabs.window.fullscreen": {
-		"message": "全螢幕"
-	},
-	"instance.settings.tabs.window.fullscreen.description": {
-		"message": "使遊戲啟動時進入全螢幕模式（透過 options.txt）。"
-	},
-	"instance.settings.tabs.window.height": {
-		"message": "高度"
-	},
-	"instance.settings.tabs.window.height.description": {
-		"message": "遊戲啟動時的視窗高度。"
-	},
-	"instance.settings.tabs.window.height.enter": {
-		"message": "輸入高度..."
-	},
-	"instance.settings.tabs.window.width": {
-		"message": "寬度"
-	},
-	"instance.settings.tabs.window.width.description": {
-		"message": "遊戲啟動時的視窗寬度。"
-	},
-	"instance.settings.tabs.window.width.enter": {
-		"message": "輸入寬度..."
-	},
-	"instance.worlds.a_minecraft_server": {
-		"message": "Minecraft 伺服器"
-	},
-	"instance.worlds.cant_connect": {
-		"message": "無法連線到伺服器"
-	},
-	"instance.worlds.copy_address": {
-		"message": "複製位址"
-	},
-	"instance.worlds.create_shortcut": {
-		"message": "建立捷徑"
-	},
-	"instance.worlds.game_already_open": {
-		"message": "實例已經開啟"
-	},
-	"instance.worlds.hardcore": {
-		"message": "極限模式"
-	},
-	"instance.worlds.incompatible_server": {
-		"message": "伺服器不相容"
-	},
-	"instance.worlds.linked_server": {
-		"message": "由伺服器專案管理"
-	},
-	"instance.worlds.no_contact": {
-		"message": "伺服器沒有回應"
-	},
-	"instance.worlds.no_server_quick_play": {
-		"message": "你只能在 Minecraft Alpha 1.0.5 以上版本直接加入伺服器"
-	},
-	"instance.worlds.no_singleplayer_quick_play": {
-		"message": "你只能在 Minecraft 1.20 以上版本直接進入單人遊戲世界"
-	},
-	"instance.worlds.play_instance": {
-		"message": "遊玩實例"
-	},
-	"instance.worlds.view_instance": {
-		"message": "檢視實例"
-	},
-	"instance.worlds.world_in_use": {
-		"message": "世界正在使用中"
-	},
-	"minecraft-account.add-microsoft-account": {
-		"message": "新增 Microsoft 帳號"
-	},
-	"minecraft-account.add-offline-account": {
-		"message": "新增離線帳號"
-	},
-	"minecraft-account.add-third-party-account": {
-		"message": "新增第三方帳號"
-	},
 	"minecraft-account.copy-uuid": {
 		"message": "複製 UUID"
 	},
-	"minecraft-account.label": {
-		"message": "Minecraft 帳號"
-	},
-	"minecraft-account.not-signed-in": {
-		"message": "未登入"
-	},
 	"minecraft-account.official-badge": {
 		"message": "官方"
-	},
-	"minecraft-account.offline-account": {
-		"message": "Minecraft 離線帳號"
-	},
-	"minecraft-account.offline-badge": {
-		"message": "離線"
-	},
-	"minecraft-account.offline-modal.create": {
-		"message": "建立帳號"
-	},
-	"minecraft-account.offline-modal.chinese-username-warning": {
-		"message": "Minecraft 1.18 及以上版本可能會拒絕中文使用者名稱，導致無法進入單人世界或伺服器。請在舊版本中使用此帳號，或在新版本改用英文使用者名稱。"
 	},
 	"minecraft-account.offline-modal.custom-uuid": {
 		"message": "自定義 UUID"
@@ -4175,210 +6398,6 @@
 	"minecraft-account.offline-modal.custom-uuid-warning": {
 		"message": "如果您不瞭解這是什麼，請不要開啟此功能"
 	},
-	"minecraft-account.offline-modal.description": {
-		"message": "設定離線帳號的使用者名稱。此帳號僅能加入未啟用正版驗證的伺服器。"
-	},
-	"minecraft-account.offline-modal.title": {
-		"message": "新增離線帳號"
-	},
-	"minecraft-account.offline-modal.username-label": {
-		"message": "Minecraft 使用者名稱"
-	},
-	"minecraft-account.offline-modal.username-placeholder": {
-		"message": "輸入使用者名稱"
-	},
-	"minecraft-account.offline-modal.username-validation": {
-		"message": "請輸入 1–16 個字母、數字或底線，支援中文。"
-	},
-	"minecraft-account.offline-mode": {
-		"message": "離線模式"
-	},
-	"minecraft-account.offline-mode.description": {
-		"message": "僅可使用離線帳號，並且只能啟動已完整下載的實例。"
-	},
-	"minecraft-account.offline-mode.refresh": {
-		"message": "刷新連接狀態"
-	},
-	"minecraft-account.remove-account": {
-		"message": "移除帳號"
-	},
-	"minecraft-account.select-account": {
-		"message": "選擇帳號"
-	},
-	"minecraft-account.sign-in": {
-		"message": "登入 Minecraft"
-	},
-	"minecraft-account.third-party-account": {
-		"message": "Minecraft 第三方帳號"
-	},
-	"minecraft-account.third-party-badge": {
-		"message": "第三方"
-	},
-	"minecraft-account.third-party-modal.account": {
-		"message": "帳號或電子郵件"
-	},
-	"minecraft-account.third-party-modal.account-placeholder": {
-		"message": "請輸入帳號或電子郵件"
-	},
-	"minecraft-account.third-party-modal.api-root": {
-		"message": "Yggdrasil API 網址"
-	},
-	"minecraft-account.third-party-modal.api-root-placeholder": {
-		"message": "https://example.com/api/yggdrasil"
-	},
-	"minecraft-account.third-party-modal.description": {
-		"message": "使用 LittleSkin 或其他相容的 Yggdrasil 外掛登入服務。"
-	},
-	"minecraft-account.third-party-modal.littleskin": {
-		"message": "使用 LittleSkin"
-	},
-	"minecraft-account.third-party-modal.password": {
-		"message": "密碼"
-	},
-	"minecraft-account.third-party-modal.remember-password": {
-		"message": "在此裝置上儲存登入資訊"
-	},
-	"minecraft-account.third-party-modal.saved-logins": {
-		"message": "已儲存的登入紀錄"
-	},
-	"minecraft-account.third-party-modal.remove-saved-login": {
-		"message": "刪除已儲存的登入紀錄"
-	},
-	"minecraft-account.third-party-modal.sign-in": {
-		"message": "登入"
-	},
-	"minecraft-account.third-party-modal.title": {
-		"message": "登入第三方帳號"
-	},
-	"minecraft-account.third-party-profile.description": {
-		"message": "請選擇此帳號要使用的 Minecraft 角色。"
-	},
-	"minecraft-account.third-party-profile.title": {
-		"message": "選擇角色"
-	},
-	"project.description.title": {
-		"message": "簡介"
-	},
-	"project.gallery.title": {
-		"message": "圖庫"
-	},
-	"project.versions.title": {
-		"message": "版本"
-	},
-	"search.filter.locked.instance": {
-		"message": "由該實例提供"
-	},
-	"search.filter.locked.instance-game-version.title": {
-		"message": "遊戲版本由實例提供"
-	},
-	"search.filter.locked.instance-loader.title": {
-		"message": "載入器版本由實例提供"
-	},
-	"search.filter.locked.instance.sync": {
-		"message": "與實例同步"
-	},
-	"search.filter.locked.server": {
-		"message": "由伺服器提供"
-	},
-	"search.filter.locked.server-environment.title": {
-		"message": "只有用戶端模組可以被加到伺服器實例"
-	},
-	"search.filter.locked.server-game-version.title": {
-		"message": "遊戲版本由伺服器提供"
-	},
-	"search.filter.locked.server-loader.title": {
-		"message": "載入器由伺服器提供"
-	},
-	"unknown-pack-warning-modal.body": {
-		"message": "只有上傳至 Modrinth 的檔案才會經過審查，無論其檔案格式為何（包含 .mrpack）。"
-	},
-	"unknown-pack-warning-modal.dont-show-again": {
-		"message": "不要再顯示這則警告"
-	},
-	"unknown-pack-warning-modal.header": {
-		"message": "確認安裝"
-	},
-	"unknown-pack-warning-modal.install-anyway": {
-		"message": "仍要安裝"
-	},
-	"unknown-pack-warning-modal.malware-statement": {
-		"message": "惡意軟體經常透過 Discord 等平臺分享模組包檔案來進行傳播。"
-	},
-	"unknown-pack-warning-modal.warning.body": {
-		"message": "我們在 Modrinth 上找不到這個檔案。強烈建議你僅安裝來自信任來源的檔案。"
-	},
-	"unknown-pack-warning-modal.warning.title": {
-		"message": "未知檔案警告"
-	},
-	"app.instance.confirm-delete.symlink-warning": {
-		"message": "這是一個連結到「{path}」的共用實例。只會刪除連結，原始檔案不會被刪除。"
-	},
-	"app.symlink-warning.write.header": {
-		"message": "共享實例"
-	},
-	"app.symlink-warning.write.body": {
-		"message": "此實例連結到「{path}」。此處的變更也會影響原始檔案。"
-	},
-	"app.symlink-warning.delete.header": {
-		"message": "共享實例"
-	},
-	"app.symlink-warning.delete.body": {
-		"message": "刪除此實例只會移除啟動器條目。「{path}」中的原始檔案將保留。"
-	},
-	"app.symlink-warning.dismiss-permanently": {
-		"message": "Don"
-	},
-	"app.symlink-warning.shared-badge": {
-		"message": "共享"
-	},
-	"app.symlink-capability.unsupported": {
-		"message": "系統不支持軟連結。"
-	},
-	"app.symlink-capability.unsupported.title": {
-		"message": "軟連結不支持"
-	},
-	"app.warning.running-as-admin": {
-		"message": "Axolotl 正在以系統管理員身分執行。此模式無法拖曳匯入檔案，請以一般權限重新啟動啟動器。"
-	},
-	"drop.help.title": {
-		"message": "我可以拖入什麼到 Axolotl？"
-	},
-	"drop.help.instances-title": {
-		"message": "啟動器實例"
-	},
-	"drop.help.instances-desc": {
-		"message": "從其他啟動器（MultiMC、Prism Launcher等）拖放文件夾來導入 Minecraft 實例。或者拖入 HMCL、PCL、PCL-CE 的啟動器"
-	},
-	"drop.help.instances-formats": {
-		"message": "（MultiMC / Prism Launcher / PolyMC） 實例文件夾或直接放入 （HMCL / PCL / PCL-CE ）啟動器。"
-	},
-	"drop.help.mods-title": {
-		"message": "模組"
-	},
-	"drop.help.mods-desc": {
-		"message": "拖放模組 JAR 文件來安裝到 Minecraft 實例。"
-	},
-	"drop.help.mods-formats": {
-		"message": "格式：.jar"
-	},
-	"drop.help.modpacks-title": {
-		"message": "整合包"
-	},
-	"drop.help.modpacks-desc": {
-		"message": "拖放整合包 ZIP/MRPACK 文件來導入整合包。"
-	},
-	"drop.help.modpacks-formats": {
-		"message": "格式：.mrpack / .zip"
-	},
-	"drop.help.resource-packs-title": {
-		"message": "資源包"
-	},
-	"drop.help.resource-packs-desc": {
-		"message": "拖放資源包 ZIP 文件來安裝到實例。"
-	},
-	"drop.help.resource-packs-formats": {
-		"message": "格式：.zip"
-	},
 	"drop.help.data-packs-title": {
 		"message": "資料包"
 	},
@@ -4387,354 +6406,6 @@
 	},
 	"drop.help.data-packs-formats": {
 		"message": "格式：.zip"
-	},
-	"drop.help.shader-packs-title": {
-		"message": "光影包"
-	},
-	"drop.help.shader-packs-desc": {
-		"message": "拖放光影包 ZIP 文件來安裝到實例。"
-	},
-	"drop.help.shader-packs-formats": {
-		"message": "格式：.zip"
-	},
-	"drop.help.worlds-title": {
-		"message": "存檔"
-	},
-	"drop.help.worlds-desc": {
-		"message": "拖放存檔文件夾來導入到實例。"
-	},
-	"drop.help.worlds-formats": {
-		"message": "Minecraft 存檔文件夾。"
-	},
-	"drop.help.schematics-title": {
-		"message": "投影"
-	},
-	"drop.help.schematics-desc": {
-		"message": "拖放 .litematic 文件來導入投影。"
-	},
-	"drop.help.schematics-formats": {
-		"message": "格式：.litematic"
-	},
-	"create.title": {
-		"message": "創建實例"
-	},
-	"create.subtitle": {
-		"message": "實例是帶有特定載入器、遊戲版本和模組的一套 Minecraft 配置。"
-	},
-	"create.new.title": {
-		"message": "全新創建"
-	},
-	"create.new.description": {
-		"message": "創建一個新的 Minecraft 實例，自選模組載入器。"
-	},
-	"create.import.title": {
-		"message": "導入已有"
-	},
-	"create.import.description": {
-		"message": "從其他啟動器導入實例，或安裝整合包。"
-	},
-	"create.back": {
-		"message": "返回庫"
-	},
-	"app.drop.overlay-title": {
-		"message": "拖放以導入"
-	},
-	"app.drop.overlay-subtitle": {
-		"message": "Release to classify and import"
-	},
-	"app.drop.error.multiple-files-title": {
-		"message": "無法導入多個文件"
-	},
-	"app.drop.error.multiple-files-text": {
-		"message": "一次只能拖放一個文件或文件夾。"
-	},
-	"app.drop.error.shortcut-title": {
-		"message": "捷徑解析失敗"
-	},
-	"app.drop.error.shortcut-text": {
-		"message": "無法解析到捷徑的目標。"
-	},
-	"app.drop.error.unknown-title": {
-		"message": "未知文件類型"
-	},
-	"app.drop.error.unknown-text": {
-		"message": "類型暫不支持"
-	},
-	"app.drop.error.title": {
-		"message": "拖放錯誤"
-	},
-	"app.drop.world-imported-title": {
-		"message": "存檔已導入"
-	},
-	"app.drop.world-imported-text": {
-		"message": "存檔已成功導入。"
-	},
-	"app.drop.content-installed-title": {
-		"message": "內容已安裝"
-	},
-	"app.drop.content-installed-text": {
-		"message": "文件已安裝到實例。"
-	},
-	"app.drop.install-failed-title": {
-		"message": "安裝失敗"
-	},
-	"app.drop.instance-imported-title": {
-		"message": "實例已導入"
-	},
-	"app.drop.instance-imported-text": {
-		"message": "{name} 導入成功。"
-	},
-	"app.drop.import-failed-title": {
-		"message": "導入失敗"
-	},
-	"app.drop.import-failed-text": {
-		"message": "導入 {name} 失敗：{error}"
-	},
-	"app.drop.no-instances": {
-		"message": "未找到實例"
-	},
-	"app.drop.import-progress-title": {
-		"message": "正在導入實例…"
-	},
-	"app.drop.import-progress-text": {
-		"message": "已導入 {current} / {total} 個實例"
-	},
-	"app.drop.import-completed-title": {
-		"message": "導入完成"
-	},
-	"app.drop.import-completed-text": {
-		"message": "成功導入 {count} 個實例"
-	},
-	"app.drop.import-completed-partial-text": {
-		"message": "已導入 {completed} / {total} 個實例（{failed} 個失敗）"
-	},
-	"app.drop.mod-compatibility-title": {
-		"message": "版本不相符"
-	},
-	"app.drop.mod-compatibility-warning": {
-		"message": "{file} 的目標版本為 {modVersion}（{modLoader}），但實例的版本是 {instVersion}（{instLoader}）。"
-	},
-	"app.drop.unknown-force-analysis-title": {
-		"message": "無法識別檔案類型"
-	},
-	"app.drop.unknown-force-analysis-text": {
-		"message": "該壓縮檔無法通過快速掃描識別，需要完整解壓後進行深度分析。此操作可能需要一些時間，是否繼續？"
-	},
-	"app.drop.unknown-force-analysis-button": {
-		"message": "強力解析"
-	},
-	"app.drop.unknown-force-analyzing": {
-		"message": "正在強力解析壓縮檔..."
-	},
-	"app.drop.unknown-force-analysis-failed-title": {
-		"message": "分析失敗"
-	},
-	"app.drop.unknown-force-analysis-failed-text": {
-		"message": "深度分析後仍無法識別該檔案類型。"
-	},
-	"app.drop.processing": {
-		"message": "正在處理 {name}..."
-	},
-	"app.drop.modpack-installing": {
-		"message": "正在安裝整合包..."
-	},
-	"app.drop.modpack-installed-success": {
-		"message": "整合包安裝完成"
-	},
-	"app.drop.modpack-install-failed": {
-		"message": "整合包安裝失敗"
-	},
-	"app.translation-settings.system-prompt": {
-		"message": "系統提示詞"
-	},
-	"app.translation-settings.system-prompt-description": {
-		"message": "輸入你的自訂系統提示詞，留空則使用預設提示詞。"
-	},
-	"app.instance.mods.parsing-files": {
-		"message": "正在解析，較大的文件可能會耗費一些時間"
-	},
-	"app.instance.mods.drag-drop-hint": {
-		"message": "釋放文件以安裝到當前實例"
-	},
-	"app.instance.mods.parse-failed": {
-		"message": "解析失敗，這可能不是一個整合包"
-	},
-	"app.instance.mods.file-already-exists": {
-		"message": "添加失敗，該文件可能已存在"
-	},
-	"app.instance.mods.dismiss": {
-		"message": "知道了"
-	},
-	"app.lab.gradient-text.colors.add": {
-		"message": "添加顏色"
-	},
-	"app.lab.gradient-text.colors.import": {
-		"message": "導入顏色"
-	},
-	"app.lab.gradient-text.colors.import-placeholder": {
-		"message": "黏貼 HEX、RGB 或 CSS 漸變"
-	},
-	"app.lab.gradient-text.colors.invalid": {
-		"message": "請至少輸入一個有效顏色。"
-	},
-	"app.lab.gradient-text.colors.move-down": {
-		"message": "下移顏色"
-	},
-	"app.lab.gradient-text.colors.move-up": {
-		"message": "上移顏色"
-	},
-	"app.lab.gradient-text.colors.remove": {
-		"message": "刪除顏色"
-	},
-	"app.lab.gradient-text.colors.randomize": {
-		"message": "隨機生成顏色"
-	},
-	"app.lab.gradient-text.colors.title": {
-		"message": "顏色"
-	},
-	"app.lab.gradient-text.colors.stops": {
-		"message": "{count} 個顏色停靠點"
-	},
-	"app.lab.gradient-text.adapter.vanilla": {
-		"message": "原版"
-	},
-	"app.lab.gradient-text.adapter.vanilla-compatible": {
-		"message": "原版相容"
-	},
-	"app.lab.gradient-text.adapter.standard": {
-		"message": "標準 HEX"
-	},
-	"app.lab.gradient-text.adapter.cmi": {
-		"message": "CMI"
-	},
-	"app.lab.gradient-text.adapter.minimessage": {
-		"message": "MiniMessage"
-	},
-	"app.lab.gradient-text.adapter.minimessage-gradient": {
-		"message": "MiniMessage 漸變"
-	},
-	"app.lab.gradient-text.adapter.minedown": {
-		"message": "MineDown"
-	},
-	"app.lab.gradient-text.adapter.snbt": {
-		"message": "字串化 NBT"
-	},
-	"app.lab.gradient-text.adapter.trchat": {
-		"message": "TrChat"
-	},
-	"app.lab.gradient-text.adapter.taboolib": {
-		"message": "TabooLib"
-	},
-	"app.lab.gradient-text.adapter.taboolib-gradient": {
-		"message": "TabooLib 漸變"
-	},
-	"app.lab.gradient-text.adapter.rosegarden-gradient": {
-		"message": "RoseGarden 漸變"
-	},
-	"app.lab.gradient-text.adapter.chat-colors": {
-		"message": "聊天顏色"
-	},
-	"app.lab.gradient-text.adapter.motd": {
-		"message": "伺服器 MOTD"
-	},
-	"app.lab.gradient-text.adapter.bbcode": {
-		"message": "BBCode"
-	},
-	"app.lab.gradient-text.adapter.json": {
-		"message": "JSON 文本組件"
-	},
-	"app.lab.gradient-text.adapter.html": {
-		"message": "HTML"
-	},
-	"app.lab.gradient-text.adapter.csv": {
-		"message": "CSV"
-	},
-	"app.lab.gradient-text.adapter.terraria": {
-		"message": "泰拉瑞亞"
-	},
-	"app.lab.gradient-text.format.bold": {
-		"message": "粗體"
-	},
-	"app.lab.gradient-text.format.italic": {
-		"message": "斜體"
-	},
-	"app.lab.gradient-text.format.obfuscated": {
-		"message": "混淆"
-	},
-	"app.lab.gradient-text.format.simplify": {
-		"message": "簡化漸變標籤"
-	},
-	"app.lab.gradient-text.format.strikethrough": {
-		"message": "刪除線"
-	},
-	"app.lab.gradient-text.format.title": {
-		"message": "輸出格式"
-	},
-	"app.lab.gradient-text.format.underlined": {
-		"message": "下劃線"
-	},
-	"app.lab.gradient-text.format.vanilla-character": {
-		"message": "顏色控制符"
-	},
-	"app.lab.gradient-text.input.placeholder": {
-		"message": "在此輸入 Minecraft 文本"
-	},
-	"app.lab.gradient-text.input.title": {
-		"message": "文本"
-	},
-	"app.lab.gradient-text.output.copy": {
-		"message": "複製輸出"
-	},
-	"app.lab.gradient-text.output.copied": {
-		"message": "已複製輸出"
-	},
-	"app.lab.gradient-text.output.export": {
-		"message": "導出輸出"
-	},
-	"app.lab.gradient-text.output.title": {
-		"message": "輸出"
-	},
-	"app.lab.gradient-text.preview.title": {
-		"message": "預覽"
-	},
-	"app.lab.gradient-text.presets.delete": {
-		"message": "刪除預設"
-	},
-	"app.lab.gradient-text.presets.export": {
-		"message": "導出預設"
-	},
-	"app.lab.gradient-text.presets.import": {
-		"message": "導入預設"
-	},
-	"app.lab.gradient-text.presets.imported": {
-		"message": "已導入 {count} 個預設"
-	},
-	"app.lab.gradient-text.presets.invalid-file": {
-		"message": "該文件不包含有效預設。"
-	},
-	"app.lab.gradient-text.presets.name": {
-		"message": "預設名稱"
-	},
-	"app.lab.gradient-text.presets.count": {
-		"message": "已保存 {count} 個"
-	},
-	"app.lab.gradient-text.presets.save": {
-		"message": "保存預設"
-	},
-	"app.lab.gradient-text.presets.template": {
-		"message": "下載模板"
-	},
-	"app.lab.gradient-text.presets.title": {
-		"message": "預設"
-	},
-	"app.lab.gradient-text.presets.apply": {
-		"message": "應用預設"
-	},
-	"app.lab.gradient-text.title": {
-		"message": "漸變文字生成器"
-	},
-	"app.lab.gradient-text.description": {
-		"message": "無需瀏覽器即可創建適用於 Minecraft 的漸變文字。"
 	},
 	"app.lab.recipe-generator.cancel": {
 		"message": "取消"
@@ -5108,596 +6779,14 @@
 	"app.lab.recipe-generator.version-label": {
 		"message": "Java {version}"
 	},
-	"app.lab.seed-map.import-from-instance": {
-		"message": "從實例導入"
-	},
-	"app.lab.seed-map.world-seed-loaded": {
-		"message": "已載入世界 {world} 的種子"
-	},
-	"app.lab.seed-map.history": {
-		"message": "種子歷史記錄"
-	},
-	"app.lab.seed-map.history-empty": {
-		"message": "查看過的種子會出現在這裡"
-	},
-	"app.lab.seed-map.clear-history": {
-		"message": "清空歷史"
-	},
-	"app.lab.seed-map.remove-history-entry": {
-		"message": "從歷史中移除"
-	},
-	"app.lab.seed-map.history-source.manual": {
-		"message": "手動輸入"
-	},
-	"app.lab.seed-map.history-source.random": {
-		"message": "隨機種子"
-	},
-	"app.lab.seed-map.history-source.share": {
-		"message": "分享連結"
-	},
-	"app.lab.seed-map.elevation-locked": {
-		"message": "開啟地形估算時自動採用估算的地表高度"
-	},
-	"app.lab.seed-map.import-world.title": {
-		"message": "從實例世界載入種子"
-	},
-	"app.lab.seed-map.import-world.choose-instance": {
-		"message": "選擇包含該世界的實例"
-	},
-	"app.lab.seed-map.import-world.choose-world": {
-		"message": "選擇一個單人世界"
-	},
-	"app.lab.seed-map.import-world.back": {
-		"message": "返回實例列表"
-	},
-	"app.lab.seed-map.import-world.no-instances": {
-		"message": "未找到實例，請先安裝一個實例。"
-	},
-	"app.lab.seed-map.import-world.no-worlds": {
-		"message": "該實例還沒有單人世界。"
-	},
-	"app.lab.seed-map.import-world.last-played": {
-		"message": "{ago}遊玩過"
-	},
-	"app.lab.seed-map.import-world.never-played": {
-		"message": "尚未遊玩"
-	},
-	"app.lab.seed-map.add-marker": {
-		"message": "添加標記"
-	},
-	"app.lab.seed-map.approximate": {
-		"message": "估算"
-	},
-	"app.lab.seed-map.center-spawn": {
-		"message": "居中顯示出生點"
-	},
-	"app.lab.seed-map.chunk-coordinates": {
-		"message": "區塊坐標"
-	},
-	"app.lab.seed-map.close-panel": {
-		"message": "關閉面板"
-	},
-	"app.lab.seed-map.clear-ruler": {
-		"message": "清除測距"
-	},
-	"app.lab.seed-map.completed": {
-		"message": "已完成"
-	},
-	"app.lab.seed-map.contours": {
-		"message": "等高線"
-	},
-	"app.lab.seed-map.copyright.disclaimer-body": {
-		"message": "Minecraft 是 Mojang Synergies AB 的商標。Axolotl Launcher 與 Mojang 或 MinecraftSearch 均無隸屬關係，也未獲得其認可。"
-	},
-	"app.lab.seed-map.copyright.disclaimer-heading": {
-		"message": "非官方工具"
-	},
-	"app.lab.seed-map.copyright.engine-body": {
-		"message": "群系、地形、出生點與結構數據由 cubiomes 和 Axolotl 原生集成在本地生成。cubiomes 版權所有 (c) 2020 Cubitect，並依據 MIT 許可證提供。"
-	},
-	"app.lab.seed-map.copyright.engine-heading": {
-		"message": "本地地圖引擎"
-	},
-	"app.lab.seed-map.copyright.icons-body": {
-		"message": "本工具使用的部分結構與群系圖示取自 MinecraftSearch。相關圖稿的權利仍歸 MinecraftSearch 及相應創作者所有。"
-	},
-	"app.lab.seed-map.copyright.icons-heading": {
-		"message": "地圖圖稿"
-	},
-	"app.lab.seed-map.copyright.open": {
-		"message": "版權與來源說明"
-	},
-	"app.lab.seed-map.copyright.title": {
-		"message": "版權與來源說明"
-	},
-	"app.lab.seed-map.copyright.view-cubiomes": {
-		"message": "查看 cubiomes"
-	},
-	"app.lab.seed-map.copyright.visit-minecraft-search": {
-		"message": "訪問 MinecraftSearch"
-	},
-	"app.lab.seed-map.copy-teleport": {
-		"message": "複製 /tp"
-	},
-	"app.lab.seed-map.description": {
-		"message": "在本地查看 Minecraft 種子的群系、結構和保存的標記。"
-	},
-	"app.lab.seed-map.dimension": {
-		"message": "維度"
-	},
-	"app.lab.seed-map.dimension.end": {
-		"message": "終界"
-	},
-	"app.lab.seed-map.dimension.nether": {
-		"message": "下界"
-	},
-	"app.lab.seed-map.dimension.overworld": {
-		"message": "主世界"
-	},
-	"app.lab.seed-map.distance": {
-		"message": "{distance} 格"
-	},
-	"app.lab.seed-map.edition": {
-		"message": "版本類型"
-	},
-	"app.lab.seed-map.edition.java": {
-		"message": "Java 版"
-	},
-	"app.lab.seed-map.elevation": {
-		"message": "群系高度"
-	},
-	"app.lab.seed-map.feature.ancient-city": {
-		"message": "遠古城市"
-	},
-	"app.lab.seed-map.feature.mansion": {
-		"message": "林地府邸"
-	},
-	"app.lab.seed-map.feature.monument": {
-		"message": "海底神殿"
-	},
-	"app.lab.seed-map.feature.outpost": {
-		"message": "掠奪者前哨站"
-	},
-	"app.lab.seed-map.feature.ruined-portal": {
-		"message": "廢棄傳送門"
-	},
-	"app.lab.seed-map.feature.shipwreck": {
-		"message": "沉船"
-	},
-	"app.lab.seed-map.feature.slime-chunk": {
-		"message": "史萊姆區塊"
-	},
-	"app.lab.seed-map.feature.stronghold": {
-		"message": "要塞"
-	},
-	"app.lab.seed-map.feature.trail-ruins": {
-		"message": "古蹟廢墟"
-	},
-	"app.lab.seed-map.feature.trial-chambers": {
-		"message": "試煉密室"
-	},
-	"app.lab.seed-map.feature.village": {
-		"message": "村莊"
-	},
-	"app.lab.seed-map.layers": {
-		"message": "地圖圖層"
-	},
-	"app.lab.seed-map.loading": {
-		"message": "載入中"
-	},
-	"app.lab.seed-map.map-failed": {
-		"message": "地圖生成失敗"
-	},
-	"app.lab.seed-map.location": {
-		"message": "位置"
-	},
-	"app.lab.seed-map.map-scale": {
-		"message": "1 像素 = {scale} 格"
-	},
-	"app.lab.seed-map.marker-name": {
-		"message": "標記名稱"
-	},
-	"app.lab.seed-map.marker-color": {
-		"message": "標記顏色"
-	},
-	"app.lab.seed-map.markers": {
-		"message": "標記"
-	},
-	"app.lab.seed-map.random-seed": {
-		"message": "隨機種子"
-	},
-	"app.lab.seed-map.remove-marker": {
-		"message": "刪除標記"
-	},
-	"app.lab.seed-map.ruler": {
-		"message": "測量距離"
-	},
-	"app.lab.seed-map.search-nearby": {
-		"message": "搜索附近"
-	},
-	"app.lab.seed-map.seed": {
-		"message": "種子"
-	},
-	"app.lab.seed-map.seed-placeholder": {
-		"message": "輸入數字或文本種子"
-	},
-	"app.lab.seed-map.settings": {
-		"message": "地圖設定"
-	},
-	"app.lab.seed-map.share": {
-		"message": "複製地圖連結"
-	},
-	"app.lab.seed-map.share-copied": {
-		"message": "已複製地圖連結"
-	},
-	"app.lab.seed-map.show-grid": {
-		"message": "顯示網格"
-	},
-	"app.lab.seed-map.teleport-copied": {
-		"message": "已複製傳送命令"
-	},
-	"app.lab.seed-map.terrain": {
-		"message": "地形估算"
-	},
-	"app.lab.seed-map.title": {
-		"message": "種子地圖"
-	},
-	"app.lab.seed-map.version": {
-		"message": "遊戲版本"
-	},
-	"app.lab.seed-map.zoom-in": {
-		"message": "放大"
-	},
-	"app.lab.seed-map.zoom-out": {
-		"message": "縮小"
-	},
-	"app.lab.seed-map.biome-highlight": {
-		"message": "群系高亮"
-	},
-	"app.lab.seed-map.biome-tag": {
-		"message": "生物群系"
-	},
-	"app.lab.seed-map.biome-selection-count": {
-		"message": "已選 {selected} / {total}"
-	},
-	"app.lab.seed-map.biome-group.beach": {
-		"message": "沙灘"
-	},
-	"app.lab.seed-map.biome-group.cave": {
-		"message": "洞穴"
-	},
-	"app.lab.seed-map.biome-group.desert": {
-		"message": "沙漠"
-	},
-	"app.lab.seed-map.biome-group.end": {
-		"message": "終界"
-	},
-	"app.lab.seed-map.biome-group.forest": {
-		"message": "森林"
-	},
-	"app.lab.seed-map.biome-group.jungle": {
-		"message": "叢林"
-	},
-	"app.lab.seed-map.biome-group.ice": {
-		"message": "冰雪群系"
-	},
-	"app.lab.seed-map.biome-group.mesa": {
-		"message": "惡地"
-	},
-	"app.lab.seed-map.biome-group.mountains": {
-		"message": "山地"
-	},
-	"app.lab.seed-map.biome-group.mushroom": {
-		"message": "蘑菇島"
-	},
-	"app.lab.seed-map.biome-group.nether": {
-		"message": "下界"
-	},
-	"app.lab.seed-map.biome-group.ocean": {
-		"message": "海洋"
-	},
-	"app.lab.seed-map.biome-group.plains": {
-		"message": "平原"
-	},
-	"app.lab.seed-map.biome-group.river": {
-		"message": "河流"
-	},
-	"app.lab.seed-map.biome-group.savanna": {
-		"message": "熱帶草原"
-	},
-	"app.lab.seed-map.biome-group.swamp": {
-		"message": "沼澤"
-	},
-	"app.lab.seed-map.biome-group.taiga": {
-		"message": "針葉林"
-	},
-	"app.lab.seed-map.search-biomes": {
-		"message": "搜索群系"
-	},
-	"app.lab.seed-map.invert-selection": {
-		"message": "反選"
-	},
-	"app.lab.seed-map.no-matching-biomes": {
-		"message": "沒有匹配的群系"
-	},
-	"app.lab.seed-map.mode.structures": {
-		"message": "結構"
-	},
-	"app.lab.seed-map.mode.ores": {
-		"message": "礦物"
-	},
-	"app.lab.seed-map.ore-layers": {
-		"message": "礦物圖層"
-	},
-	"app.lab.seed-map.zoom-to-scan-ores": {
-		"message": "放大地圖以掃描礦物"
-	},
-	"app.lab.seed-map.no-ores-in-end": {
-		"message": "終界不支持礦物掃描"
-	},
-	"app.lab.seed-map.ores-require-modern": {
-		"message": "礦物預測需要 Java 版 1.18 或更新版本"
-	},
-	"app.lab.seed-map.ore-y-range": {
-		"message": "Y 範圍"
-	},
-	"app.lab.seed-map.ore-min-y": {
-		"message": "最低 Y"
-	},
-	"app.lab.seed-map.ore-max-y": {
-		"message": "最高 Y"
-	},
-	"app.lab.seed-map.reset-y-range": {
-		"message": "重設 Y 範圍"
-	},
-	"app.lab.seed-map.scanning-ores": {
-		"message": "正在掃描礦物 {processed}/{total}"
-	},
-	"app.lab.seed-map.ore-scan-failed": {
-		"message": "礦物掃描失敗，請刷新地圖後重試。"
-	},
-	"app.lab.seed-map.ore-verified": {
-		"message": "已驗證"
-	},
-	"app.lab.seed-map.ore-likely": {
-		"message": "可能存在"
-	},
-	"app.lab.seed-map.ore-precision": {
-		"message": "精度 {precision}%"
-	},
-	"app.lab.seed-map.ore-coverage": {
-		"message": "Y {min} 到 {max}"
-	},
-	"app.lab.seed-map.mined": {
-		"message": "已挖掘"
-	},
-	"app.lab.seed-map.ore.diamond": {
-		"message": "鑽石礦石"
-	},
-	"app.lab.seed-map.ore.netherite": {
-		"message": "遠古遺骸"
-	},
-	"app.lab.seed-map.ore.iron": {
-		"message": "鐵礦石"
-	},
-	"app.lab.seed-map.ore.iron-vein": {
-		"message": "鐵礦脈"
-	},
-	"app.lab.seed-map.ore.copper": {
-		"message": "銅礦石"
-	},
-	"app.lab.seed-map.ore.copper-vein": {
-		"message": "銅礦脈"
-	},
-	"app.lab.seed-map.ore.gold": {
-		"message": "金礦石"
-	},
-	"app.lab.seed-map.ore.redstone": {
-		"message": "紅石礦石"
-	},
-	"app.lab.seed-map.ore.lapis": {
-		"message": "青金石礦石"
-	},
-	"app.lab.seed-map.ore.coal": {
-		"message": "煤礦石"
-	},
-	"app.lab.seed-map.choose-biome": {
-		"message": "選擇群系"
-	},
-	"app.lab.seed-map.clear": {
-		"message": "清除"
-	},
-	"app.lab.seed-map.collapse-layers": {
-		"message": "收起圖層"
-	},
-	"app.lab.seed-map.coordinates": {
-		"message": "坐標"
-	},
-	"app.lab.seed-map.edition.java-large-biomes": {
-		"message": "Java 版：大型生物群系"
-	},
-	"app.lab.seed-map.exit-fullscreen": {
-		"message": "退出全螢幕"
-	},
-	"app.lab.seed-map.expand-layers": {
-		"message": "展開圖層"
-	},
-	"app.lab.seed-map.feature.bastion": {
-		"message": "堡壘遺跡"
-	},
-	"app.lab.seed-map.feature.buried-treasure": {
-		"message": "埋藏的寶藏"
-	},
-	"app.lab.seed-map.feature.desert-pyramid": {
-		"message": "沙漠神殿"
-	},
-	"app.lab.seed-map.feature.desert-well": {
-		"message": "沙漠水井"
-	},
-	"app.lab.seed-map.feature.end-city": {
-		"message": "終界城"
-	},
-	"app.lab.seed-map.feature.end-city-with-ship": {
-		"message": "終界城（有終界船）"
-	},
-	"app.lab.seed-map.feature.end-city-without-ship": {
-		"message": "終界城（無終界船）"
-	},
-	"app.lab.seed-map.feature.end-gateway": {
-		"message": "終界折躍門"
-	},
-	"app.lab.seed-map.feature.fortress": {
-		"message": "下界要塞"
-	},
-	"app.lab.seed-map.feature.geode": {
-		"message": "紫晶洞"
-	},
-	"app.lab.seed-map.feature.igloo": {
-		"message": "雪屋"
-	},
-	"app.lab.seed-map.feature.jungle-temple": {
-		"message": "叢林神廟"
-	},
-	"app.lab.seed-map.feature.mineshaft": {
-		"message": "廢棄礦井"
-	},
-	"app.lab.seed-map.feature.ocean-ruin": {
-		"message": "海底廢墟"
-	},
-	"app.lab.seed-map.feature.swamp-hut": {
-		"message": "沼澤小屋"
-	},
-	"app.lab.seed-map.fullscreen": {
-		"message": "全螢幕"
-	},
-	"app.lab.seed-map.go": {
-		"message": "前往"
-	},
-	"app.lab.seed-map.hide-layer-names": {
-		"message": "隱藏圖層名稱"
-	},
-	"app.lab.seed-map.marker-saved": {
-		"message": "標記已保存"
-	},
-	"app.lab.seed-map.no-markers": {
-		"message": "暫無保存的標記"
-	},
-	"app.lab.seed-map.reset": {
-		"message": "重設"
-	},
-	"app.lab.seed-map.select-all": {
-		"message": "全選"
-	},
-	"app.lab.seed-map.selected-biomes": {
-		"message": "已選擇 {count} 個群系"
-	},
-	"app.lab.seed-map.show-layer-names": {
-		"message": "顯示圖層名稱"
-	},
-	"app.lab.seed-map.spawn-point": {
-		"message": "出生點"
-	},
-	"app.lab.seed-map.zoom-to-show": {
-		"message": "放大以顯示{layer}"
-	},
-	"app.lab.category.all": {
-		"message": "全部工具"
-	},
-	"app.lab.category.creation": {
-		"message": "創作"
-	},
-	"app.lab.category.maintenance": {
-		"message": "維護"
-	},
-	"app.lab.category.world": {
-		"message": "世界"
-	},
-	"app.lab.no-results": {
-		"message": "沒有匹配的工具。"
-	},
-	"app.lab.search": {
-		"message": "搜索工具"
-	},
-	"app.lab.title": {
-		"message": "實驗室"
-	},
-	"app.lab.tool-count": {
-		"message": "{count} 個工具"
-	},
-	"app.lab.tool-count-plural": {
-		"message": "{count} 個工具"
-	},
-	"app.navigation.lab": {
-		"message": "實驗室"
-	},
-	"app.onboarding.action.click-lab": {
-		"message": "點擊實驗室，繼續"
-	},
-	"app.onboarding.action.open-gradient-text": {
-		"message": "打開漸變文字生成器，繼續"
-	},
 	"app.onboarding.action.open-recipe-generator": {
 		"message": "開啟配方生成器，繼續"
-	},
-	"app.onboarding.action.open-seed-map": {
-		"message": "打開種子地圖，繼續"
-	},
-	"app.onboarding.action.return-lab": {
-		"message": "點擊實驗室，查看另一個項目"
-	},
-	"app.onboarding.lab-editor.description": {
-		"message": "編輯文本、選擇顏色、即時預覽，並複製適用於 Minecraft 配置的格式。"
-	},
-	"app.onboarding.lab-editor.title": {
-		"message": "在同一處編輯和複製"
 	},
 	"app.onboarding.lab-recipe-generator.description": {
 		"message": "選擇 Java 版本、填充配方槽位，然後在本地複製或匯出 JSON。"
 	},
 	"app.onboarding.lab-recipe-generator.title": {
 		"message": "製作資料包配方"
-	},
-	"app.onboarding.lab-seed-map.description": {
-		"message": "輸入種子或從實例載入，然後在本地地圖中查看群系、結構與礦物圖層。"
-	},
-	"app.onboarding.lab-seed-map.title": {
-		"message": "載入世界前先找到它"
-	},
-	"app.onboarding.lab-tools.description": {
-		"message": "生成帶格式的漸變文字，或用本地種子地圖探索 Java 世界。"
-	},
-	"app.onboarding.lab-tools.title": {
-		"message": "首批兩個項目"
-	},
-	"app.onboarding.lab.description": {
-		"message": "實驗室將本地 Minecraft 工具放進啟動器，無需打開其他網站或註冊額外帳號。"
-	},
-	"app.onboarding.lab.title": {
-		"message": "內建的實用工具"
-	},
-	"app.appearance-settings.auto-hide-downloads-button.description": {
-		"message": "沒有進行中的下載任務時隱藏側邊欄中的下載按鈕，有任務時自動顯示。"
-	},
-	"app.appearance-settings.auto-hide-downloads-button.title": {
-		"message": "自動隱藏下載按鈕"
-	},
-	"app.appearance-settings.home-layout.description": {
-		"message": "在資訊首頁和專注的實例啟動頁之間選擇。"
-	},
-	"app.appearance-settings.home-layout.minimal": {
-		"message": "極簡"
-	},
-	"app.appearance-settings.home-layout.standard": {
-		"message": "資訊"
-	},
-	"app.appearance-settings.home-layout.title": {
-		"message": "首頁布局"
-	},
-	"app.curseforge.automatic-downloads-failed.notification-body": {
-		"message": "重試後仍有 {failed, number} 個文件下載失敗（{list}）。可在“下載”中查看已記錄的錯誤。"
-	},
-	"app.curseforge.automatic-downloads-failed.notification-title": {
-		"message": "部分 CurseForge 文件下載失敗"
 	},
 	"app.curseforge.dependency-notes.notification-body": {
 		"message": "{optional, plural, =0 {沒有跳過可選前置模組。} other {跳過了 # 個可選前置模組。}} {incompatible, plural, =0 {未檢測到不相容的前置模組。} other {檢測到 # 個不相容的前置模組。}} {skipped, plural, =0 {沒有跳過其他前置模組。} other {跳過了 # 個其他前置模組。}}"
@@ -5710,9 +6799,6 @@
 	},
 	"app.curseforge.network-download-failed.notification-title": {
 		"message": "CurseForge 下載失敗"
-	},
-	"app.home.greeting.with-player": {
-		"message": "{name}，{greeting}"
 	},
 	"app.home.greeting.welcome": {
 		"message": "歡迎回來。"
@@ -5777,131 +6863,11 @@
 	"app.home.greeting.settings.title": {
 		"message": "自定義問候語"
 	},
-	"app.home.greeting.minimal.afternoon": {
-		"message": "午安"
-	},
-	"app.home.greeting.minimal.dawn": {
-		"message": "清晨好"
-	},
-	"app.home.greeting.minimal.evening": {
-		"message": "傍晚好"
-	},
-	"app.home.greeting.minimal.late-night": {
-		"message": "夜深了"
-	},
-	"app.home.greeting.minimal.morning": {
-		"message": "早安"
-	},
-	"app.home.greeting.minimal.night": {
-		"message": "晚上好"
-	},
-	"app.home.greeting.minimal.with-player": {
-		"message": "{greeting}，{name}"
-	},
-	"app.home.greeting.late-night": {
-		"message": "月亮還在加班。\n安靜的世界正等著你。\n夜班總能寫出好故事。\n黎明前再放一塊方塊？\n星光會看顧好你的伺服器。\n深夜時段，也能留下傳奇存檔。\n現在的火把光格外好看。\n下一場冒險還沒睡。\n午夜後的礦洞更安靜。\n和平的出生點在等你。\n耐心的建造者屬於夜晚。\n把音樂調低，把靈感調高。\n每一座好基地都從一塊方塊開始。\n終界可以等等，除非它等不了。\n短短一局也算數。\n這個世界已經為你保存好了。"
-	},
-	"app.home.greeting.dawn": {
-		"message": "天剛亮，區塊正新。\n新的一天正在載入。\n日出增益已生效。\n清晨的世界總像全新的。\n先喝咖啡，再挖鑽石。\n你的基地想你一整晚了。\n從容開局，也能成就好冒險。\n主世界正在甦醒。\n新鮮空氣，新鮮資源包。\n今天很適合去探索。\n村莊已經開門交易了。\n安靜的早晨適合大工程。\n新的一天，新的坐標。\n苦力怕也不太像早起的人。\n先從小事開始，看看會去向何處。\n下一局已經準備好，等你出發。"
-	},
-	"app.home.greeting.morning": {
-		"message": "早安，冒險家。\n今天還有許多未探索的區塊。\n正適合重新開始。\n你的工具已為今天就緒。\n主世界有不少好計劃。\n造點未來的你會喜歡的東西。\n新的一局像一張乾淨畫布。\n太陽升起了，村民也是。\n讓今天多一點方塊感。\n礦井安靜得有點可疑。\n下一個項目只差一次啟動。\n好早晨，配好世界。\n總能再裝下一個新點子。\n工作台正在待命。\n地圖在等新的標記。\n坐穩，做點進度。"
-	},
-	"app.home.greeting.afternoon": {
-		"message": "午後休息，時機正好。\n短短一局也可能很精彩。\n世界已準備好接住你的下一步。\n該去看看那座半成品建築了。\n一點探索就能走很遠。\n下一個生物群系正在呼喚。\n你的背包耐心等候很久了。\n村莊市場還沒關門。\n這一小時適合專心做個項目。\n紅石今天大概會聽話。\n你的鎬子準備開工。\n出生點外還有新路線。\n午後天生適合支線任務。\n要不要快速回世界看看？\n下一章從這裡開始。\n花一點時間，做點東西。"
-	},
-	"app.home.greeting.evening": {
-		"message": "傍晚正是建造的黃金時間。\n白天將盡，世界剛剛展開。\n熟悉的世界是個好去處。\n該回到你最愛的項目了。\n從新塔上看日落更美。\n基地的燈正等著你。\n輕鬆玩一局正合適。\n村民很快要收攤了。\n你的下一座建築值得一層暮色。\n適合沒有計劃地四處走走。\n營火已經點好了。\n基地要不要再加一間房？\n地平線看起來格外誘人。\n安靜的夜晚從好世界開始。\n下一塊方塊該你放下。\n讓今晚的進度算數。"
-	},
-	"app.home.greeting.night": {
-		"message": "夜班準備好了。\n熟悉的世界適合這個夜晚。\n你最愛的實例就在附近。\n星星出來了，計劃也定好了。\n平靜的一局能好好結束今天。\n天黑後世界更安靜。\n該再放幾塊方塊了。\n遠處的基地正在發光。\n下一場冒險從日落開始。\n一個好存檔配得上一個好夜晚。\n不知何處，營火正噼啪作響。\n月光讓每座建築都更有戲劇感。\n明天之前來一點 Minecraft。\n你的世界隨時歡迎你回去。\n按區塊算，夜還很長。\n開始一段值得的遊戲時光吧。"
-	},
-	"app.home.instances.empty": {
-		"message": "還沒有實例"
-	},
-	"app.home.instances.create": {
-		"message": "創建實例"
-	},
-	"app.home.instances.pin": {
-		"message": "固定到首頁"
-	},
-	"app.home.instances.pinned": {
-		"message": "固定的實例"
-	},
-	"app.home.instances.pinned-empty": {
-		"message": "在實例卡片菜單或實例庫中選擇「固定到首頁」，實例就會顯示在這裡。"
-	},
-	"app.home.instances.unpin": {
-		"message": "取消固定"
-	},
-	"app.home.instances.view-all": {
-		"message": "查看全部實例"
-	},
-	"app.home.layout.switch-to-information": {
-		"message": "切換到資訊首頁"
-	},
-	"app.home.layout.switch-to-minimal": {
-		"message": "切換到極簡首頁"
-	},
-	"app.home.layout.toggle": {
-		"message": "極簡首頁"
-	},
-	"app.home.minimal.change-instance": {
-		"message": "更換首頁實例"
-	},
-	"app.home.minimal.choose-instance": {
-		"message": "選擇實例"
-	},
-	"app.home.minimal.picker.no-results": {
-		"message": "沒有匹配的實例"
-	},
 	"app.home.minimal.picker.no-instances": {
 		"message": "沒有可用例項"
 	},
-	"app.home.minimal.picker.search": {
-		"message": "搜索實例"
-	},
-	"app.home.minimal.picker.select": {
-		"message": "選擇 {name}"
-	},
-	"app.home.minimal.picker.title": {
-		"message": "選擇首頁實例"
-	},
-	"app.home.recent.title": {
-		"message": "從最近的項目開始"
-	},
 	"app.home.recent.empty": {
 		"message": "還沒有最近活動。"
-	},
-	"app.home.worlds.pinned": {
-		"message": "固定的世界"
-	},
-	"app.home.worlds.empty": {
-		"message": "將世界標記為收藏後，就會固定在這裡。"
-	},
-	"app.home.servers.pinned": {
-		"message": "固定的伺服器"
-	},
-	"app.home.servers.empty": {
-		"message": "將伺服器標記為收藏後，就會固定在這裡。"
-	},
-	"app.home.servers.players-online": {
-		"message": "{online}/{max} 人在線"
-	},
-	"app.home.servers.offline": {
-		"message": "離線"
-	},
-	"app.home.servers.join": {
-		"message": "加入伺服器"
-	},
-	"app.home.servers.stop": {
-		"message": "停止"
-	},
-	"app.home.servers.unpin": {
-		"message": "取消固定"
-	},
-	"app.home.servers.more-options": {
-		"message": "更多選項"
 	},
 	"app.home.shortcut.kind.instance": {
 		"message": "例項"
@@ -6059,107 +7025,11 @@
 	"app.home.widgets.world-description": {
 		"message": "選擇一個世界，建立獨立的快速遊玩入口。"
 	},
-	"app.home.calendar.title": {
-		"message": "日曆"
-	},
-	"app.home.calendar.this-month": {
-		"message": "回到本月"
-	},
-	"app.home.calendar.previous": {
-		"message": "上個月"
-	},
-	"app.home.calendar.next": {
-		"message": "下個月"
-	},
-	"app.home.calendar.played-on": {
-		"message": "{date}你遊玩了："
-	},
-	"app.home.calendar.no-activity": {
-		"message": "這一天沒有遊玩記錄。"
-	},
-	"app.home.calendar.play": {
-		"message": "啟動"
-	},
-	"app.home.calendar.stop": {
-		"message": "停止"
-	},
-	"app.home.insights.title": {
-		"message": "遊玩洞察"
-	},
-	"app.home.insights.this-week": {
-		"message": "本週遊玩 {duration}"
-	},
-	"app.home.insights.this-week-more": {
-		"message": "本週遊玩 {duration}（比上週多 {percent}%）"
-	},
-	"app.home.insights.this-week-less": {
-		"message": "本週遊玩 {duration}（比上週少 {percent}%）"
-	},
-	"app.home.insights.this-week-same": {
-		"message": "本週遊玩 {duration}（與上週持平）"
-	},
-	"app.home.insights.streak": {
-		"message": "已連續遊玩 {days} 天"
-	},
-	"app.home.insights.week-top": {
-		"message": "本週常玩：{name}"
-	},
-	"app.home.insights.empty": {
-		"message": "開始遊玩後，這裡會顯示你的統計。"
-	},
-	"app.home.challenge.title": {
-		"message": "每日小挑戰"
-	},
-	"app.home.challenge.shuffle": {
-		"message": "換一個"
-	},
-	"app.home.challenge.easy": {
-		"message": "簡單"
-	},
-	"app.home.challenge.medium": {
-		"message": "中等"
-	},
-	"app.home.challenge.hard": {
-		"message": "困難"
-	},
-	"app.home.news.title": {
-		"message": "Minecraft 新聞"
-	},
-	"app.home.news.open-article": {
-		"message": "在 minecraft.net 上閱讀"
-	},
-	"app.home.playtime.minutes": {
-		"message": "{minutes} 分鐘"
-	},
-	"app.home.playtime.hours-minutes": {
-		"message": "{hours} 小時 {minutes} 分鐘"
-	},
-	"app.home.playtime.seconds": {
-		"message": "{seconds} 秒"
-	},
-	"app.home.playtime.sessions": {
-		"message": "成功啟動 {count} 次"
-	},
-	"app.home.playtime.most-played": {
-		"message": "當天常玩：{name}"
-	},
-	"app.instances.pin-to-home": {
-		"message": "固定到首頁"
-	},
-	"app.instances.unpin-from-home": {
-		"message": "取消固定"
-	},
 	"app.onboarding.home-customize.title": {
 		"message": "按你的方式排列"
 	},
 	"app.onboarding.home-customize.description": {
 		"message": "使用右下角的編輯控制元件新增、調整和配置小元件。編輯時可在自動排滿的網格與保留空格的自由網格之間切換。"
-	},
-	"app.onboarding.home-layout.description": {
-		"message": "隨時使用這個懸浮按鈕，在資訊首頁和極簡首頁之間切換。"
-	},
-	"app.onboarding.home-layout.title": {
-		"message": "切換資訊密度"
 	},
 	"app.onboarding.home-widgets.title": {
 		"message": "你的主頁，你的佈局"
@@ -6167,197 +7037,11 @@
 	"app.onboarding.home-widgets.description": {
 		"message": "資訊主頁由最近活動、遊玩時間、例項、世界和伺服器小元件組成。視窗或賬號側邊欄變化時，網格會自動重排。"
 	},
-	"app.instance-item.already-open": {
-		"message": "實例已經在運行"
-	},
-	"app.instance-item.loading-modpack": {
-		"message": "正在載入整合包……"
-	},
-	"app.instance-item.not-played-yet": {
-		"message": "還沒有遊玩過"
-	},
-	"app.instance-item.view-instance": {
-		"message": "查看實例"
-	},
-	"app.navigation.multiplayer": {
-		"message": "多人遊戲"
-	},
-	"app.multiplayer.title": {
-		"message": "多人遊戲"
-	},
-	"app.multiplayer.host": {
-		"message": "創建房間"
-	},
-	"app.multiplayer.join": {
-		"message": "加入房間"
-	},
-	"app.multiplayer.host-description": {
-		"message": "創建虛擬區域網路房間，讓好友直接連接到你的遊戲。"
-	},
-	"app.multiplayer.join-description": {
-		"message": "輸入房間碼加入好友的虛擬區域網路房間。"
-	},
-	"app.multiplayer.player-name": {
-		"message": "玩家名"
-	},
-	"app.multiplayer.room-code": {
-		"message": "房間碼"
-	},
-	"app.multiplayer.room-code-invalid": {
-		"message": "請輸入 U/XXXX-XXXX-XXXX-XXXX 格式的房間碼。"
-	},
-	"app.multiplayer.room-code-placeholder": {
-		"message": "例如 U/ABCD-EFGH-IJKL-MNOP"
-	},
-	"app.multiplayer.start-hosting": {
-		"message": "創建房間"
-	},
-	"app.multiplayer.join-room": {
-		"message": "加入房間"
-	},
-	"app.multiplayer.copy-room-code": {
-		"message": "複製房間碼"
-	},
-	"app.multiplayer.status.idle": {
-		"message": "未連接"
-	},
-	"app.multiplayer.status.starting": {
-		"message": "啟動中..."
-	},
-	"app.multiplayer.status.host-scanning": {
-		"message": "正在掃描..."
-	},
-	"app.multiplayer.status.host-ready": {
-		"message": "房間已就緒"
-	},
-	"app.multiplayer.status.guest-connecting": {
-		"message": "正在加入..."
-	},
-	"app.multiplayer.status.guest-ready": {
-		"message": "已連接到房間"
-	},
-	"app.multiplayer.status.error": {
-		"message": "錯誤"
-	},
-	"app.multiplayer.players": {
-		"message": "玩家"
-	},
-	"app.multiplayer.players-in-room": {
-		"message": "{count} 位玩家在房間中"
-	},
-	"app.multiplayer.not-running": {
-		"message": "聯機服務未運行。請創建房間或加入房間以開始聯機。"
-	},
-	"app.multiplayer.not-running-title": {
-		"message": "開始聯機會話"
-	},
-	"app.multiplayer.share-code": {
-		"message": "將此代碼分享給好友："
-	},
-	"app.multiplayer.server-address": {
-		"message": "備用連接地址"
-	},
-	"app.multiplayer.host-label": {
-		"message": "房主"
-	},
-	"app.multiplayer.guest-label": {
-		"message": "訪客"
-	},
-	"app.multiplayer.unknown-player-role": {
-		"message": "未知身份"
-	},
-	"app.multiplayer.platform-info": {
-		"message": "當前平台：{platform}"
-	},
-	"app.multiplayer.binary-not-found": {
-		"message": "未找到陶瓦聯機程序，請放置於："
-	},
-	"app.multiplayer.download-terracotta": {
-		"message": "下載陶瓦聯機"
-	},
 	"app.multiplayer.terracotta.update": {
 		"message": "更新陶瓦聯機"
 	},
 	"app.multiplayer.terracotta.update-available": {
 		"message": "陶瓦聯機 {version} 已可安裝。"
-	},
-	"app.multiplayer.status.downloading": {
-		"message": "下載中..."
-	},
-	"app.multiplayer.status.fatal": {
-		"message": "嚴重錯誤"
-	},
-	"app.multiplayer.status.guest-starting": {
-		"message": "正在連接..."
-	},
-	"app.multiplayer.status.host-starting": {
-		"message": "正在啟動主機..."
-	},
-	"app.multiplayer.status.waiting": {
-		"message": "等待中..."
-	},
-	"app.multiplayer.check-network": {
-		"message": "檢查網路連接"
-	},
-	"app.multiplayer.connecting": {
-		"message": "連線中..."
-	},
-	"app.multiplayer.disconnect": {
-		"message": "斷開連接"
-	},
-	"app.multiplayer.download-progress": {
-		"message": "下載進度"
-	},
-	"app.multiplayer.error.install": {
-		"message": "安裝錯誤"
-	},
-	"app.multiplayer.error.network": {
-		"message": "網路錯誤"
-	},
-	"app.multiplayer.error.os": {
-		"message": "系統錯誤"
-	},
-	"app.multiplayer.error.terracotta": {
-		"message": "陶瓦聯機錯誤"
-	},
-	"app.multiplayer.error.unknown": {
-		"message": "未知錯誤"
-	},
-	"app.multiplayer.retry": {
-		"message": "重試"
-	},
-	"app.multiplayer.export-error-report": {
-		"message": "匯出錯誤報告"
-	},
-	"app.multiplayer.verifying": {
-		"message": "驗證中..."
-	},
-	"app.multiplayer.extracting": {
-		"message": "正在解壓..."
-	},
-	"app.multiplayer.installing": {
-		"message": "正在安裝..."
-	},
-	"app.multiplayer.powered-by-terracotta": {
-		"message": "由 Terracotta | 陶瓦聯機 強力驅動"
-	},
-	"app.multiplayer.back": {
-		"message": "返回"
-	},
-	"app.multiplayer.start-terracotta": {
-		"message": "啟動陶瓦聯機"
-	},
-	"app.multiplayer.start-description": {
-		"message": "啟動聯機服務以創建房間或加入好友的房間。"
-	},
-	"app.multiplayer.lan-hint": {
-		"message": "請打開 Minecraft 進入世界，按 ESC → 對區域網路開放 → 選擇一個埠，陶瓦聯機會自動檢測。"
-	},
-	"app.multiplayer.loading": {
-		"message": "初始化中..."
-	},
-	"app.multiplayer.no-players": {
-		"message": "暫無玩家"
 	},
 	"app.multiplayer.provider.terracotta": {
 		"message": "陶瓦聯機"
@@ -6767,45 +7451,6 @@
 	"app.onboarding.lab-schematic.title": {
 		"message": "放置前先檢查建築"
 	},
-	"app.drop.error.unknown-depth-text": {
-		"message": "壓縮檔嵌套層級過深，無法分析。請先解壓到資料夾後重試。"
-	},
-	"app.drop.error.unknown-encrypted-text": {
-		"message": "壓縮檔包含加密檔案，無法分析。"
-	},
-	"app.drop.extract-failed": {
-		"message": "壓縮檔解壓失敗"
-	},
-	"app.drop.installing-file": {
-		"message": "正在安裝 {name}…"
-	},
-	"app.drop.nested-unpack-button": {
-		"message": "繼續分析"
-	},
-	"app.drop.nested-unpack-text": {
-		"message": "此壓縮檔內含嵌套壓縮檔（{size}），需要解壓後才能分析，可能需要一些時間。是否繼續？"
-	},
-	"app.drop.nested-unpack-title": {
-		"message": "偵測到嵌套壓縮檔"
-	},
-	"app.drop.process-failed-title": {
-		"message": "處理檔案失敗"
-	},
-	"app.drop.scan-failed": {
-		"message": "實例掃描失敗"
-	},
-	"app.drop.scanning": {
-		"message": "正在掃描實例…"
-	},
-	"app.drop.temporary-file-text": {
-		"message": "檔案「{file}」似乎是暫存副本。請嘗試從檔案的原始位置拖入，而不是從瀏覽器、壓縮檔或雲端儲存。"
-	},
-	"app.drop.temporary-file-title": {
-		"message": "偵測到暫存檔案"
-	},
-	"app.drop.unexpected-type": {
-		"message": "意外的類型：{type}"
-	},
 	"app.ai-settings.add-model": {
 		"message": "新增模型"
 	},
@@ -7169,12 +7814,6 @@
 	"app.lab.mod-translation.background-running": {
 		"message": "任務仍在後臺執行"
 	},
-	"app.curseforge.manual-downloads.choose-file": {
-		"message": "選擇本機檔案"
-	},
-	"app.instance.mods.skipped-files-warning.complete": {
-		"message": "補齊缺失檔案"
-	},
 	"app.downloads.item-status.failed": {
 		"message": "失敗"
 	},
@@ -7183,24 +7822,6 @@
 	},
 	"app.multiplayer.hongshi.binary-missing": {
 		"message": "建立房間前，請先下載適用於當前裝置的紅石聯機核心。"
-	},
-	"app.multiplayer.terracotta.public-nodes": {
-		"message": "陶瓦公共節點"
-	},
-	"app.multiplayer.terracotta.public-nodes-description": {
-		"message": "每行輸入一個節點 URI。變更將在下次建立或加入房間時生效。留空則僅使用陶瓦內建節點。"
-	},
-	"app.multiplayer.terracotta.public-nodes-placeholder": {
-		"message": "wss://center.node.1tmc.top"
-	},
-	"app.multiplayer.terracotta.public-node-invalid": {
-		"message": "節點 URI 無效：{node}。請使用 http、https、tcp、tls、udp、ws 或 wss。"
-	},
-	"app.multiplayer.terracotta.save-public-nodes": {
-		"message": "儲存節點"
-	},
-	"app.multiplayer.terracotta.public-nodes-saved": {
-		"message": "陶瓦公共節點已儲存"
 	},
 	"app.onboarding.privacy.description": {
 		"message": "匿名遙測、Discord 活動狀態與 Minecraft 日誌分析服務都可以在這裡調整。"
@@ -7232,9 +7853,6 @@
 	"app.privacy-consent.title": {
 		"message": "隱私與安全"
 	},
-	"app.settings.about.preview-privacy-consent-modal": {
-		"message": "預覽隱私與安全彈窗"
-	},
 	"app.settings.privacy.data-handling": {
 		"message": "遙測使用隨機安裝標識。錯誤上下文離開裝置前會經過脫敏和長度限制。關閉遙測會立即清空待傳送報告。"
 	},
@@ -7249,36 +7867,6 @@
 	},
 	"app.settings.privacy.telemetry-description": {
 		"message": "傳送匿名每日活躍訊號和脫敏的啟動器錯誤報告。絕不上傳 Minecraft 日誌或賬戶憑據。"
-	},
-	"app.curseforge.manual-downloads.state-changed": {
-		"message": "下載狀態已變更，正在等待同步。"
-	},
-	"app.instances.selected-count": {
-		"message": "已選擇 {count} 個"
-	},
-	"app.instances.select-all": {
-		"message": "全選"
-	},
-	"app.instances.edit-groups": {
-		"message": "編輯分組"
-	},
-	"app.instances.deselect-all": {
-		"message": "取消全選"
-	},
-	"app.instances.batch-edit-groups.header": {
-		"message": "編輯分組"
-	},
-	"app.instances.batch-edit-groups.enter-group-name": {
-		"message": "分組名稱"
-	},
-	"app.instances.batch-edit-groups.description": {
-		"message": "為 {count} 個實例設定分組"
-	},
-	"app.instances.batch-edit-groups.create-group": {
-		"message": "建立新分組"
-	},
-	"app.instances.batch-edit-groups.apply": {
-		"message": "套用"
 	},
 	"app.content-install.preview.unavailable-curseforge-project": {
 		"message": "CurseForge 專案不可用"
@@ -7312,18 +7900,6 @@
 	},
 	"app.browse.add": {
 		"message": "新增"
-	},
-	"app.settings.resources.source.tianpao": {
-		"message": "Tianpao 鏡像"
-	},
-	"app.settings.resources.modrinth-mirror-description": {
-		"message": "Modrinth 檔案下載。"
-	},
-	"app.settings.resources.modrinth-mirror": {
-		"message": "Modrinth"
-	},
-	"app.downloads.source.tianpao": {
-		"message": "Tianpao 鏡像"
 	},
 	"app.browse.choose-instance": {
 		"message": "選擇例項"
@@ -7880,12 +8456,6 @@
 	"app.onboarding.favorites.title": {
 		"message": "留個清單"
 	},
-	"app.settings.about.survey-description": {
-		"message": "幫助我們改進 Axolotl Launcher"
-	},
-	"app.settings.about.survey": {
-		"message": "調查問卷"
-	},
 	"app.library.view.standard": {
 		"message": "標準網格"
 	},
@@ -7895,53 +8465,14 @@
 	"app.library.view": {
 		"message": "檢視"
 	},
-	"app.translation-settings.provider.deepl": {
-		"message": "DeepL 翻譯"
-	},
-	"app.translation-settings.deepl-api-key-placeholder": {
-		"message": "輸入你的 DeepL API 金鑰"
-	},
-	"app.translation-settings.deepl-api-key-hint": {
-		"message": "在 deepl.com/pro-api 免費取得金鑰"
-	},
-	"app.translation-settings.deepl-api-key": {
-		"message": "API 金鑰"
-	},
-	"app.translation-settings.deepl-api-endpoint-placeholder": {
-		"message": "https://api-free.deepl.com/v2/translate"
-	},
-	"app.translation-settings.deepl-api-endpoint": {
-		"message": "API 端點"
-	},
-	"app.survey-promotion.title": {
-		"message": "調查問卷"
-	},
-	"app.survey-promotion.reward": {
-		"message": "我們將從填寫問卷的使用者中抽取幸運使用者，贈送 Minecraft 正版帳號（可折現）。"
-	},
-	"app.survey-promotion.intro": {
-		"message": "為了更好地改進 Axolotl Launcher，我們準備了一份簡短的調查問卷，期待聽到你的回饋。"
-	},
-	"app.survey-promotion.fill-survey": {
-		"message": "填寫問卷"
-	},
-	"app.survey-promotion.defer-hint": {
-		"message": "關閉此彈窗後，你仍可以隨時在「設定 → 關於」頁面中找到並填寫問卷。"
-	},
 	"browse.selected-projects-floating-bar.hide-projects": {
 		"message": "隱藏已選擇的專案"
 	},
 	"browse.selected-projects-floating-bar.show-projects": {
 		"message": "顯示 {count, plural, one {# selected project} other {# selected projects}}"
 	},
-	"app.translation-settings.provider.microsoft": {
-		"message": "Microsoft 翻譯（無法使用）"
-	},
 	"instance.files.studio.unsaved-switch-blocked": {
 		"message": "請先儲存或放棄當前更改，再開啟其他檔案。"
-	},
-	"app.settings.resources.source.mcim": {
-		"message": "MCIM 鏡像"
 	},
 	"app.settings.storage.collapse-action": {
 		"message": "摺疊"
@@ -7955,188 +8486,8 @@
 	"app.multiplayer.tab.servers": {
 		"message": "伺服器"
 	},
-	"app.servers.action.open-folder": {
-		"message": "開啟資料夾"
-	},
-	"app.servers.action.share": {
-		"message": "分享至公開網路"
-	},
-	"app.servers.action.start": {
-		"message": "啟動"
-	},
-	"app.servers.action.stop": {
-		"message": "停止"
-	},
-	"app.servers.card.port": {
-		"message": "連接埠 {port}"
-	},
-	"app.servers.card.type": {
-		"message": "{type} · {version}"
-	},
-	"app.servers.create.title": {
-		"message": "建立伺服器"
-	},
-	"app.servers.count": {
-		"message": "{count, plural, =0 {還沒有伺服器} other {共 # 個伺服器}}"
-	},
-	"app.servers.detail.back": {
-		"message": "伺服器"
-	},
-	"app.servers.detail.console": {
-		"message": "主控台"
-	},
-	"app.servers.detail.not-found": {
-		"message": "該伺服器已不存在。"
-	},
-	"app.servers.detail.settings": {
-		"message": "設定"
-	},
-	"app.servers.empty.description": {
-		"message": "在啟動器中建立伺服器，與好友一起遊玩。"
-	},
-	"app.servers.empty.heading": {
-		"message": "還沒有伺服器"
-	},
-	"app.servers.eula.accept": {
-		"message": "同意並繼續"
-	},
-	"app.servers.eula.decline": {
-		"message": "取消"
-	},
-	"app.servers.eula.description": {
-		"message": "伺服器啟動前需要同意 Minecraft 最終使用者授權條款（EULA）。請查看以下內容："
-	},
-	"app.servers.eula.title": {
-		"message": "Minecraft EULA"
-	},
-	"app.servers.loading": {
-		"message": "載入中"
-	},
-	"app.servers.properties.load-failed": {
-		"message": "載入伺服器設定失敗。"
-	},
-	"app.servers.properties.missing": {
-		"message": "啟動一次伺服器即可產生此檔案。"
-	},
-	"app.servers.properties.mode.form": {
-		"message": "表單"
-	},
-	"app.servers.properties.mode.text": {
-		"message": "文字"
-	},
-	"app.servers.properties.save": {
-		"message": "儲存變更"
-	},
-	"app.servers.properties.saved": {
-		"message": "伺服器設定已儲存"
-	},
-	"app.servers.properties.title": {
-		"message": "伺服器屬性"
-	},
-	"app.servers.refresh": {
-		"message": "重新整理"
-	},
-	"app.servers.settings.config": {
-		"message": "設定檔"
-	},
-	"app.servers.settings.delete": {
-		"message": "刪除伺服器"
-	},
-	"app.servers.settings.delete-confirm": {
-		"message": "刪除 {name} 及其所有檔案？此操作無法復原。"
-	},
-	"app.servers.settings.delete-hint": {
-		"message": "永久刪除該伺服器及其所有檔案。"
-	},
-	"app.servers.settings.delete-proceed": {
-		"message": "刪除"
-	},
-	"app.servers.settings.general": {
-		"message": "一般"
-	},
-	"app.servers.settings.icon": {
-		"message": "圖示"
-	},
-	"app.servers.settings.java": {
-		"message": "Java"
-	},
-	"app.servers.settings.java-none": {
-		"message": "系統預設"
-	},
-	"app.servers.settings.jvm-args": {
-		"message": "JVM 參數"
-	},
-	"app.servers.settings.jvm-args-hint": {
-		"message": "以空格分隔的參數，例如 -XX:+UseG1GC"
-	},
-	"app.servers.settings.memory": {
-		"message": "記憶體"
-	},
-	"app.servers.settings.name": {
-		"message": "伺服器名稱"
-	},
-	"app.servers.settings.running-hint": {
-		"message": "您的變更在下次啟動伺服器後才會生效。"
-	},
-	"app.servers.settings.running-title": {
-		"message": "伺服器執行中"
-	},
-	"app.servers.settings.save": {
-		"message": "儲存變更"
-	},
-	"app.servers.settings.saved": {
-		"message": "伺服器設定已儲存"
-	},
-	"app.servers.status.crashed": {
-		"message": "已崩潰"
-	},
-	"app.servers.status.created": {
-		"message": "未設定"
-	},
-	"app.servers.status.eula-pending": {
-		"message": "待同意 EULA"
-	},
-	"app.servers.status.ready": {
-		"message": "就緒"
-	},
-	"app.servers.status.running": {
-		"message": "執行中"
-	},
-	"app.servers.status.starting": {
-		"message": "啟動中"
-	},
-	"app.servers.wizard.configure-heading": {
-		"message": "調整伺服器設定，或直接完成，稍後再編輯。"
-	},
-	"app.servers.wizard.configure-title": {
-		"message": "設定"
-	},
-	"app.servers.wizard.done": {
-		"message": "伺服器已就緒"
-	},
-	"app.servers.wizard.downloading": {
-		"message": "正在下載伺服器端檔案…"
-	},
-	"app.servers.wizard.eula-wait": {
-		"message": "等待確認 EULA"
-	},
-	"app.servers.wizard.failed": {
-		"message": "建立失敗"
-	},
-	"app.servers.wizard.finish": {
-		"message": "完成"
-	},
-	"app.servers.wizard.first-run": {
-		"message": "正在首次啟動…"
-	},
-	"app.servers.wizard.game-version": {
-		"message": "遊戲版本"
-	},
 	"app.servers.wizard.install-java": {
 		"message": "安裝 Java"
-	},
-	"app.servers.wizard.install-title": {
-		"message": "安裝"
 	},
 	"app.servers.wizard.java-missing": {
 		"message": "未找到已安裝的 Java。"
@@ -8147,343 +8498,7 @@
 	"app.servers.wizard.java-placeholder": {
 		"message": "選擇 Java 版本"
 	},
-	"app.servers.wizard.loader-version": {
-		"message": "載入器版本"
-	},
-	"app.servers.wizard.log": {
-		"message": "輸出"
-	},
-	"app.servers.wizard.memory-value": {
-		"message": "{value} MB"
-	},
-	"app.servers.wizard.name": {
-		"message": "伺服器名稱"
-	},
-	"app.servers.wizard.name-placeholder": {
-		"message": "生存服"
-	},
-	"app.servers.wizard.next": {
-		"message": "下一步"
-	},
-	"app.servers.wizard.retry": {
-		"message": "重試"
-	},
-	"app.servers.wizard.setup-title": {
-		"message": "設定"
-	},
-	"app.servers.wizard.show-snapshots": {
-		"message": "顯示快照版本"
-	},
 	"app.servers.wizard.type-coming-soon": {
 		"message": "即將支援"
-	},
-	"app.servers.wizard.type-heading": {
-		"message": "選擇伺服器端類型"
-	},
-	"app.servers.wizard.type-title": {
-		"message": "伺服器端類型"
-	},
-	"app.servers.console.command-echo": {
-		"message": "> {command}"
-	},
-	"app.servers.console.not-running": {
-		"message": "伺服器未執行"
-	},
-	"app.servers.properties.field.accepts-transfers": {
-		"message": "接受玩家轉移"
-	},
-	"app.servers.properties.field.allow-end": {
-		"message": "允許終界"
-	},
-	"app.servers.properties.field.allow-flight": {
-		"message": "允許飛行"
-	},
-	"app.servers.properties.field.allow-nether": {
-		"message": "允許地獄"
-	},
-	"app.servers.properties.field.announce-player-achievements": {
-		"message": "廣播玩家成就"
-	},
-	"app.servers.properties.field.broadcast-console-to-ops": {
-		"message": "向管理員廣播主控台訊息"
-	},
-	"app.servers.properties.field.broadcast-rcon-to-ops": {
-		"message": "向管理員廣播 RCON 訊息"
-	},
-	"app.servers.properties.field.bug-report-link": {
-		"message": "Bug 回報連結"
-	},
-	"app.servers.properties.field.chat-spam-threshold-seconds": {
-		"message": "聊天洗版門檻（秒）"
-	},
-	"app.servers.properties.field.command-spam-threshold-seconds": {
-		"message": "指令洗版門檻（秒）"
-	},
-	"app.servers.properties.field.difficulty": {
-		"message": "難度"
-	},
-	"app.servers.properties.field.enable-code-of-conduct": {
-		"message": "啟用行為準則"
-	},
-	"app.servers.properties.field.enable-command-block": {
-		"message": "啟用指令方塊"
-	},
-	"app.servers.properties.field.enable-jmx-monitoring": {
-		"message": "啟用 JMX 監控"
-	},
-	"app.servers.properties.field.enable-lan": {
-		"message": "啟用區域網路"
-	},
-	"app.servers.properties.field.enable-query": {
-		"message": "啟用查詢"
-	},
-	"app.servers.properties.field.enable-rcon": {
-		"message": "啟用 RCON"
-	},
-	"app.servers.properties.field.enable-status": {
-		"message": "啟用伺服器狀態"
-	},
-	"app.servers.properties.field.enforce-secure-profile": {
-		"message": "強制安全設定檔"
-	},
-	"app.servers.properties.field.enforce-whitelist": {
-		"message": "強制白名單"
-	},
-	"app.servers.properties.field.entity-broadcast-range-percentage": {
-		"message": "實體廣播範圍百分比"
-	},
-	"app.servers.properties.field.force-gamemode": {
-		"message": "強制遊戲模式"
-	},
-	"app.servers.properties.field.function-permission-level": {
-		"message": "函式權限等級"
-	},
-	"app.servers.properties.field.gamemode": {
-		"message": "遊戲模式"
-	},
-	"app.servers.properties.field.generate-structures": {
-		"message": "生成結構"
-	},
-	"app.servers.properties.field.generator-settings": {
-		"message": "生成器設定"
-	},
-	"app.servers.properties.field.hardcore": {
-		"message": "核心模式"
-	},
-	"app.servers.properties.field.hide-online-players": {
-		"message": "隱藏線上玩家"
-	},
-	"app.servers.properties.field.initial-disabled-packs": {
-		"message": "初始停用的資料包"
-	},
-	"app.servers.properties.field.initial-enabled-packs": {
-		"message": "初始啟用的資料包"
-	},
-	"app.servers.properties.field.level-name": {
-		"message": "世界名稱"
-	},
-	"app.servers.properties.field.level-seed": {
-		"message": "世界種子"
-	},
-	"app.servers.properties.field.level-type": {
-		"message": "世界類型"
-	},
-	"app.servers.properties.field.log-ips": {
-		"message": "記錄 IP"
-	},
-	"app.servers.properties.field.management-server-allowed-origins": {
-		"message": "管理伺服器允許的來源"
-	},
-	"app.servers.properties.field.management-server-enabled": {
-		"message": "啟用管理伺服器"
-	},
-	"app.servers.properties.field.management-server-host": {
-		"message": "管理伺服器主機"
-	},
-	"app.servers.properties.field.management-server-port": {
-		"message": "管理伺服器連接埠"
-	},
-	"app.servers.properties.field.management-server-secret": {
-		"message": "管理伺服器金鑰"
-	},
-	"app.servers.properties.field.management-server-tls-enabled": {
-		"message": "管理伺服器啟用 TLS"
-	},
-	"app.servers.properties.field.management-server-tls-keystore": {
-		"message": "管理伺服器 TLS 金鑰儲存庫"
-	},
-	"app.servers.properties.field.management-server-tls-keystore-password": {
-		"message": "管理伺服器 TLS 金鑰儲存庫密碼"
-	},
-	"app.servers.properties.field.max-chained-neighbor-updates": {
-		"message": "最大連鎖鄰近更新次數"
-	},
-	"app.servers.properties.field.max-players": {
-		"message": "最大玩家數"
-	},
-	"app.servers.properties.field.max-tick-time": {
-		"message": "最大單 Tick 時間"
-	},
-	"app.servers.properties.field.max-world-size": {
-		"message": "最大世界大小"
-	},
-	"app.servers.properties.field.motd": {
-		"message": "伺服器標語（MOTD）"
-	},
-	"app.servers.properties.field.network-compression-threshold": {
-		"message": "網路壓縮門檻"
-	},
-	"app.servers.properties.field.online-mode": {
-		"message": "正版驗證"
-	},
-	"app.servers.properties.field.op-permission-level": {
-		"message": "管理員權限等級"
-	},
-	"app.servers.properties.field.pause-when-empty-seconds": {
-		"message": "空服暫停（秒）"
-	},
-	"app.servers.properties.field.player-idle-timeout": {
-		"message": "玩家閒置逾時"
-	},
-	"app.servers.properties.field.prevent-proxy-connections": {
-		"message": "禁止代理連線"
-	},
-	"app.servers.properties.field.pvp": {
-		"message": "玩家對戰（PvP）"
-	},
-	"app.servers.properties.field.query.port": {
-		"message": "查詢連接埠"
-	},
-	"app.servers.properties.field.rate-limit": {
-		"message": "頻率限制"
-	},
-	"app.servers.properties.field.rcon.password": {
-		"message": "RCON 密碼"
-	},
-	"app.servers.properties.field.rcon.port": {
-		"message": "RCON 連接埠"
-	},
-	"app.servers.properties.field.region-file-compression": {
-		"message": "區域檔案壓縮方式"
-	},
-	"app.servers.properties.field.require-resource-pack": {
-		"message": "強制資源包"
-	},
-	"app.servers.properties.field.resource-pack": {
-		"message": "資源包"
-	},
-	"app.servers.properties.field.resource-pack-id": {
-		"message": "資源包 ID"
-	},
-	"app.servers.properties.field.resource-pack-prompt": {
-		"message": "資源包提示"
-	},
-	"app.servers.properties.field.resource-pack-sha1": {
-		"message": "資源包 SHA-1"
-	},
-	"app.servers.properties.field.server-ip": {
-		"message": "伺服器 IP"
-	},
-	"app.servers.properties.field.server-port": {
-		"message": "伺服器連接埠"
-	},
-	"app.servers.properties.field.simulation-distance": {
-		"message": "模擬距離"
-	},
-	"app.servers.properties.field.spawn-animals": {
-		"message": "生成動物"
-	},
-	"app.servers.properties.field.spawn-monsters": {
-		"message": "生成怪物"
-	},
-	"app.servers.properties.field.spawn-npcs": {
-		"message": "生成 NPC"
-	},
-	"app.servers.properties.field.spawn-protection": {
-		"message": "重生點保護範圍"
-	},
-	"app.servers.properties.field.status-heartbeat-interval": {
-		"message": "狀態心跳間隔"
-	},
-	"app.servers.properties.field.sync-chunk-writes": {
-		"message": "同步區塊寫入"
-	},
-	"app.servers.properties.field.text-filtering-config": {
-		"message": "文字過濾設定"
-	},
-	"app.servers.properties.field.text-filtering-version": {
-		"message": "文字過濾版本"
-	},
-	"app.servers.properties.field.use-native-transport": {
-		"message": "使用原生傳輸"
-	},
-	"app.servers.properties.field.view-distance": {
-		"message": "繪製距離"
-	},
-	"app.servers.properties.field.white-list": {
-		"message": "白名單"
-	},
-	"app.servers.properties.section.advanced": {
-		"message": "進階"
-	},
-	"app.servers.properties.section.content": {
-		"message": "資源與內容"
-	},
-	"app.servers.properties.section.gameplay": {
-		"message": "遊戲玩法"
-	},
-	"app.servers.properties.section.network": {
-		"message": "網路與安全"
-	},
-	"app.servers.properties.section.others": {
-		"message": "其他"
-	},
-	"app.servers.properties.section.world": {
-		"message": "世界"
-	},
-	"app.servers.settings.cancel": {
-		"message": "取消"
-	},
-	"app.servers.detail.files": {
-		"message": "檔案"
-	},
-	"app.servers.files.busy-tooltip": {
-		"message": "停止伺服器後才能修改檔案"
-	},
-	"app.servers.files.save-as": {
-		"message": "另存為..."
-	},
-	"app.servers.icon.change": {
-		"message": "變更圖示"
-	},
-	"app.servers.icon.edit": {
-		"message": "編輯圖示"
-	},
-	"app.servers.icon.remove": {
-		"message": "移除圖示"
-	},
-	"app.servers.icon.select": {
-		"message": "選擇圖示"
-	},
-	"app.servers.port.change": {
-		"message": "修改連接埠"
-	},
-	"app.servers.port.conflict-description": {
-		"message": "{process} 正在佔用此連接埠，伺服器無法啟動。建議修改伺服器連接埠，也可以強制結束佔用程序後再啟動。"
-	},
-	"app.servers.port.conflict-title": {
-		"message": "連接埠 {port} 已被佔用"
-	},
-	"app.servers.port.force-quit": {
-		"message": "強制結束佔用程序"
-	},
-	"app.servers.port.force-quit-failed": {
-		"message": "結束佔用連接埠的程序失敗"
-	},
-	"app.servers.port.recheck": {
-		"message": "重新偵測"
-	},
-	"app.servers.port.unknown-process": {
-		"message": "未知程序（PID {pid}）"
 	}
 }

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -11,6 +11,24 @@
 	"app.action-bar.downloads": {
 		"message": "下載"
 	},
+	"app.action-bar.install.cache-repair.action": {
+		"message": "清除專案快取並重試"
+	},
+	"app.action-bar.install.cache-repair.description": {
+		"message": "啟動器無法讀取本地 CurseForge 專案快取，安裝已停止。"
+	},
+	"app.action-bar.install.cache-repair.failed": {
+		"message": "專案快取清除失敗；尚未開始重試。"
+	},
+	"app.action-bar.install.cache-repair.in-progress": {
+		"message": "正在清除專案快取…"
+	},
+	"app.action-bar.install.cache-repair.title": {
+		"message": "專案後設資料快取異常"
+	},
+	"app.action-bar.install.deleted-instance": {
+		"message": "例項已刪除"
+	},
 	"app.action-bar.hide-more-running-instances": {
 		"message": "隱藏更多執行中的實例"
 	},
@@ -35,6 +53,9 @@
 	"app.action-bar.install.summary.bad-modpack-file": {
 		"message": "無法讀取模組包檔案"
 	},
+	"app.action-bar.install.summary.unrecognized-format": {
+		"message": "這似乎不是一個整合包文件，無法識別其格式"
+	},
 	"app.action-bar.install.summary.canceled": {
 		"message": "已取消"
 	},
@@ -52,9 +73,6 @@
 	},
 	"app.action-bar.install.summary.download-failed": {
 		"message": "下載未能完成"
-	},
-	"app.action-bar.install.summary.file-download-failed": {
-		"message": "無法下載 {file}"
 	},
 	"app.action-bar.install.summary.instance-not-found": {
 		"message": "找不到實例"
@@ -89,11 +107,11 @@
 	"app.action-bar.install.summary.pack-download-failed": {
 		"message": "無法下載模組包"
 	},
+	"app.action-bar.install.summary.file-download-failed": {
+		"message": "無法下載 {file}"
+	},
 	"app.action-bar.install.summary.unexpected-error": {
 		"message": "發生預期之外的錯誤"
-	},
-	"app.action-bar.install.summary.unrecognized-format": {
-		"message": "這似乎不是一個整合包文件，無法識別其格式"
 	},
 	"app.action-bar.install.unknown-instance": {
 		"message": "未知的實例"
@@ -179,12 +197,6 @@
 	"app.appearance-settings.advanced-rendering.title": {
 		"message": "進階繪製"
 	},
-	"app.appearance-settings.auto-hide-downloads-button.description": {
-		"message": "沒有進行中的下載任務時隱藏側邊欄中的下載按鈕，有任務時自動顯示。"
-	},
-	"app.appearance-settings.auto-hide-downloads-button.title": {
-		"message": "自動隱藏下載按鈕"
-	},
 	"app.appearance-settings.color-theme.description": {
 		"message": "請選擇你偏好的 Axolotl Launcher 色彩主題。"
 	},
@@ -242,18 +254,6 @@
 	"app.appearance-settings.hide-nametag.title": {
 		"message": "隱藏名牌"
 	},
-	"app.appearance-settings.home-layout.description": {
-		"message": "在資訊首頁和專注的實例啟動頁之間選擇。"
-	},
-	"app.appearance-settings.home-layout.minimal": {
-		"message": "極簡"
-	},
-	"app.appearance-settings.home-layout.standard": {
-		"message": "資訊"
-	},
-	"app.appearance-settings.home-layout.title": {
-		"message": "首頁布局"
-	},
 	"app.appearance-settings.minimize-launcher.description": {
 		"message": "當 Minecraft 處理程序啟動時最小化啟動器。"
 	},
@@ -271,6 +271,18 @@
 	},
 	"app.appearance-settings.native-decorations.title": {
 		"message": "原生視窗"
+	},
+	"app.appearance-settings.page-transitions.description": {
+		"message": "在啟動器頁面之間切換時播放過渡動畫。"
+	},
+	"app.appearance-settings.page-transitions.title": {
+		"message": "頁面切換過渡動畫"
+	},
+	"app.appearance-settings.auto-install-dependencies.description": {
+		"message": "安裝內容時自動下載所需前置。每次安裝前仍可在確認對話方塊中調整選擇。"
+	},
+	"app.appearance-settings.auto-install-dependencies.title": {
+		"message": "自動安裝前置"
 	},
 	"app.appearance-settings.select-option": {
 		"message": "選擇選項"
@@ -359,14 +371,23 @@
 	"app.browse.discover-content": {
 		"message": "探索內容"
 	},
+	"app.browse.discover-maps": {
+		"message": "發現地圖"
+	},
 	"app.browse.discover-servers": {
 		"message": "探索伺服器"
 	},
 	"app.browse.hide-added-servers": {
 		"message": "隱藏已新增的伺服器"
 	},
-	"app.browse.project-type.datapacks": {
-		"message": "資料包"
+	"app.browse.maps-unavailable": {
+		"message": "地圖不可用"
+	},
+	"app.browse.maps-unavailable-description": {
+		"message": "請配置 CurseForge API Key 以瀏覽和安裝地圖。"
+	},
+	"app.browse.maps-no-installable-file": {
+		"message": "所選 CurseForge 地圖沒有可安裝的檔案。"
 	},
 	"app.browse.project-type.modpacks": {
 		"message": "模組包"
@@ -377,11 +398,17 @@
 	"app.browse.project-type.resourcepacks": {
 		"message": "資源包"
 	},
-	"app.browse.project-type.servers": {
-		"message": "伺服器"
+	"app.browse.project-type.datapacks": {
+		"message": "資料包"
+	},
+	"app.browse.project-type.maps": {
+		"message": "地圖"
 	},
 	"app.browse.project-type.shaders": {
 		"message": "光影包"
+	},
+	"app.browse.project-type.servers": {
+		"message": "伺服器"
 	},
 	"app.browse.server-instance-content-warning": {
 		"message": "加入內容可能會導致加入伺服器時發生相容性問題。當你更新伺服器實例內容時，任何新增的內容也會遺失。"
@@ -419,17 +446,107 @@
 	"app.content-install.no-compatible-versions": {
 		"message": "沒有符合 {compatibilityLabel} 的可用版本。請選擇一個版本強制安裝。不會自動安裝相依模組。"
 	},
+	"app.content-install.dependencies-installed.notification-body": {
+		"message": "已自動安裝 {count, plural, other {# 個前置}}：{list}"
+	},
+	"app.content-install.dependencies-installed.notification-title": {
+		"message": "已安裝前置"
+	},
+	"app.content-install.dependencies-skipped.notification-body": {
+		"message": "以下前置未安裝：{list}"
+	},
+	"app.content-install.dependencies-skipped.notification-title": {
+		"message": "部分前置已跳過"
+	},
+	"app.content-install.preview.already-included": {
+		"message": "已包含"
+	},
+	"app.content-install.preview.already-installed": {
+		"message": "已安裝"
+	},
+	"app.content-install.preview.cancel": {
+		"message": "取消"
+	},
+	"app.content-install.preview.clear-all": {
+		"message": "全部取消"
+	},
+	"app.content-install.preview.dependencies-count": {
+		"message": "{count, number} 個前置"
+	},
+	"app.content-install.preview.dependencies-header": {
+		"message": "前置"
+	},
+	"app.content-install.preview.description": {
+		"message": "將在 {instance} 中為 {project} 自動安裝 {count, plural, other {# 個前置}}。"
+	},
+	"app.content-install.preview.header": {
+		"message": "確認安裝"
+	},
+	"app.content-install.preview.install": {
+		"message": "安裝"
+	},
+	"app.content-install.preview.only-checked": {
+		"message": "只會安裝勾選的前置。"
+	},
+	"app.content-install.preview.optional-dependencies-header": {
+		"message": "可選前置"
+	},
+	"app.content-install.preview.required-dependencies-header": {
+		"message": "必要前置"
+	},
+	"app.content-install.preview.required-by": {
+		"message": "被 {projects} 需要"
+	},
+	"app.content-install.preview.select-all": {
+		"message": "全選"
+	},
+	"app.content-install.preview.skip.already-installed": {
+		"message": "已安裝"
+	},
+	"app.content-install.preview.skip.conflicting-dependency": {
+		"message": "前置版本衝突"
+	},
+	"app.content-install.preview.skip.duplicate-project": {
+		"message": "已包含"
+	},
+	"app.content-install.preview.skip.embedded": {
+		"message": "已內建於專案中"
+	},
+	"app.content-install.preview.skip.excluded-by-user": {
+		"message": "已由使用者取消"
+	},
+	"app.content-install.preview.skip.incompatible": {
+		"message": "不相容的前置"
+	},
+	"app.content-install.preview.skip.missing-version": {
+		"message": "找不到引用的版本"
+	},
+	"app.content-install.preview.skip.no-compatible-version": {
+		"message": "找不到相容版本"
+	},
+	"app.content-install.preview.skip.optional": {
+		"message": "可選前置"
+	},
+	"app.content-install.preview.skip.quilt-fabric-api": {
+		"message": "已替換為 Quilt 版本"
+	},
+	"app.content-install.preview.skip.tool": {
+		"message": "開發工具，不安裝"
+	},
+	"app.content-install.preview.skip.unsupported-project-type": {
+		"message": "不支援的專案型別"
+	},
+	"app.content-install.preview.skipped-header": {
+		"message": "跳過"
+	},
+	"app.content-install.preview.version-mismatch": {
+		"message": "下載的版本可能與當前版本不相容。"
+	},
 	"app.content.add-from-file": {
 		"message": "從檔案新增"
 	},
 	"app.content.install-content": {
 		"message": "安裝內容"
-	},
-	"app.curseforge.automatic-downloads-failed.notification-body": {
-		"message": "重試後仍有 {failed, number} 個文件下載失敗（{list}）。可在“下載”中查看已記錄的錯誤。"
-	},
-	"app.curseforge.automatic-downloads-failed.notification-title": {
-		"message": "部分 CurseForge 文件下載失敗"
 	},
 	"app.curseforge.manual-downloads.all-imported": {
 		"message": "所有檔案均已匯入"
@@ -445,9 +562,6 @@
 	},
 	"app.curseforge.manual-downloads.checking-downloads": {
 		"message": "正在檢查監控匯入目錄..."
-	},
-	"app.curseforge.manual-downloads.choose-file": {
-		"message": "選擇本機檔案"
 	},
 	"app.curseforge.manual-downloads.downloads-unavailable": {
 		"message": "無法存取監控匯入目錄。"
@@ -497,9 +611,6 @@
 	"app.curseforge.manual-downloads.scanner-failed": {
 		"message": "自動匯入檢查失敗，正在重試。"
 	},
-	"app.curseforge.manual-downloads.state-changed": {
-		"message": "下載狀態已變更，正在等待同步。"
-	},
 	"app.curseforge.manual-downloads.view-instance": {
 		"message": "查看實例"
 	},
@@ -515,9 +626,6 @@
 	"app.curseforge.modpack-installed.title": {
 		"message": "CurseForge 模組包已安裝"
 	},
-	"app.downloads.action-needed": {
-		"message": "需要操作"
-	},
 	"app.downloads.all-sources": {
 		"message": "所有來源"
 	},
@@ -530,14 +638,107 @@
 	"app.downloads.cancel": {
 		"message": "取消"
 	},
+	"app.downloads.skip-missing-files": {
+		"message": "略過"
+	},
+	"app.downloads.complete-missing-files": {
+		"message": "補全缺失檔案"
+	},
+	"app.downloads.missing-content.header": {
+		"message": "補全缺失檔案"
+	},
+	"app.downloads.missing-content.body": {
+		"message": "本機檔案必須通過完整性驗證，才能取代實例中的目標檔案。"
+	},
+	"app.downloads.missing-content.remaining": {
+		"message": "還有 {count} 個檔案需要補全"
+	},
+	"app.downloads.missing-content.continuing": {
+		"message": "正在繼續安裝"
+	},
+	"app.downloads.missing-content.continuing-body": {
+		"message": "全部必要檔案已就緒。啟動器正在重新驗證並繼續安裝。"
+	},
+	"app.downloads.missing-content.expected-size": {
+		"message": "預期大小：{size}"
+	},
+	"app.downloads.missing-content.fallbacks": {
+		"message": "{count} 個備用連結"
+	},
+	"app.downloads.missing-content.retry": {
+		"message": "重新下載"
+	},
+	"app.downloads.missing-content.retry-all": {
+		"message": "重新嘗試全部缺失檔案"
+	},
+	"app.downloads.missing-content.browser-download": {
+		"message": "瀏覽器下載"
+	},
+	"app.downloads.missing-content.choose-file": {
+		"message": "選擇本機檔案"
+	},
+	"app.downloads.missing-content.attempts": {
+		"message": "第 {attempt}/{max} 次嘗試"
+	},
+	"app.downloads.missing-content.no-attempts": {
+		"message": "暫無嘗試資訊"
+	},
+	"app.downloads.missing-content.automatic-import": {
+		"message": "自動從監控目錄匯入"
+	},
+	"app.downloads.missing-content.automatic-import-disabled": {
+		"message": "自動匯入已關閉"
+	},
+	"app.downloads.missing-content.automatic-import-disabled-body": {
+		"message": "你仍可重新下載，或手動選擇每個缺少檔案。"
+	},
+	"app.downloads.missing-content.verifying-candidate": {
+		"message": "正在驗證下載檔案"
+	},
+	"app.downloads.missing-content.verifying-candidate-body": {
+		"message": "正在確認候選檔案是否與整合包要求的檔案一致。"
+	},
+	"app.downloads.missing-content.importing-candidate": {
+		"message": "正在匯入已驗證檔案"
+	},
+	"app.downloads.missing-content.importing-candidate-body": {
+		"message": "正在將已驗證檔案匯入實例..."
+	},
+	"app.downloads.missing-content.watching-downloads-title": {
+		"message": "正在監控匯入目錄"
+	},
+	"app.downloads.missing-content.watching-downloads-body": {
+		"message": "下載完成後將自動驗證並匯入。"
+	},
+	"app.downloads.missing-content.watching-downloads": {
+		"message": "正在監控 {path}。匹配檔案通過驗證後才會匯入。"
+	},
+	"app.downloads.missing-content.waiting-for-completion": {
+		"message": "偵測到下載檔案，正在等待寫入完成..."
+	},
+	"app.downloads.missing-content.downloads-unavailable": {
+		"message": "監控目錄無法使用，仍可手動選擇本機檔案。"
+	},
+	"app.downloads.missing-content.scanner-failed": {
+		"message": "自動檢查失敗，仍可手動選擇本機檔案。"
+	},
+	"app.downloads.missing-content.file-mismatch": {
+		"message": "發現同名候選檔案，但它不是整合包要求的檔案。"
+	},
+	"app.downloads.missing-content.file-mismatch-title": {
+		"message": "發現同名檔案，但檔案驗證未通過"
+	},
+	"app.downloads.missing-content.file-mismatch-body": {
+		"message": "啟動器會繼續等待正確檔案，你也可以手動選擇。"
+	},
+	"app.downloads.missing-content.imported-automatically": {
+		"message": "已自動匯入 {count} 個檔案，還有 {remaining} 個檔案需要補全。"
+	},
 	"app.downloads.clear-history": {
 		"message": "清除歷史紀錄"
 	},
 	"app.downloads.clear-history-title": {
 		"message": "清除下載歷史紀錄？"
-	},
-	"app.downloads.complete-missing-files": {
-		"message": "補全缺失檔案"
 	},
 	"app.downloads.confirm-clear": {
 		"message": "已完成、失敗、中斷和已取消的紀錄將被永久刪除。"
@@ -587,9 +788,6 @@
 	"app.downloads.in-progress": {
 		"message": "執行中"
 	},
-	"app.downloads.instance-deleted": {
-		"message": "實例已刪除"
-	},
 	"app.downloads.instance-target": {
 		"message": "目標實例：{instance}"
 	},
@@ -607,6 +805,9 @@
 	},
 	"app.downloads.item-status": {
 		"message": "狀態"
+	},
+	"app.downloads.manual-download-required": {
+		"message": "CurseForge 要求手動下載此檔案。"
 	},
 	"app.downloads.item-status.completed": {
 		"message": "已完成"
@@ -628,102 +829,6 @@
 	},
 	"app.downloads.local": {
 		"message": "本機"
-	},
-	"app.downloads.manual-download-required": {
-		"message": "CurseForge 要求手動下載此檔案。"
-	},
-	"app.downloads.missing-content.attempts": {
-		"message": "第 {attempt}/{max} 次嘗試"
-	},
-	"app.downloads.missing-content.automatic-import": {
-		"message": "自動從監控目錄匯入"
-	},
-	"app.downloads.missing-content.automatic-import-disabled": {
-		"message": "自動匯入已關閉"
-	},
-	"app.downloads.missing-content.automatic-import-disabled-body": {
-		"message": "你仍可重新下載，或手動選擇每個缺少檔案。"
-	},
-	"app.downloads.missing-content.body": {
-		"message": "本機檔案必須通過完整性驗證，才能取代實例中的目標檔案。"
-	},
-	"app.downloads.missing-content.browser-download": {
-		"message": "瀏覽器下載"
-	},
-	"app.downloads.missing-content.choose-file": {
-		"message": "選擇本機檔案"
-	},
-	"app.downloads.missing-content.continuing": {
-		"message": "正在繼續安裝"
-	},
-	"app.downloads.missing-content.continuing-body": {
-		"message": "全部必要檔案已就緒。啟動器正在重新驗證並繼續安裝。"
-	},
-	"app.downloads.missing-content.downloads-unavailable": {
-		"message": "監控目錄無法使用，仍可手動選擇本機檔案。"
-	},
-	"app.downloads.missing-content.expected-size": {
-		"message": "預期大小：{size}"
-	},
-	"app.downloads.missing-content.fallbacks": {
-		"message": "{count} 個備用連結"
-	},
-	"app.downloads.missing-content.file-mismatch": {
-		"message": "發現同名候選檔案，但它不是整合包要求的檔案。"
-	},
-	"app.downloads.missing-content.file-mismatch-body": {
-		"message": "啟動器會繼續等待正確檔案，你也可以手動選擇。"
-	},
-	"app.downloads.missing-content.file-mismatch-title": {
-		"message": "發現同名檔案，但檔案驗證未通過"
-	},
-	"app.downloads.missing-content.header": {
-		"message": "補全缺失檔案"
-	},
-	"app.downloads.missing-content.imported-automatically": {
-		"message": "已自動匯入 {count} 個檔案，還有 {remaining} 個檔案需要補全。"
-	},
-	"app.downloads.missing-content.importing-candidate": {
-		"message": "正在匯入已驗證檔案"
-	},
-	"app.downloads.missing-content.importing-candidate-body": {
-		"message": "正在將已驗證檔案匯入實例..."
-	},
-	"app.downloads.missing-content.no-attempts": {
-		"message": "暫無嘗試資訊"
-	},
-	"app.downloads.missing-content.remaining": {
-		"message": "還有 {count} 個檔案需要補全"
-	},
-	"app.downloads.missing-content.retry": {
-		"message": "重新下載"
-	},
-	"app.downloads.missing-content.retry-all": {
-		"message": "重新嘗試全部缺失檔案"
-	},
-	"app.downloads.missing-content.scanner-failed": {
-		"message": "自動檢查失敗，仍可手動選擇本機檔案。"
-	},
-	"app.downloads.missing-content.verifying-candidate": {
-		"message": "正在驗證下載檔案"
-	},
-	"app.downloads.missing-content.verifying-candidate-body": {
-		"message": "正在確認候選檔案是否與整合包要求的檔案一致。"
-	},
-	"app.downloads.missing-content.waiting-for-completion": {
-		"message": "偵測到下載檔案，正在等待寫入完成..."
-	},
-	"app.downloads.missing-content.watching-downloads": {
-		"message": "正在監控 {path}。匹配檔案通過驗證後才會匯入。"
-	},
-	"app.downloads.missing-content.watching-downloads-body": {
-		"message": "下載完成後將自動驗證並匯入。"
-	},
-	"app.downloads.missing-content.watching-downloads-title": {
-		"message": "正在監控匯入目錄"
-	},
-	"app.downloads.missing-required-content": {
-		"message": "已完成 {completed} / {total} 個必要檔案，還有 {missing} 個檔案需要補全。"
 	},
 	"app.downloads.more-active-requests": {
 		"message": "另有 {count} 個進行中的請求"
@@ -749,8 +854,14 @@
 	"app.downloads.open-instance": {
 		"message": "開啟實例"
 	},
+	"app.downloads.instance-deleted": {
+		"message": "實例已刪除"
+	},
 	"app.downloads.phase.downloading-content": {
 		"message": "正在下載內容"
+	},
+	"app.downloads.phase.verifying-downloaded-files": {
+		"message": "正在驗證並繼續安裝"
 	},
 	"app.downloads.phase.downloading-minecraft": {
 		"message": "正在下載 Minecraft"
@@ -788,20 +899,20 @@
 	"app.downloads.phase.running-loader-processors": {
 		"message": "正在安裝載入器"
 	},
-	"app.downloads.phase.verifying-downloaded-files": {
-		"message": "正在驗證並繼續安裝"
-	},
 	"app.downloads.progress": {
 		"message": "進度"
 	},
 	"app.downloads.retry": {
 		"message": "重試"
 	},
+	"app.downloads.action-needed": {
+		"message": "需要操作"
+	},
+	"app.downloads.missing-required-content": {
+		"message": "已完成 {completed} / {total} 個必要檔案，還有 {missing} 個檔案需要補全。"
+	},
 	"app.downloads.search": {
 		"message": "搜尋下載任務"
-	},
-	"app.downloads.skip-missing-files": {
-		"message": "略過"
 	},
 	"app.downloads.source.alternate": {
 		"message": "備用來源"
@@ -838,153 +949,6 @@
 	},
 	"app.downloads.status.waiting-for-user": {
 		"message": "需要操作"
-	},
-	"app.drop.content-installed-text": {
-		"message": "文件已安裝到實例。"
-	},
-	"app.drop.content-installed-title": {
-		"message": "內容已安裝"
-	},
-	"app.drop.error.multiple-files-text": {
-		"message": "一次只能拖放一個文件或文件夾。"
-	},
-	"app.drop.error.multiple-files-title": {
-		"message": "無法導入多個文件"
-	},
-	"app.drop.error.shortcut-text": {
-		"message": "無法解析到捷徑的目標。"
-	},
-	"app.drop.error.shortcut-title": {
-		"message": "捷徑解析失敗"
-	},
-	"app.drop.error.title": {
-		"message": "拖放錯誤"
-	},
-	"app.drop.error.unknown-depth-text": {
-		"message": "壓縮檔嵌套層級過深，無法分析。請先解壓到資料夾後重試。"
-	},
-	"app.drop.error.unknown-encrypted-text": {
-		"message": "壓縮檔包含加密檔案，無法分析。"
-	},
-	"app.drop.error.unknown-text": {
-		"message": "類型暫不支持"
-	},
-	"app.drop.error.unknown-title": {
-		"message": "未知文件類型"
-	},
-	"app.drop.extract-failed": {
-		"message": "壓縮檔解壓失敗"
-	},
-	"app.drop.import-completed-partial-text": {
-		"message": "已導入 {completed} / {total} 個實例（{failed} 個失敗）"
-	},
-	"app.drop.import-completed-text": {
-		"message": "成功導入 {count} 個實例"
-	},
-	"app.drop.import-completed-title": {
-		"message": "導入完成"
-	},
-	"app.drop.import-failed-text": {
-		"message": "導入 {name} 失敗：{error}"
-	},
-	"app.drop.import-failed-title": {
-		"message": "導入失敗"
-	},
-	"app.drop.import-progress-text": {
-		"message": "已導入 {current} / {total} 個實例"
-	},
-	"app.drop.import-progress-title": {
-		"message": "正在導入實例…"
-	},
-	"app.drop.install-failed-title": {
-		"message": "安裝失敗"
-	},
-	"app.drop.installing-file": {
-		"message": "正在安裝 {name}…"
-	},
-	"app.drop.instance-imported-text": {
-		"message": "{name} 導入成功。"
-	},
-	"app.drop.instance-imported-title": {
-		"message": "實例已導入"
-	},
-	"app.drop.mod-compatibility-title": {
-		"message": "版本不相符"
-	},
-	"app.drop.mod-compatibility-warning": {
-		"message": "{file} 的目標版本為 {modVersion}（{modLoader}），但實例的版本是 {instVersion}（{instLoader}）。"
-	},
-	"app.drop.modpack-install-failed": {
-		"message": "整合包安裝失敗"
-	},
-	"app.drop.modpack-installed-success": {
-		"message": "整合包安裝完成"
-	},
-	"app.drop.modpack-installing": {
-		"message": "正在安裝整合包..."
-	},
-	"app.drop.nested-unpack-button": {
-		"message": "繼續分析"
-	},
-	"app.drop.nested-unpack-text": {
-		"message": "此壓縮檔內含嵌套壓縮檔（{size}），需要解壓後才能分析，可能需要一些時間。是否繼續？"
-	},
-	"app.drop.nested-unpack-title": {
-		"message": "偵測到嵌套壓縮檔"
-	},
-	"app.drop.no-instances": {
-		"message": "未找到實例"
-	},
-	"app.drop.overlay-subtitle": {
-		"message": "Release to classify and import"
-	},
-	"app.drop.overlay-title": {
-		"message": "拖放以導入"
-	},
-	"app.drop.process-failed-title": {
-		"message": "處理檔案失敗"
-	},
-	"app.drop.processing": {
-		"message": "正在處理 {name}..."
-	},
-	"app.drop.scan-failed": {
-		"message": "實例掃描失敗"
-	},
-	"app.drop.scanning": {
-		"message": "正在掃描實例…"
-	},
-	"app.drop.temporary-file-text": {
-		"message": "檔案「{file}」似乎是暫存副本。請嘗試從檔案的原始位置拖入，而不是從瀏覽器、壓縮檔或雲端儲存。"
-	},
-	"app.drop.temporary-file-title": {
-		"message": "偵測到暫存檔案"
-	},
-	"app.drop.unexpected-type": {
-		"message": "意外的類型：{type}"
-	},
-	"app.drop.unknown-force-analysis-button": {
-		"message": "強力解析"
-	},
-	"app.drop.unknown-force-analysis-failed-text": {
-		"message": "深度分析後仍無法識別該檔案類型。"
-	},
-	"app.drop.unknown-force-analysis-failed-title": {
-		"message": "分析失敗"
-	},
-	"app.drop.unknown-force-analysis-text": {
-		"message": "該壓縮檔無法通過快速掃描識別，需要完整解壓後進行深度分析。此操作可能需要一些時間，是否繼續？"
-	},
-	"app.drop.unknown-force-analysis-title": {
-		"message": "無法識別檔案類型"
-	},
-	"app.drop.unknown-force-analyzing": {
-		"message": "正在強力解析壓縮檔..."
-	},
-	"app.drop.world-imported-text": {
-		"message": "存檔已成功導入。"
-	},
-	"app.drop.world-imported-title": {
-		"message": "存檔已導入"
 	},
 	"app.error.account-description": {
 		"message": "請確認登入的是正確帳號。你可能在另一個 Microsoft 帳號上擁有 Minecraft。"
@@ -1127,213 +1091,6 @@
 	"app.home.breadcrumb": {
 		"message": "首頁"
 	},
-	"app.home.calendar.next": {
-		"message": "下個月"
-	},
-	"app.home.calendar.no-activity": {
-		"message": "這一天沒有遊玩記錄。"
-	},
-	"app.home.calendar.play": {
-		"message": "啟動"
-	},
-	"app.home.calendar.played-on": {
-		"message": "{date}你遊玩了："
-	},
-	"app.home.calendar.previous": {
-		"message": "上個月"
-	},
-	"app.home.calendar.stop": {
-		"message": "停止"
-	},
-	"app.home.calendar.this-month": {
-		"message": "回到本月"
-	},
-	"app.home.calendar.title": {
-		"message": "日曆"
-	},
-	"app.home.challenge.easy": {
-		"message": "簡單"
-	},
-	"app.home.challenge.hard": {
-		"message": "困難"
-	},
-	"app.home.challenge.medium": {
-		"message": "中等"
-	},
-	"app.home.challenge.shuffle": {
-		"message": "換一個"
-	},
-	"app.home.challenge.title": {
-		"message": "每日小挑戰"
-	},
-	"app.home.greeting.afternoon": {
-		"message": "午後休息，時機正好。\n短短一局也可能很精彩。\n世界已準備好接住你的下一步。\n該去看看那座半成品建築了。\n一點探索就能走很遠。\n下一個生物群系正在呼喚。\n你的背包耐心等候很久了。\n村莊市場還沒關門。\n這一小時適合專心做個項目。\n紅石今天大概會聽話。\n你的鎬子準備開工。\n出生點外還有新路線。\n午後天生適合支線任務。\n要不要快速回世界看看？\n下一章從這裡開始。\n花一點時間，做點東西。"
-	},
-	"app.home.greeting.dawn": {
-		"message": "天剛亮，區塊正新。\n新的一天正在載入。\n日出增益已生效。\n清晨的世界總像全新的。\n先喝咖啡，再挖鑽石。\n你的基地想你一整晚了。\n從容開局，也能成就好冒險。\n主世界正在甦醒。\n新鮮空氣，新鮮資源包。\n今天很適合去探索。\n村莊已經開門交易了。\n安靜的早晨適合大工程。\n新的一天，新的坐標。\n苦力怕也不太像早起的人。\n先從小事開始，看看會去向何處。\n下一局已經準備好，等你出發。"
-	},
-	"app.home.greeting.evening": {
-		"message": "傍晚正是建造的黃金時間。\n白天將盡，世界剛剛展開。\n熟悉的世界是個好去處。\n該回到你最愛的項目了。\n從新塔上看日落更美。\n基地的燈正等著你。\n輕鬆玩一局正合適。\n村民很快要收攤了。\n你的下一座建築值得一層暮色。\n適合沒有計劃地四處走走。\n營火已經點好了。\n基地要不要再加一間房？\n地平線看起來格外誘人。\n安靜的夜晚從好世界開始。\n下一塊方塊該你放下。\n讓今晚的進度算數。"
-	},
-	"app.home.greeting.late-night": {
-		"message": "月亮還在加班。\n安靜的世界正等著你。\n夜班總能寫出好故事。\n黎明前再放一塊方塊？\n星光會看顧好你的伺服器。\n深夜時段，也能留下傳奇存檔。\n現在的火把光格外好看。\n下一場冒險還沒睡。\n午夜後的礦洞更安靜。\n和平的出生點在等你。\n耐心的建造者屬於夜晚。\n把音樂調低，把靈感調高。\n每一座好基地都從一塊方塊開始。\n終界可以等等，除非它等不了。\n短短一局也算數。\n這個世界已經為你保存好了。"
-	},
-	"app.home.greeting.minimal.afternoon": {
-		"message": "午安"
-	},
-	"app.home.greeting.minimal.dawn": {
-		"message": "清晨好"
-	},
-	"app.home.greeting.minimal.evening": {
-		"message": "傍晚好"
-	},
-	"app.home.greeting.minimal.late-night": {
-		"message": "夜深了"
-	},
-	"app.home.greeting.minimal.morning": {
-		"message": "早安"
-	},
-	"app.home.greeting.minimal.night": {
-		"message": "晚上好"
-	},
-	"app.home.greeting.minimal.with-player": {
-		"message": "{greeting}，{name}"
-	},
-	"app.home.greeting.morning": {
-		"message": "早安，冒險家。\n今天還有許多未探索的區塊。\n正適合重新開始。\n你的工具已為今天就緒。\n主世界有不少好計劃。\n造點未來的你會喜歡的東西。\n新的一局像一張乾淨畫布。\n太陽升起了，村民也是。\n讓今天多一點方塊感。\n礦井安靜得有點可疑。\n下一個項目只差一次啟動。\n好早晨，配好世界。\n總能再裝下一個新點子。\n工作台正在待命。\n地圖在等新的標記。\n坐穩，做點進度。"
-	},
-	"app.home.greeting.night": {
-		"message": "夜班準備好了。\n熟悉的世界適合這個夜晚。\n你最愛的實例就在附近。\n星星出來了，計劃也定好了。\n平靜的一局能好好結束今天。\n天黑後世界更安靜。\n該再放幾塊方塊了。\n遠處的基地正在發光。\n下一場冒險從日落開始。\n一個好存檔配得上一個好夜晚。\n不知何處，營火正噼啪作響。\n月光讓每座建築都更有戲劇感。\n明天之前來一點 Minecraft。\n你的世界隨時歡迎你回去。\n按區塊算，夜還很長。\n開始一段值得的遊戲時光吧。"
-	},
-	"app.home.greeting.with-player": {
-		"message": "{name}，{greeting}"
-	},
-	"app.home.insights.empty": {
-		"message": "開始遊玩後，這裡會顯示你的統計。"
-	},
-	"app.home.insights.streak": {
-		"message": "已連續遊玩 {days} 天"
-	},
-	"app.home.insights.this-week": {
-		"message": "本週遊玩 {duration}"
-	},
-	"app.home.insights.this-week-less": {
-		"message": "本週遊玩 {duration}（比上週少 {percent}%）"
-	},
-	"app.home.insights.this-week-more": {
-		"message": "本週遊玩 {duration}（比上週多 {percent}%）"
-	},
-	"app.home.insights.this-week-same": {
-		"message": "本週遊玩 {duration}（與上週持平）"
-	},
-	"app.home.insights.title": {
-		"message": "遊玩洞察"
-	},
-	"app.home.insights.week-top": {
-		"message": "本週常玩：{name}"
-	},
-	"app.home.instances.create": {
-		"message": "創建實例"
-	},
-	"app.home.instances.empty": {
-		"message": "還沒有實例"
-	},
-	"app.home.instances.pin": {
-		"message": "固定到首頁"
-	},
-	"app.home.instances.pinned": {
-		"message": "固定的實例"
-	},
-	"app.home.instances.pinned-empty": {
-		"message": "在實例卡片菜單或實例庫中選擇「固定到首頁」，實例就會顯示在這裡。"
-	},
-	"app.home.instances.unpin": {
-		"message": "取消固定"
-	},
-	"app.home.instances.view-all": {
-		"message": "查看全部實例"
-	},
-	"app.home.layout.switch-to-information": {
-		"message": "切換到資訊首頁"
-	},
-	"app.home.layout.switch-to-minimal": {
-		"message": "切換到極簡首頁"
-	},
-	"app.home.layout.toggle": {
-		"message": "極簡首頁"
-	},
-	"app.home.minimal.change-instance": {
-		"message": "更換首頁實例"
-	},
-	"app.home.minimal.choose-instance": {
-		"message": "選擇實例"
-	},
-	"app.home.minimal.picker.no-results": {
-		"message": "沒有匹配的實例"
-	},
-	"app.home.minimal.picker.search": {
-		"message": "搜索實例"
-	},
-	"app.home.minimal.picker.select": {
-		"message": "選擇 {name}"
-	},
-	"app.home.minimal.picker.title": {
-		"message": "選擇首頁實例"
-	},
-	"app.home.news.open-article": {
-		"message": "在 minecraft.net 上閱讀"
-	},
-	"app.home.news.title": {
-		"message": "Minecraft 新聞"
-	},
-	"app.home.playtime.hours-minutes": {
-		"message": "{hours} 小時 {minutes} 分鐘"
-	},
-	"app.home.playtime.minutes": {
-		"message": "{minutes} 分鐘"
-	},
-	"app.home.playtime.most-played": {
-		"message": "當天常玩：{name}"
-	},
-	"app.home.playtime.seconds": {
-		"message": "{seconds} 秒"
-	},
-	"app.home.playtime.sessions": {
-		"message": "成功啟動 {count} 次"
-	},
-	"app.home.recent.title": {
-		"message": "從最近的項目開始"
-	},
-	"app.home.servers.empty": {
-		"message": "將伺服器標記為收藏後，就會固定在這裡。"
-	},
-	"app.home.servers.join": {
-		"message": "加入伺服器"
-	},
-	"app.home.servers.more-options": {
-		"message": "更多選項"
-	},
-	"app.home.servers.offline": {
-		"message": "離線"
-	},
-	"app.home.servers.pinned": {
-		"message": "固定的伺服器"
-	},
-	"app.home.servers.players-online": {
-		"message": "{online}/{max} 人在線"
-	},
-	"app.home.servers.stop": {
-		"message": "停止"
-	},
-	"app.home.servers.unpin": {
-		"message": "取消固定"
-	},
-	"app.home.worlds.empty": {
-		"message": "將世界標記為收藏後，就會固定在這裡。"
-	},
-	"app.home.worlds.pinned": {
-		"message": "固定的世界"
-	},
 	"app.install.phase.downloading_content": {
 		"message": "正在下載內容"
 	},
@@ -1388,18 +1145,6 @@
 	"app.install.phase.running_loader_processors": {
 		"message": "正在執行載入器處理程式"
 	},
-	"app.instance-item.already-open": {
-		"message": "實例已經在運行"
-	},
-	"app.instance-item.loading-modpack": {
-		"message": "正在載入整合包……"
-	},
-	"app.instance-item.not-played-yet": {
-		"message": "還沒有遊玩過"
-	},
-	"app.instance-item.view-instance": {
-		"message": "查看實例"
-	},
 	"app.instance.back": {
 		"message": "返回實例"
 	},
@@ -1409,23 +1154,20 @@
 	"app.instance.confirm-delete.admonition-header": {
 		"message": "這項動作無法復原"
 	},
-	"app.instance.confirm-delete.batch-admonition-body": {
-		"message": "將永久刪除 {count, plural, other {#}} 個實例，包括存檔、設定和所有已安裝內容。"
+	"app.instance.confirm-delete.delete-button": {
+		"message": "刪除實例"
 	},
 	"app.instance.confirm-delete.batch-delete-button": {
 		"message": "刪除 {count, plural, other {#}} 個實例"
 	},
-	"app.instance.confirm-delete.batch-header": {
-		"message": "刪除實例"
-	},
-	"app.instance.confirm-delete.delete-button": {
-		"message": "刪除實例"
-	},
 	"app.instance.confirm-delete.header": {
 		"message": "刪除實例"
 	},
-	"app.instance.confirm-delete.symlink-warning": {
-		"message": "這是一個連結到「{path}」的共用實例。只會刪除連結，原始檔案不會被刪除。"
+	"app.instance.confirm-delete.batch-header": {
+		"message": "刪除實例"
+	},
+	"app.instance.confirm-delete.batch-admonition-body": {
+		"message": "將永久刪除 {count, plural, other {#}} 個實例，包括存檔、設定和所有已安裝內容。"
 	},
 	"app.instance.copy-links": {
 		"message": "複製連結"
@@ -1457,9 +1199,6 @@
 	"app.instance.icon-picker.description": {
 		"message": "選擇內建的 Minecraft 圖示，或上傳自己的圖片。"
 	},
-	"app.instance.icon-picker.icon.anvil": {
-		"message": "鐵砧"
-	},
 	"app.instance.icon-picker.icon.bread": {
 		"message": "麵包"
 	},
@@ -1484,9 +1223,6 @@
 	"app.instance.icon-picker.icon.end-stone": {
 		"message": "終界石"
 	},
-	"app.instance.icon-picker.icon.fabric": {
-		"message": "Fabric"
-	},
 	"app.instance.icon-picker.icon.furnace": {
 		"message": "熔爐"
 	},
@@ -1508,17 +1244,11 @@
 	"app.instance.icon-picker.icon.item-frame": {
 		"message": "物品展示框"
 	},
-	"app.instance.icon-picker.icon.neoforge": {
-		"message": "NeoForge"
-	},
 	"app.instance.icon-picker.icon.netherrack": {
 		"message": "地獄石"
 	},
 	"app.instance.icon-picker.icon.oak-sapling": {
 		"message": "橡木樹苗"
-	},
-	"app.instance.icon-picker.icon.quilt": {
-		"message": "Quilt"
 	},
 	"app.instance.icon-picker.icon.stone": {
 		"message": "石頭"
@@ -1528,6 +1258,18 @@
 	},
 	"app.instance.icon-picker.icon.water-bucket": {
 		"message": "水桶"
+	},
+	"app.instance.icon-picker.icon.anvil": {
+		"message": "鐵砧"
+	},
+	"app.instance.icon-picker.icon.fabric": {
+		"message": "Fabric"
+	},
+	"app.instance.icon-picker.icon.neoforge": {
+		"message": "NeoForge"
+	},
+	"app.instance.icon-picker.icon.quilt": {
+		"message": "Quilt"
 	},
 	"app.instance.icon-picker.load-error": {
 		"message": "無法載入內建圖示。"
@@ -1577,17 +1319,59 @@
 	"app.instance.mods.content-refresh-warning.title": {
 		"message": "部分線上資訊暫時無法使用"
 	},
+	"app.instance.mods.pack-member-missing": {
+		"message": "此模組包檔案在本機缺失"
+	},
+	"app.instance.mods.pack-member-removed": {
+		"message": "此模組包檔案已在本機移除"
+	},
+	"app.instance.mods.restore-pack-default": {
+		"message": "還原模組包預設檔案"
+	},
 	"app.instance.mods.content-type-project": {
 		"message": "專案"
 	},
-	"app.instance.mods.dismiss": {
-		"message": "知道了"
+	"app.instance.mods.orphaned-dependencies.body": {
+		"message": "以下前置已不再被其他內容需要，且不會被自動刪除：{list}"
 	},
-	"app.instance.mods.drag-drop-hint": {
-		"message": "釋放文件以安裝到當前實例"
+	"app.instance.mods.orphaned-dependencies.title": {
+		"message": "前置已不再被需要"
 	},
-	"app.instance.mods.file-already-exists": {
-		"message": "添加失敗，該文件可能已存在"
+	"app.instance.mods.toggle-dependencies.apply": {
+		"message": "切換相關內容"
+	},
+	"app.instance.mods.toggle-dependencies.bulk-body": {
+		"message": "切換所選內容將同時影響 {count} 個其他內容。"
+	},
+	"app.instance.mods.toggle-dependencies.selected-only": {
+		"message": "僅切換所選"
+	},
+	"app.instance.mods.toggle-dependencies.single-body": {
+		"message": "切換 {project} 將同時影響 {count} 個其他內容。"
+	},
+	"app.instance.mods.toggle-dependencies.title": {
+		"message": "確認切換"
+	},
+	"app.instance.mods.toggle-dependencies.warning": {
+		"message": "是否自動應用這些相關更改？忽略它們可能導致遊戲無法正常執行。"
+	},
+	"app.instance.mods.toggle-dependencies.will-disable": {
+		"message": "以下內容將同時禁用："
+	},
+	"app.instance.mods.toggle-dependencies.will-enable": {
+		"message": "以下內容將同時啟用："
+	},
+	"app.instance.mods.project-was-added": {
+		"message": "已新增「{name}」"
+	},
+	"app.instance.mods.projects-were-added": {
+		"message": "已新增 {count} 個專案"
+	},
+	"app.instance.mods.share-text": {
+		"message": "快來看看我在模組包中使用的專案！"
+	},
+	"app.instance.mods.share-title": {
+		"message": "分享模組包內容"
 	},
 	"app.instance.mods.missing-files-warning.body": {
 		"message": "以下模組包必要檔案未能下載或已不在本機。可逐項還原；重新整理會再次掃描實例資料夾。"
@@ -1598,41 +1382,11 @@
 	"app.instance.mods.missing-files-warning.title": {
 		"message": "模組包檔案缺失"
 	},
-	"app.instance.mods.pack-member-missing": {
-		"message": "此模組包檔案在本機缺失"
-	},
-	"app.instance.mods.pack-member-removed": {
-		"message": "此模組包檔案已在本機移除"
-	},
-	"app.instance.mods.parse-failed": {
-		"message": "解析失敗，這可能不是一個整合包"
-	},
-	"app.instance.mods.parsing-files": {
-		"message": "正在解析，較大的文件可能會耗費一些時間"
-	},
-	"app.instance.mods.project-was-added": {
-		"message": "已新增「{name}」"
-	},
-	"app.instance.mods.projects-were-added": {
-		"message": "已新增 {count} 個專案"
-	},
-	"app.instance.mods.restore-pack-default": {
-		"message": "還原模組包預設檔案"
-	},
-	"app.instance.mods.share-text": {
-		"message": "快來看看我在模組包中使用的專案！"
-	},
-	"app.instance.mods.share-title": {
-		"message": "分享模組包內容"
-	},
 	"app.instance.mods.skipped-files-warning.body": {
 		"message": "由於網路原因或依模組開發者要求，安裝過程中已略過 {count, number} 個檔案。點擊檔案名稱下載；啟動器會自動驗證設定中的監控匯入目錄。也可以把下載後的檔案拖入此實例。開啟「補全缺失檔案」對話框時，啟動器會自動檢查監聽匯入資料夾。你也可以直接將下載的檔案拖入此實例。"
 	},
 	"app.instance.mods.skipped-files-warning.body-disabled": {
 		"message": "由於網路原因或依模組開發者要求，安裝過程中已略過 {count, number} 個檔案。請把下載後的檔案拖入此實例，或在資源管理設定中開啟自動匯入。監聽資料夾自動匯入功能已關閉，你可以在設定中開啟。"
-	},
-	"app.instance.mods.skipped-files-warning.complete": {
-		"message": "補齊缺失檔案"
 	},
 	"app.instance.mods.skipped-files-warning.more": {
 		"message": "另有 {count, number} 個檔案。"
@@ -1640,14 +1394,14 @@
 	"app.instance.mods.skipped-files-warning.title": {
 		"message": "部分模組包檔案需要手動安裝"
 	},
-	"app.instance.mods.successfully-uploaded": {
-		"message": "已成功上傳"
-	},
 	"app.instance.mods.update-added-content": {
 		"message": "更新後裝內容"
 	},
 	"app.instance.mods.update-added-content.description": {
 		"message": "僅更新模組包安裝後新增的內容，不會變更模組包內建檔案。"
+	},
+	"app.instance.mods.successfully-uploaded": {
+		"message": "已成功上傳"
 	},
 	"app.instance.never-played": {
 		"message": "從未遊玩"
@@ -1751,6 +1505,9 @@
 	"app.instance.worlds.add-server": {
 		"message": "新增伺服器"
 	},
+	"app.instance.worlds.browse-maps": {
+		"message": "瀏覽地圖"
+	},
 	"app.instance.worlds.browse-servers": {
 		"message": "瀏覽伺服器"
 	},
@@ -1799,44 +1556,14 @@
 	"app.instance.worlds.search-worlds-placeholder": {
 		"message": "搜尋 {count} 個世界..."
 	},
-	"app.settings.resources.curseforge-mirror-description": {
-		"message": "CurseForge 檔案下載。"
-	},
 	"app.instances.add-content": {
 		"message": "新增內容"
-	},
-	"app.instances.batch-edit-groups.apply": {
-		"message": "套用"
-	},
-	"app.instances.batch-edit-groups.create-group": {
-		"message": "建立新分組"
-	},
-	"app.instances.batch-edit-groups.description": {
-		"message": "為 {count} 個實例設定分組"
-	},
-	"app.instances.batch-edit-groups.enter-group-name": {
-		"message": "分組名稱"
-	},
-	"app.settings.resources.source.tianpao": {
-		"message": "Tianpao 鏡像"
-	},
-	"app.settings.resources.maximum-downloads": {
-		"message": "最大同時下載數"
-	},
-	"app.instances.batch-edit-groups.header": {
-		"message": "編輯分組"
 	},
 	"app.instances.copy-path": {
 		"message": "複製路徑"
 	},
-	"app.instances.deselect-all": {
-		"message": "取消全選"
-	},
 	"app.instances.duplicate-instance": {
 		"message": "複製實例"
-	},
-	"app.instances.edit-groups": {
-		"message": "編輯分組"
 	},
 	"app.instances.group-by": {
 		"message": "分組方式："
@@ -1853,20 +1580,14 @@
 	"app.instances.group.none": {
 		"message": "無"
 	},
-	"app.instances.pin-to-home": {
-		"message": "固定到首頁"
+	"app.instances.group.ungrouped": {
+		"message": "無分組"
 	},
 	"app.instances.search": {
 		"message": "搜尋"
 	},
 	"app.instances.select": {
 		"message": "請選擇..."
-	},
-	"app.instances.select-all": {
-		"message": "全選"
-	},
-	"app.instances.selected-count": {
-		"message": "已選擇 {count} 個"
 	},
 	"app.instances.sort.date-created": {
 		"message": "建立日期"
@@ -1879,9 +1600,6 @@
 	},
 	"app.instances.sort.name": {
 		"message": "名稱"
-	},
-	"app.instances.unpin-from-home": {
-		"message": "取消固定"
 	},
 	"app.instances.view-instance": {
 		"message": "查看實例"
@@ -1931,6 +1649,81 @@
 	"app.java.select-version": {
 		"message": "選擇 Java 版本"
 	},
+	"app.java-arguments.presets.applied": {
+		"message": "已應用"
+	},
+	"app.java-arguments.presets.arguments": {
+		"message": "引數"
+	},
+	"app.java-arguments.presets.auth-group-title": {
+		"message": "Mojang認證代理"
+	},
+	"app.java-arguments.presets.auth-mirror.description": {
+		"message": "來自 Fallen-Breath 搭建的 Mojang 認證伺服器 HTTP 轉發。"
+	},
+	"app.java-arguments.presets.auth-mirror.title": {
+		"message": "映象認證服務"
+	},
+	"app.java-arguments.presets.button": {
+		"message": "引數預設"
+	},
+	"app.java-arguments.presets.collapse-group": {
+		"message": "摺疊分組"
+	},
+	"app.java-arguments.presets.expand-group": {
+		"message": "展開分組"
+	},
+	"app.java-arguments.presets.gc-group-title": {
+		"message": "記憶體回收策略 (GC)"
+	},
+	"app.java-arguments.presets.gc.auto.description": {
+		"message": "自動為你的系統選擇最佳 GC 策略"
+	},
+	"app.java-arguments.presets.gc.auto.reason-chain": {
+		"message": "決策路徑：{chain}"
+	},
+	"app.java-arguments.presets.gc.auto.resolved": {
+		"message": "已解析 → {strategy}"
+	},
+	"app.java-arguments.presets.gc.auto.title": {
+		"message": "自動GC"
+	},
+	"app.java-arguments.presets.gc.g1gc-mojang.description": {
+		"message": "接近官方的 G1GC 調優"
+	},
+	"app.java-arguments.presets.gc.g1gc-mojang.title": {
+		"message": "Mojang G1GC"
+	},
+	"app.java-arguments.presets.gc.g1gc-pcl.description": {
+		"message": "PCL 啟動器使用的 Shenandoah（adaptive）調優"
+	},
+	"app.java-arguments.presets.gc.g1gc-pcl.title": {
+		"message": "PCL"
+	},
+	"app.java-arguments.presets.gc.shenandoah.description": {
+		"message": "自適應低停頓 Shenandoah，啟用大頁記憶體（如支援）"
+	},
+	"app.java-arguments.presets.gc.shenandoah.title": {
+		"message": "Shenandoah"
+	},
+	"app.java-arguments.presets.gc.zgc.description": {
+		"message": "面向高階系統的超低延遲 GC（Java 15+）"
+	},
+	"app.java-arguments.presets.gc.zgc.title": {
+		"message": "ZGC"
+	},
+	"app.java-arguments.presets.modal-title": {
+		"message": "Java 引數預設"
+	},
+	"app.java-arguments.presets.remove": {
+		"message": "移除預設"
+	},
+	"app.java-arguments.presets.use": {
+		"message": "使用預設"
+	},
+	"app.java.test-installation": {
+		"message": "測試 Java 安裝"
+	},
 	"app.java.table.actions": {
 		"message": "操作"
 	},
@@ -1939,699 +1732,6 @@
 	},
 	"app.java.table.version": {
 		"message": "版本"
-	},
-	"app.java.test-installation": {
-		"message": "測試 Java 安裝"
-	},
-	"app.lab.category.all": {
-		"message": "全部工具"
-	},
-	"app.lab.category.creation": {
-		"message": "創作"
-	},
-	"app.lab.category.maintenance": {
-		"message": "維護"
-	},
-	"app.lab.category.world": {
-		"message": "世界"
-	},
-	"app.lab.gradient-text.adapter.bbcode": {
-		"message": "BBCode"
-	},
-	"app.lab.gradient-text.adapter.chat-colors": {
-		"message": "聊天顏色"
-	},
-	"app.lab.gradient-text.adapter.cmi": {
-		"message": "CMI"
-	},
-	"app.lab.gradient-text.adapter.csv": {
-		"message": "CSV"
-	},
-	"app.lab.gradient-text.adapter.html": {
-		"message": "HTML"
-	},
-	"app.lab.gradient-text.adapter.json": {
-		"message": "JSON 文本組件"
-	},
-	"app.lab.gradient-text.adapter.minedown": {
-		"message": "MineDown"
-	},
-	"app.lab.gradient-text.adapter.minimessage": {
-		"message": "MiniMessage"
-	},
-	"app.lab.gradient-text.adapter.minimessage-gradient": {
-		"message": "MiniMessage 漸變"
-	},
-	"app.lab.gradient-text.adapter.motd": {
-		"message": "伺服器 MOTD"
-	},
-	"app.lab.gradient-text.adapter.rosegarden-gradient": {
-		"message": "RoseGarden 漸變"
-	},
-	"app.lab.gradient-text.adapter.snbt": {
-		"message": "字串化 NBT"
-	},
-	"app.lab.gradient-text.adapter.standard": {
-		"message": "標準 HEX"
-	},
-	"app.lab.gradient-text.adapter.taboolib": {
-		"message": "TabooLib"
-	},
-	"app.lab.gradient-text.adapter.taboolib-gradient": {
-		"message": "TabooLib 漸變"
-	},
-	"app.lab.gradient-text.adapter.terraria": {
-		"message": "泰拉瑞亞"
-	},
-	"app.lab.gradient-text.adapter.trchat": {
-		"message": "TrChat"
-	},
-	"app.lab.gradient-text.adapter.vanilla": {
-		"message": "原版"
-	},
-	"app.lab.gradient-text.adapter.vanilla-compatible": {
-		"message": "原版相容"
-	},
-	"app.lab.gradient-text.colors.add": {
-		"message": "添加顏色"
-	},
-	"app.lab.gradient-text.colors.import": {
-		"message": "導入顏色"
-	},
-	"app.lab.gradient-text.colors.import-placeholder": {
-		"message": "黏貼 HEX、RGB 或 CSS 漸變"
-	},
-	"app.lab.gradient-text.colors.invalid": {
-		"message": "請至少輸入一個有效顏色。"
-	},
-	"app.lab.gradient-text.colors.move-down": {
-		"message": "下移顏色"
-	},
-	"app.lab.gradient-text.colors.move-up": {
-		"message": "上移顏色"
-	},
-	"app.lab.gradient-text.colors.randomize": {
-		"message": "隨機生成顏色"
-	},
-	"app.lab.gradient-text.colors.remove": {
-		"message": "刪除顏色"
-	},
-	"app.lab.gradient-text.colors.stops": {
-		"message": "{count} 個顏色停靠點"
-	},
-	"app.lab.gradient-text.colors.title": {
-		"message": "顏色"
-	},
-	"app.lab.gradient-text.description": {
-		"message": "無需瀏覽器即可創建適用於 Minecraft 的漸變文字。"
-	},
-	"app.lab.gradient-text.format.bold": {
-		"message": "粗體"
-	},
-	"app.lab.gradient-text.format.italic": {
-		"message": "斜體"
-	},
-	"app.lab.gradient-text.format.obfuscated": {
-		"message": "混淆"
-	},
-	"app.lab.gradient-text.format.simplify": {
-		"message": "簡化漸變標籤"
-	},
-	"app.lab.gradient-text.format.strikethrough": {
-		"message": "刪除線"
-	},
-	"app.lab.gradient-text.format.title": {
-		"message": "輸出格式"
-	},
-	"app.lab.gradient-text.format.underlined": {
-		"message": "下劃線"
-	},
-	"app.lab.gradient-text.format.vanilla-character": {
-		"message": "顏色控制符"
-	},
-	"app.lab.gradient-text.input.placeholder": {
-		"message": "在此輸入 Minecraft 文本"
-	},
-	"app.lab.gradient-text.input.title": {
-		"message": "文本"
-	},
-	"app.lab.gradient-text.output.copied": {
-		"message": "已複製輸出"
-	},
-	"app.lab.gradient-text.output.copy": {
-		"message": "複製輸出"
-	},
-	"app.lab.gradient-text.output.export": {
-		"message": "導出輸出"
-	},
-	"app.lab.gradient-text.output.title": {
-		"message": "輸出"
-	},
-	"app.lab.gradient-text.presets.apply": {
-		"message": "應用預設"
-	},
-	"app.lab.gradient-text.presets.count": {
-		"message": "已保存 {count} 個"
-	},
-	"app.lab.gradient-text.presets.delete": {
-		"message": "刪除預設"
-	},
-	"app.lab.gradient-text.presets.export": {
-		"message": "導出預設"
-	},
-	"app.lab.gradient-text.presets.import": {
-		"message": "導入預設"
-	},
-	"app.lab.gradient-text.presets.imported": {
-		"message": "已導入 {count} 個預設"
-	},
-	"app.lab.gradient-text.presets.invalid-file": {
-		"message": "該文件不包含有效預設。"
-	},
-	"app.lab.gradient-text.presets.name": {
-		"message": "預設名稱"
-	},
-	"app.lab.gradient-text.presets.save": {
-		"message": "保存預設"
-	},
-	"app.lab.gradient-text.presets.template": {
-		"message": "下載模板"
-	},
-	"app.lab.gradient-text.presets.title": {
-		"message": "預設"
-	},
-	"app.lab.gradient-text.preview.title": {
-		"message": "預覽"
-	},
-	"app.lab.gradient-text.title": {
-		"message": "漸變文字生成器"
-	},
-	"app.lab.no-results": {
-		"message": "沒有匹配的工具。"
-	},
-	"app.lab.search": {
-		"message": "搜索工具"
-	},
-	"app.lab.seed-map.add-marker": {
-		"message": "添加標記"
-	},
-	"app.lab.seed-map.approximate": {
-		"message": "估算"
-	},
-	"app.lab.seed-map.biome-group.beach": {
-		"message": "沙灘"
-	},
-	"app.lab.seed-map.biome-group.cave": {
-		"message": "洞穴"
-	},
-	"app.lab.seed-map.biome-group.desert": {
-		"message": "沙漠"
-	},
-	"app.lab.seed-map.biome-group.end": {
-		"message": "終界"
-	},
-	"app.lab.seed-map.biome-group.forest": {
-		"message": "森林"
-	},
-	"app.lab.seed-map.biome-group.ice": {
-		"message": "冰雪群系"
-	},
-	"app.lab.seed-map.biome-group.jungle": {
-		"message": "叢林"
-	},
-	"app.lab.seed-map.biome-group.mesa": {
-		"message": "惡地"
-	},
-	"app.lab.seed-map.biome-group.mountains": {
-		"message": "山地"
-	},
-	"app.lab.seed-map.biome-group.mushroom": {
-		"message": "蘑菇島"
-	},
-	"app.lab.seed-map.biome-group.nether": {
-		"message": "下界"
-	},
-	"app.lab.seed-map.biome-group.ocean": {
-		"message": "海洋"
-	},
-	"app.lab.seed-map.biome-group.plains": {
-		"message": "平原"
-	},
-	"app.lab.seed-map.biome-group.river": {
-		"message": "河流"
-	},
-	"app.lab.seed-map.biome-group.savanna": {
-		"message": "熱帶草原"
-	},
-	"app.lab.seed-map.biome-group.swamp": {
-		"message": "沼澤"
-	},
-	"app.lab.seed-map.biome-group.taiga": {
-		"message": "針葉林"
-	},
-	"app.lab.seed-map.biome-highlight": {
-		"message": "群系高亮"
-	},
-	"app.lab.seed-map.biome-selection-count": {
-		"message": "已選 {selected} / {total}"
-	},
-	"app.lab.seed-map.biome-tag": {
-		"message": "生物群系"
-	},
-	"app.lab.seed-map.center-spawn": {
-		"message": "居中顯示出生點"
-	},
-	"app.lab.seed-map.choose-biome": {
-		"message": "選擇群系"
-	},
-	"app.lab.seed-map.chunk-coordinates": {
-		"message": "區塊坐標"
-	},
-	"app.lab.seed-map.clear": {
-		"message": "清除"
-	},
-	"app.lab.seed-map.clear-history": {
-		"message": "清空歷史"
-	},
-	"app.lab.seed-map.clear-ruler": {
-		"message": "清除測距"
-	},
-	"app.lab.seed-map.close-panel": {
-		"message": "關閉面板"
-	},
-	"app.lab.seed-map.collapse-layers": {
-		"message": "收起圖層"
-	},
-	"app.lab.seed-map.completed": {
-		"message": "已完成"
-	},
-	"app.lab.seed-map.contours": {
-		"message": "等高線"
-	},
-	"app.lab.seed-map.coordinates": {
-		"message": "坐標"
-	},
-	"app.lab.seed-map.copy-teleport": {
-		"message": "複製 /tp"
-	},
-	"app.lab.seed-map.copyright.disclaimer-body": {
-		"message": "Minecraft 是 Mojang Synergies AB 的商標。Axolotl Launcher 與 Mojang 或 MinecraftSearch 均無隸屬關係，也未獲得其認可。"
-	},
-	"app.lab.seed-map.copyright.disclaimer-heading": {
-		"message": "非官方工具"
-	},
-	"app.lab.seed-map.copyright.engine-body": {
-		"message": "群系、地形、出生點與結構數據由 cubiomes 和 Axolotl 原生集成在本地生成。cubiomes 版權所有 (c) 2020 Cubitect，並依據 MIT 許可證提供。"
-	},
-	"app.lab.seed-map.copyright.engine-heading": {
-		"message": "本地地圖引擎"
-	},
-	"app.lab.seed-map.copyright.icons-body": {
-		"message": "本工具使用的部分結構與群系圖示取自 MinecraftSearch。相關圖稿的權利仍歸 MinecraftSearch 及相應創作者所有。"
-	},
-	"app.lab.seed-map.copyright.icons-heading": {
-		"message": "地圖圖稿"
-	},
-	"app.lab.seed-map.copyright.open": {
-		"message": "版權與來源說明"
-	},
-	"app.lab.seed-map.copyright.title": {
-		"message": "版權與來源說明"
-	},
-	"app.lab.seed-map.copyright.view-cubiomes": {
-		"message": "查看 cubiomes"
-	},
-	"app.lab.seed-map.copyright.visit-minecraft-search": {
-		"message": "訪問 MinecraftSearch"
-	},
-	"app.lab.seed-map.description": {
-		"message": "在本地查看 Minecraft 種子的群系、結構和保存的標記。"
-	},
-	"app.lab.seed-map.dimension": {
-		"message": "維度"
-	},
-	"app.lab.seed-map.dimension.end": {
-		"message": "終界"
-	},
-	"app.lab.seed-map.dimension.nether": {
-		"message": "下界"
-	},
-	"app.lab.seed-map.dimension.overworld": {
-		"message": "主世界"
-	},
-	"app.lab.seed-map.distance": {
-		"message": "{distance} 格"
-	},
-	"app.lab.seed-map.edition": {
-		"message": "版本類型"
-	},
-	"app.lab.seed-map.edition.java": {
-		"message": "Java 版"
-	},
-	"app.lab.seed-map.edition.java-large-biomes": {
-		"message": "Java 版：大型生物群系"
-	},
-	"app.lab.seed-map.elevation": {
-		"message": "群系高度"
-	},
-	"app.lab.seed-map.elevation-locked": {
-		"message": "開啟地形估算時自動採用估算的地表高度"
-	},
-	"app.lab.seed-map.exit-fullscreen": {
-		"message": "退出全螢幕"
-	},
-	"app.lab.seed-map.expand-layers": {
-		"message": "展開圖層"
-	},
-	"app.lab.seed-map.feature.ancient-city": {
-		"message": "遠古城市"
-	},
-	"app.lab.seed-map.feature.bastion": {
-		"message": "堡壘遺跡"
-	},
-	"app.lab.seed-map.feature.buried-treasure": {
-		"message": "埋藏的寶藏"
-	},
-	"app.lab.seed-map.feature.desert-pyramid": {
-		"message": "沙漠神殿"
-	},
-	"app.lab.seed-map.feature.desert-well": {
-		"message": "沙漠水井"
-	},
-	"app.lab.seed-map.feature.end-city": {
-		"message": "終界城"
-	},
-	"app.lab.seed-map.feature.end-city-with-ship": {
-		"message": "終界城（有終界船）"
-	},
-	"app.lab.seed-map.feature.end-city-without-ship": {
-		"message": "終界城（無終界船）"
-	},
-	"app.lab.seed-map.feature.end-gateway": {
-		"message": "終界折躍門"
-	},
-	"app.lab.seed-map.feature.fortress": {
-		"message": "下界要塞"
-	},
-	"app.lab.seed-map.feature.geode": {
-		"message": "紫晶洞"
-	},
-	"app.lab.seed-map.feature.igloo": {
-		"message": "雪屋"
-	},
-	"app.lab.seed-map.feature.jungle-temple": {
-		"message": "叢林神廟"
-	},
-	"app.lab.seed-map.feature.mansion": {
-		"message": "林地府邸"
-	},
-	"app.lab.seed-map.feature.mineshaft": {
-		"message": "廢棄礦井"
-	},
-	"app.lab.seed-map.feature.monument": {
-		"message": "海底神殿"
-	},
-	"app.lab.seed-map.feature.ocean-ruin": {
-		"message": "海底廢墟"
-	},
-	"app.lab.seed-map.feature.outpost": {
-		"message": "掠奪者前哨站"
-	},
-	"app.lab.seed-map.feature.ruined-portal": {
-		"message": "廢棄傳送門"
-	},
-	"app.lab.seed-map.feature.shipwreck": {
-		"message": "沉船"
-	},
-	"app.lab.seed-map.feature.slime-chunk": {
-		"message": "史萊姆區塊"
-	},
-	"app.lab.seed-map.feature.stronghold": {
-		"message": "要塞"
-	},
-	"app.lab.seed-map.feature.swamp-hut": {
-		"message": "沼澤小屋"
-	},
-	"app.lab.seed-map.feature.trail-ruins": {
-		"message": "古蹟廢墟"
-	},
-	"app.lab.seed-map.feature.trial-chambers": {
-		"message": "試煉密室"
-	},
-	"app.lab.seed-map.feature.village": {
-		"message": "村莊"
-	},
-	"app.lab.seed-map.fullscreen": {
-		"message": "全螢幕"
-	},
-	"app.lab.seed-map.go": {
-		"message": "前往"
-	},
-	"app.lab.seed-map.hide-layer-names": {
-		"message": "隱藏圖層名稱"
-	},
-	"app.lab.seed-map.history": {
-		"message": "種子歷史記錄"
-	},
-	"app.lab.seed-map.history-empty": {
-		"message": "查看過的種子會出現在這裡"
-	},
-	"app.lab.seed-map.history-source.manual": {
-		"message": "手動輸入"
-	},
-	"app.lab.seed-map.history-source.random": {
-		"message": "隨機種子"
-	},
-	"app.lab.seed-map.history-source.share": {
-		"message": "分享連結"
-	},
-	"app.lab.seed-map.import-from-instance": {
-		"message": "從實例導入"
-	},
-	"app.lab.seed-map.import-world.back": {
-		"message": "返回實例列表"
-	},
-	"app.lab.seed-map.import-world.choose-instance": {
-		"message": "選擇包含該世界的實例"
-	},
-	"app.lab.seed-map.import-world.choose-world": {
-		"message": "選擇一個單人世界"
-	},
-	"app.lab.seed-map.import-world.last-played": {
-		"message": "{ago}遊玩過"
-	},
-	"app.lab.seed-map.import-world.never-played": {
-		"message": "尚未遊玩"
-	},
-	"app.lab.seed-map.import-world.no-instances": {
-		"message": "未找到實例，請先安裝一個實例。"
-	},
-	"app.lab.seed-map.import-world.no-worlds": {
-		"message": "該實例還沒有單人世界。"
-	},
-	"app.lab.seed-map.import-world.title": {
-		"message": "從實例世界載入種子"
-	},
-	"app.lab.seed-map.invert-selection": {
-		"message": "反選"
-	},
-	"app.lab.seed-map.layers": {
-		"message": "地圖圖層"
-	},
-	"app.lab.seed-map.loading": {
-		"message": "載入中"
-	},
-	"app.lab.seed-map.location": {
-		"message": "位置"
-	},
-	"app.lab.seed-map.map-failed": {
-		"message": "地圖生成失敗"
-	},
-	"app.lab.seed-map.map-scale": {
-		"message": "1 像素 = {scale} 格"
-	},
-	"app.lab.seed-map.marker-color": {
-		"message": "標記顏色"
-	},
-	"app.lab.seed-map.marker-name": {
-		"message": "標記名稱"
-	},
-	"app.lab.seed-map.marker-saved": {
-		"message": "標記已保存"
-	},
-	"app.lab.seed-map.markers": {
-		"message": "標記"
-	},
-	"app.lab.seed-map.mined": {
-		"message": "已挖掘"
-	},
-	"app.lab.seed-map.mode.ores": {
-		"message": "礦物"
-	},
-	"app.lab.seed-map.mode.structures": {
-		"message": "結構"
-	},
-	"app.lab.seed-map.no-markers": {
-		"message": "暫無保存的標記"
-	},
-	"app.lab.seed-map.no-matching-biomes": {
-		"message": "沒有匹配的群系"
-	},
-	"app.lab.seed-map.no-ores-in-end": {
-		"message": "終界不支持礦物掃描"
-	},
-	"app.lab.seed-map.ore-coverage": {
-		"message": "Y {min} 到 {max}"
-	},
-	"app.lab.seed-map.ore-layers": {
-		"message": "礦物圖層"
-	},
-	"app.lab.seed-map.ore-likely": {
-		"message": "可能存在"
-	},
-	"app.lab.seed-map.ore-max-y": {
-		"message": "最高 Y"
-	},
-	"app.lab.seed-map.ore-min-y": {
-		"message": "最低 Y"
-	},
-	"app.lab.seed-map.ore-precision": {
-		"message": "精度 {precision}%"
-	},
-	"app.lab.seed-map.ore-scan-failed": {
-		"message": "礦物掃描失敗，請刷新地圖後重試。"
-	},
-	"app.lab.seed-map.ore-verified": {
-		"message": "已驗證"
-	},
-	"app.lab.seed-map.ore-y-range": {
-		"message": "Y 範圍"
-	},
-	"app.lab.seed-map.ore.coal": {
-		"message": "煤礦石"
-	},
-	"app.lab.seed-map.ore.copper": {
-		"message": "銅礦石"
-	},
-	"app.lab.seed-map.ore.copper-vein": {
-		"message": "銅礦脈"
-	},
-	"app.lab.seed-map.ore.diamond": {
-		"message": "鑽石礦石"
-	},
-	"app.lab.seed-map.ore.gold": {
-		"message": "金礦石"
-	},
-	"app.lab.seed-map.ore.iron": {
-		"message": "鐵礦石"
-	},
-	"app.lab.seed-map.ore.iron-vein": {
-		"message": "鐵礦脈"
-	},
-	"app.lab.seed-map.ore.lapis": {
-		"message": "青金石礦石"
-	},
-	"app.lab.seed-map.ore.netherite": {
-		"message": "遠古遺骸"
-	},
-	"app.lab.seed-map.ore.redstone": {
-		"message": "紅石礦石"
-	},
-	"app.lab.seed-map.ores-require-modern": {
-		"message": "礦物預測需要 Java 版 1.18 或更新版本"
-	},
-	"app.lab.seed-map.random-seed": {
-		"message": "隨機種子"
-	},
-	"app.lab.seed-map.remove-history-entry": {
-		"message": "從歷史中移除"
-	},
-	"app.lab.seed-map.remove-marker": {
-		"message": "刪除標記"
-	},
-	"app.lab.seed-map.reset": {
-		"message": "重設"
-	},
-	"app.lab.seed-map.reset-y-range": {
-		"message": "重設 Y 範圍"
-	},
-	"app.lab.seed-map.ruler": {
-		"message": "測量距離"
-	},
-	"app.lab.seed-map.scanning-ores": {
-		"message": "正在掃描礦物 {processed}/{total}"
-	},
-	"app.lab.seed-map.search-biomes": {
-		"message": "搜索群系"
-	},
-	"app.lab.seed-map.search-nearby": {
-		"message": "搜索附近"
-	},
-	"app.lab.seed-map.seed": {
-		"message": "種子"
-	},
-	"app.lab.seed-map.seed-placeholder": {
-		"message": "輸入數字或文本種子"
-	},
-	"app.lab.seed-map.select-all": {
-		"message": "全選"
-	},
-	"app.lab.seed-map.selected-biomes": {
-		"message": "已選擇 {count} 個群系"
-	},
-	"app.lab.seed-map.settings": {
-		"message": "地圖設定"
-	},
-	"app.lab.seed-map.share": {
-		"message": "複製地圖連結"
-	},
-	"app.lab.seed-map.share-copied": {
-		"message": "已複製地圖連結"
-	},
-	"app.lab.seed-map.show-grid": {
-		"message": "顯示網格"
-	},
-	"app.lab.seed-map.show-layer-names": {
-		"message": "顯示圖層名稱"
-	},
-	"app.lab.seed-map.spawn-point": {
-		"message": "出生點"
-	},
-	"app.lab.seed-map.teleport-copied": {
-		"message": "已複製傳送命令"
-	},
-	"app.lab.seed-map.terrain": {
-		"message": "地形估算"
-	},
-	"app.lab.seed-map.title": {
-		"message": "種子地圖"
-	},
-	"app.lab.seed-map.version": {
-		"message": "遊戲版本"
-	},
-	"app.lab.seed-map.world-seed-loaded": {
-		"message": "已載入世界 {world} 的種子"
-	},
-	"app.lab.seed-map.zoom-in": {
-		"message": "放大"
-	},
-	"app.lab.seed-map.zoom-out": {
-		"message": "縮小"
-	},
-	"app.lab.seed-map.zoom-to-scan-ores": {
-		"message": "放大地圖以掃描礦物"
-	},
-	"app.lab.seed-map.zoom-to-show": {
-		"message": "放大以顯示{layer}"
-	},
-	"app.lab.title": {
-		"message": "實驗室"
-	},
-	"app.lab.tool-count": {
-		"message": "{count} 個工具"
-	},
-	"app.lab.tool-count-plural": {
-		"message": "{count} 個工具"
 	},
 	"app.library.create-instance": {
 		"message": "建立新實例"
@@ -2659,36 +1759,6 @@
 	},
 	"app.library.title": {
 		"message": "實例庫"
-	},
-	"app.memory-display.available": {
-		"message": "可用 {memory}"
-	},
-	"app.memory-display.game": {
-		"message": "遊戲分配"
-	},
-	"app.memory-display.optimization-description": {
-		"message": "釋放 Windows 中未使用的工作集和待機記憶體。"
-	},
-	"app.memory-display.optimize": {
-		"message": "記憶體最佳化"
-	},
-	"app.memory-display.optimized": {
-		"message": "記憶體最佳化完成"
-	},
-	"app.memory-display.optimizing": {
-		"message": "正在最佳化……"
-	},
-	"app.memory-display.reclaimed": {
-		"message": "已釋放 {memory} 記憶體。"
-	},
-	"app.memory-display.remaining": {
-		"message": "分配後剩餘"
-	},
-	"app.memory-display.unsupported": {
-		"message": "記憶體最佳化僅支持 Windows。"
-	},
-	"app.memory-display.used": {
-		"message": "已使用記憶體"
 	},
 	"app.minecraft-auth.contact-support": {
 		"message": "聯絡支援"
@@ -2726,17 +1796,65 @@
 	"app.minecraft-auth.unknown-error": {
 		"message": "未知錯誤"
 	},
+	"app.ai-log-analysis.analyzing": {
+		"message": "正在AI分析日誌……這可能需要等待半分鐘"
+	},
+	"app.ai-log-analysis.cancel": {
+		"message": "取消"
+	},
+	"app.ai-log-analysis.close": {
+		"message": "關閉"
+	},
+	"app.ai-log-analysis.copy-link": {
+		"message": "複製連結"
+	},
+	"app.ai-log-analysis.copy-result": {
+		"message": "複製結果"
+	},
+	"app.ai-log-analysis.error": {
+		"message": "AI 分析失敗：{message}"
+	},
+	"app.ai-log-analysis.link-copied": {
+		"message": "連結已複製到剪貼簿"
+	},
+	"app.ai-log-analysis.logshare-unavailable": {
+		"message": "LogShare.CN 無法訪問，AI 分析不可用（mclo.gs 不支援 AI 分析）。{message}"
+	},
+	"app.ai-log-analysis.privacy": {
+		"message": "你的日誌內容將被上傳第三方 AI 服務進行分析, 請勿上傳包含敏感資訊的日誌。\n 感謝logshare.cn提供的日誌分享與分析服務。"
+	},
+	"app.ai-log-analysis.result-copied": {
+		"message": "分析結果已複製到剪貼簿"
+	},
+	"app.ai-log-analysis.title": {
+		"message": "AI 日誌分析"
+	},
+	"app.ai-log-analysis.upload-failed": {
+		"message": "上傳失敗，正在直接分析日誌內容（無分享連結）。"
+	},
+	"app.ai-log-analysis.uploading": {
+		"message": "正在上傳日誌……"
+	},
 	"app.minecraft-auth.warning": {
 		"message": "無法登入你的 Microsoft 帳號，原因可能是帳號限制或地區限制。"
 	},
 	"app.minecraft-auth.what-happened": {
 		"message": "我們推測的原因"
 	},
+	"app.minecraft-crash.ai-analyze": {
+		"message": "AI 分析"
+	},
+	"app.minecraft-crash.ai-unavailable": {
+		"message": "當前日誌服務（mclo.gs）不支援 AI 分析，請在設定中切換到 LogShare.CN。"
+	},
 	"app.minecraft-crash.analyzing": {
 		"message": "正在分析本次啟動留下的日誌……"
 	},
 	"app.minecraft-crash.body": {
 		"message": "尋求幫助時不要發送此窗口截圖。請導出錯誤報告，這樣對方才能同時檢查崩潰報告、遊戲日誌、除錯日誌和 JVM 資訊。"
+	},
+	"app.minecraft-crash.copy-link": {
+		"message": "複製連結"
 	},
 	"app.minecraft-crash.diagnosis.forge-java.action": {
 		"message": "可以嘗試使用此 Forge 版本所需的 Java，或更新 Forge。"
@@ -2816,11 +1934,29 @@
 	"app.minecraft-crash.launch-failure-hint": {
 		"message": "打開 Minecraft 日誌可以查看已捕獲的 Java 輸出。尋求幫助時，請導出並發送完整的 Minecraft 診斷包。"
 	},
+	"app.minecraft-crash.no-log-content": {
+		"message": "沒有找到可分享或分析的日誌內容，請確認例項中有最近幾分鐘內生成的日誌。"
+	},
 	"app.minecraft-crash.preparation-timed-out": {
 		"message": "啟動準備在 60 秒內未能完成，現已取消。請檢查 Java 路徑、啟動前命令、包裝器命令和網路連接，然後重試。"
 	},
 	"app.minecraft-crash.preview-instance": {
 		"message": "Minecraft 測試實例"
+	},
+	"app.minecraft-crash.share-copied": {
+		"message": "診斷連結已複製到剪貼簿"
+	},
+	"app.minecraft-crash.share-diagnostic": {
+		"message": "匯出分享"
+	},
+	"app.minecraft-crash.share-failed": {
+		"message": "匯出分享失敗"
+	},
+	"app.minecraft-crash.share-truncated": {
+		"message": "診斷日誌過大，已自動擷取最後 9MB 上傳。"
+	},
+	"app.minecraft-crash.sharing-diagnostic": {
+		"message": "正在匯出分享……"
 	},
 	"app.minecraft-crash.summary": {
 		"message": "Minecraft 意外停止運行。"
@@ -2879,195 +2015,6 @@
 	"app.modpack.version-supports": {
 		"message": "支援"
 	},
-	"app.multiplayer.back": {
-		"message": "返回"
-	},
-	"app.multiplayer.binary-not-found": {
-		"message": "未找到陶瓦聯機程序，請放置於："
-	},
-	"app.multiplayer.check-network": {
-		"message": "檢查網路連接"
-	},
-	"app.multiplayer.connecting": {
-		"message": "連線中..."
-	},
-	"app.multiplayer.copy-room-code": {
-		"message": "複製房間碼"
-	},
-	"app.multiplayer.disconnect": {
-		"message": "斷開連接"
-	},
-	"app.multiplayer.download-progress": {
-		"message": "下載進度"
-	},
-	"app.multiplayer.download-terracotta": {
-		"message": "下載陶瓦聯機"
-	},
-	"app.multiplayer.error.install": {
-		"message": "安裝錯誤"
-	},
-	"app.multiplayer.error.network": {
-		"message": "網路錯誤"
-	},
-	"app.multiplayer.error.os": {
-		"message": "系統錯誤"
-	},
-	"app.multiplayer.error.terracotta": {
-		"message": "陶瓦聯機錯誤"
-	},
-	"app.multiplayer.error.unknown": {
-		"message": "未知錯誤"
-	},
-	"app.multiplayer.export-error-report": {
-		"message": "匯出錯誤報告"
-	},
-	"app.multiplayer.extracting": {
-		"message": "正在解壓..."
-	},
-	"app.multiplayer.guest-label": {
-		"message": "訪客"
-	},
-	"app.multiplayer.host": {
-		"message": "創建房間"
-	},
-	"app.multiplayer.host-description": {
-		"message": "創建虛擬區域網路房間，讓好友直接連接到你的遊戲。"
-	},
-	"app.multiplayer.host-label": {
-		"message": "房主"
-	},
-	"app.multiplayer.installing": {
-		"message": "正在安裝..."
-	},
-	"app.multiplayer.join": {
-		"message": "加入房間"
-	},
-	"app.multiplayer.join-description": {
-		"message": "輸入房間碼加入好友的虛擬區域網路房間。"
-	},
-	"app.multiplayer.join-room": {
-		"message": "加入房間"
-	},
-	"app.multiplayer.lan-hint": {
-		"message": "請打開 Minecraft 進入世界，按 ESC → 對區域網路開放 → 選擇一個埠，陶瓦聯機會自動檢測。"
-	},
-	"app.multiplayer.loading": {
-		"message": "初始化中..."
-	},
-	"app.multiplayer.no-players": {
-		"message": "暫無玩家"
-	},
-	"app.multiplayer.not-running": {
-		"message": "聯機服務未運行。請創建房間或加入房間以開始聯機。"
-	},
-	"app.multiplayer.not-running-title": {
-		"message": "開始聯機會話"
-	},
-	"app.multiplayer.platform-info": {
-		"message": "當前平台：{platform}"
-	},
-	"app.multiplayer.player-name": {
-		"message": "玩家名"
-	},
-	"app.multiplayer.players": {
-		"message": "玩家"
-	},
-	"app.multiplayer.players-in-room": {
-		"message": "{count} 位玩家在房間中"
-	},
-	"app.multiplayer.powered-by-terracotta": {
-		"message": "由 Terracotta | 陶瓦聯機 強力驅動"
-	},
-	"app.multiplayer.retry": {
-		"message": "重試"
-	},
-	"app.multiplayer.room-code": {
-		"message": "房間碼"
-	},
-	"app.multiplayer.room-code-invalid": {
-		"message": "請輸入 U/XXXX-XXXX-XXXX-XXXX 格式的房間碼。"
-	},
-	"app.multiplayer.room-code-placeholder": {
-		"message": "例如 U/ABCD-EFGH-IJKL-MNOP"
-	},
-	"app.multiplayer.server-address": {
-		"message": "備用連接地址"
-	},
-	"app.multiplayer.share-code": {
-		"message": "將此代碼分享給好友："
-	},
-	"app.multiplayer.start-description": {
-		"message": "啟動聯機服務以創建房間或加入好友的房間。"
-	},
-	"app.multiplayer.start-hosting": {
-		"message": "創建房間"
-	},
-	"app.multiplayer.start-terracotta": {
-		"message": "啟動陶瓦聯機"
-	},
-	"app.multiplayer.status.downloading": {
-		"message": "下載中..."
-	},
-	"app.multiplayer.status.error": {
-		"message": "錯誤"
-	},
-	"app.multiplayer.status.fatal": {
-		"message": "嚴重錯誤"
-	},
-	"app.multiplayer.status.guest-connecting": {
-		"message": "正在加入..."
-	},
-	"app.multiplayer.status.guest-ready": {
-		"message": "已連接到房間"
-	},
-	"app.multiplayer.status.guest-starting": {
-		"message": "正在連接..."
-	},
-	"app.multiplayer.status.host-ready": {
-		"message": "房間已就緒"
-	},
-	"app.multiplayer.status.host-scanning": {
-		"message": "正在掃描..."
-	},
-	"app.multiplayer.status.host-starting": {
-		"message": "正在啟動主機..."
-	},
-	"app.multiplayer.status.idle": {
-		"message": "未連接"
-	},
-	"app.multiplayer.status.starting": {
-		"message": "啟動中..."
-	},
-	"app.multiplayer.status.waiting": {
-		"message": "等待中..."
-	},
-	"app.multiplayer.terracotta.public-node-invalid": {
-		"message": "節點 URI 無效：{node}。請使用 http、https、tcp、tls、udp、ws 或 wss。"
-	},
-	"app.multiplayer.terracotta.public-nodes": {
-		"message": "陶瓦公共節點"
-	},
-	"app.multiplayer.terracotta.public-nodes-description": {
-		"message": "每行輸入一個節點 URI。變更將在下次建立或加入房間時生效。留空則僅使用陶瓦內建節點。"
-	},
-	"app.multiplayer.terracotta.public-nodes-placeholder": {
-		"message": "wss://center.node.1tmc.top"
-	},
-	"app.multiplayer.terracotta.public-nodes-saved": {
-		"message": "陶瓦公共節點已儲存"
-	},
-	"app.multiplayer.terracotta.save-public-nodes": {
-		"message": "儲存節點"
-	},
-	"app.multiplayer.title": {
-		"message": "多人遊戲"
-	},
-	"app.multiplayer.unknown-player-role": {
-		"message": "未知身份"
-	},
-	"app.multiplayer.verifying": {
-		"message": "驗證中..."
-	},
 	"app.navigation.create-instance": {
 		"message": "建立新實例"
 	},
@@ -3077,17 +2024,14 @@
 	"app.navigation.downloads": {
 		"message": "下載"
 	},
+	"app.navigation.edit-world": {
+		"message": "編輯存檔"
+	},
 	"app.navigation.home": {
 		"message": "首頁"
 	},
-	"app.navigation.lab": {
-		"message": "實驗室"
-	},
 	"app.navigation.library": {
 		"message": "實例庫"
-	},
-	"app.navigation.multiplayer": {
-		"message": "多人遊戲"
 	},
 	"app.navigation.skin-selector": {
 		"message": "外觀選擇器"
@@ -3119,9 +2063,6 @@
 	"app.onboarding.action.click-downloads": {
 		"message": "點擊下載，繼續"
 	},
-	"app.onboarding.action.click-lab": {
-		"message": "點擊實驗室，繼續"
-	},
 	"app.onboarding.action.click-library": {
 		"message": "點擊實例庫，繼續"
 	},
@@ -3139,15 +2080,6 @@
 	},
 	"app.onboarding.action.finish-area": {
 		"message": "點擊任意位置，收工"
-	},
-	"app.onboarding.action.open-gradient-text": {
-		"message": "打開漸變文字生成器，繼續"
-	},
-	"app.onboarding.action.open-seed-map": {
-		"message": "打開種子地圖，繼續"
-	},
-	"app.onboarding.action.return-lab": {
-		"message": "點擊實驗室，查看另一個項目"
 	},
 	"app.onboarding.action.skip": {
 		"message": "先不逛了"
@@ -3173,6 +2105,12 @@
 	"app.onboarding.create.title": {
 		"message": "開個新檔"
 	},
+	"app.onboarding.creation.description": {
+		"message": "Custom setup, modpack, or import. The choices are yours; I am just here for the subtitles."
+	},
+	"app.onboarding.creation.title": {
+		"message": "選條路"
+	},
 	"app.onboarding.creation-confirm.description": {
 		"message": "這裡會按你的選擇創建實例。我堅持不替你按確認。"
 	},
@@ -3196,12 +2134,6 @@
 	},
 	"app.onboarding.creation-version.title": {
 		"message": "定下遊戲版本"
-	},
-	"app.onboarding.creation.description": {
-		"message": "Custom setup, modpack, or import. The choices are yours; I am just here for the subtitles."
-	},
-	"app.onboarding.creation.title": {
-		"message": "選條路"
 	},
 	"app.onboarding.defaults.description": {
 		"message": "新實例會繼承這些選擇，省得你每次重做作業。"
@@ -3227,12 +2159,6 @@
 	"app.onboarding.downloads.title": {
 		"message": "下載指揮室"
 	},
-	"app.onboarding.home-layout.description": {
-		"message": "隨時使用這個懸浮按鈕，在資訊首頁和極簡首頁之間切換。"
-	},
-	"app.onboarding.home-layout.title": {
-		"message": "切換資訊密度"
-	},
 	"app.onboarding.instance-actions.description": {
 		"message": "從實例頁頭部啟動、停止、修復、配置、導出或打開這個實例。"
 	},
@@ -3251,44 +2177,11 @@
 	"app.onboarding.java.title": {
 		"message": "Java，在後台"
 	},
-	"app.onboarding.lab-editor.description": {
-		"message": "編輯文本、選擇顏色、即時預覽，並複製適用於 Minecraft 配置的格式。"
-	},
-	"app.onboarding.lab-editor.title": {
-		"message": "在同一處編輯和複製"
-	},
-	"app.onboarding.lab-seed-map.description": {
-		"message": "輸入種子或從實例載入，然後在本地地圖中查看群系、結構與礦物圖層。"
-	},
-	"app.onboarding.lab-seed-map.title": {
-		"message": "載入世界前先找到它"
-	},
-	"app.onboarding.lab-tools.description": {
-		"message": "生成帶格式的漸變文字，或用本地種子地圖探索 Java 世界。"
-	},
-	"app.onboarding.lab-tools.title": {
-		"message": "首批兩個項目"
-	},
-	"app.onboarding.lab.description": {
-		"message": "實驗室將本地 Minecraft 工具放進啟動器，無需打開其他網站或註冊額外帳號。"
-	},
-	"app.onboarding.lab.title": {
-		"message": "內建的實用工具"
-	},
 	"app.onboarding.language.description": {
 		"message": "在這裡選擇啟動器語言和管理翻譯。不需要翻譯腔。"
 	},
 	"app.onboarding.language.title": {
 		"message": "說你的語言"
-	},
-	"app.settings.resources.modrinth-mirror": {
-		"message": "Modrinth"
-	},
-	"app.settings.resources.modrinth-mirror-description": {
-		"message": "Modrinth 檔案下載。"
-	},
-	"app.settings.resources.concurrency.manual": {
-		"message": "手動"
 	},
 	"app.onboarding.library-page.description": {
 		"message": "按整合包、伺服器或自訂配置篩選，再打開任意實例管理。"
@@ -3362,14 +2255,14 @@
 	"app.project.install-button.already-installed": {
 		"message": "這個專案已安裝"
 	},
-	"app.downloads.source.tianpao": {
-		"message": "Tianpao 鏡像"
-	},
 	"app.project.install-button.switch-version": {
 		"message": "切換版本"
 	},
 	"app.project.install-context.back-to-browse": {
 		"message": "返回瀏覽"
+	},
+	"app.project.install-context.back-to-instance-content": {
+		"message": "返回例項內容"
 	},
 	"app.project.install-context.install-content-to-instance": {
 		"message": "將內容安裝至實例"
@@ -3473,9 +2366,6 @@
 	"app.settings.about.preview-minecraft-crash-modal": {
 		"message": "預覽 Minecraft 崩潰窗口"
 	},
-	"app.settings.about.preview-privacy-consent-modal": {
-		"message": "預覽隱私與安全彈窗"
-	},
 	"app.settings.about.product-title": {
 		"message": "關於 {productName}"
 	},
@@ -3500,12 +2390,6 @@
 	"app.settings.about.repository": {
 		"message": "原始碼"
 	},
-	"app.settings.about.survey": {
-		"message": "調查問卷"
-	},
-	"app.settings.about.survey-description": {
-		"message": "幫助我們改進 Axolotl Launcher"
-	},
 	"app.settings.about.test-error": {
 		"message": "觸發測試錯誤"
 	},
@@ -3523,12 +2407,6 @@
 	},
 	"app.settings.about.version": {
 		"message": "版本 {version}"
-	},
-	"app.settings.defaults.automatic-memory": {
-		"message": "啟動時自動分配記憶體"
-	},
-	"app.settings.defaults.automatic-memory-description": {
-		"message": "根據可用記憶體和已安裝的模組，在每次啟動時動態調整記憶體。"
 	},
 	"app.settings.defaults.environment-variables": {
 		"message": "環境變數"
@@ -3560,8 +2438,50 @@
 	"app.settings.defaults.memory": {
 		"message": "分配記憶體"
 	},
+	"app.settings.defaults.automatic-memory": {
+		"message": "啟動時自動分配記憶體"
+	},
+	"app.settings.defaults.automatic-memory-description": {
+		"message": "根據可用記憶體和已安裝的模組，在每次啟動時動態調整記憶體。"
+	},
 	"app.settings.defaults.memory-description": {
 		"message": "分配給每個實例的記憶體。"
+	},
+	"app.settings.defaults.optimize-memory-before-launch": {
+		"message": "啟動遊戲前最佳化記憶體"
+	},
+	"app.settings.defaults.optimize-memory-before-launch-description": {
+		"message": "等待 Windows 記憶體最佳化完成後再啟動遊戲。"
+	},
+	"app.memory-display.available": {
+		"message": "可用 {memory}"
+	},
+	"app.memory-display.game": {
+		"message": "遊戲分配"
+	},
+	"app.memory-display.optimize": {
+		"message": "記憶體最佳化"
+	},
+	"app.memory-display.optimized": {
+		"message": "記憶體最佳化完成"
+	},
+	"app.memory-display.optimizing": {
+		"message": "正在最佳化……"
+	},
+	"app.memory-display.optimization-description": {
+		"message": "釋放 Windows 中未使用的工作集和待機記憶體。"
+	},
+	"app.memory-display.remaining": {
+		"message": "分配後剩餘"
+	},
+	"app.memory-display.reclaimed": {
+		"message": "已釋放 {memory} 記憶體。"
+	},
+	"app.memory-display.unsupported": {
+		"message": "記憶體最佳化僅支持 Windows。"
+	},
+	"app.memory-display.used": {
+		"message": "已使用記憶體"
 	},
 	"app.settings.defaults.post-exit-description": {
 		"message": "在遊戲關閉後執行。"
@@ -3608,6 +2528,9 @@
 	"app.settings.feature-flags.reset-to-default": {
 		"message": "恢復預設值"
 	},
+	"settings.feature-flags.title": {
+		"message": "功能開關"
+	},
 	"app.settings.java.auto-high-performance-mode": {
 		"message": "自動為 Java 使用高性能顯示卡"
 	},
@@ -3625,30 +2548,6 @@
 	},
 	"app.settings.java.download-java": {
 		"message": "下載 Java"
-	},
-	"app.settings.java.download.back": {
-		"message": "返回發行版列表"
-	},
-	"app.settings.java.download.loading": {
-		"message": "載入中……"
-	},
-	"app.settings.java.download.no-vendors": {
-		"message": "沒有可用的發行版。"
-	},
-	"app.settings.java.download.no-versions": {
-		"message": "沒有可用的版本。"
-	},
-	"app.settings.java.download.select-vendor": {
-		"message": "選擇發行版："
-	},
-	"app.settings.java.download.select-version-feed": {
-		"message": "選擇 {vendor} 的版本："
-	},
-	"app.settings.java.download.title": {
-		"message": "下載 Java"
-	},
-	"app.settings.java.download.version-label": {
-		"message": "Java {version}"
 	},
 	"app.settings.java.find-java": {
 		"message": "尋找 Java"
@@ -3677,8 +2576,8 @@
 	"app.settings.java.scanning": {
 		"message": "掃描中……"
 	},
-	"app.settings.java.table.actions": {
-		"message": ""
+	"app.settings.java.table.version": {
+		"message": "版本"
 	},
 	"app.settings.java.table.distribution": {
 		"message": "發行版"
@@ -3686,11 +2585,35 @@
 	"app.settings.java.table.path": {
 		"message": "路徑"
 	},
-	"app.settings.java.table.version": {
-		"message": "版本"
+	"app.settings.java.table.actions": {
+		"message": ""
 	},
 	"app.settings.java.view-installed": {
 		"message": "查看已安裝 Java"
+	},
+	"app.settings.java.download.select-vendor": {
+		"message": "選擇發行版："
+	},
+	"app.settings.java.download.no-vendors": {
+		"message": "沒有可用的發行版。"
+	},
+	"app.settings.java.download.select-version-feed": {
+		"message": "選擇 {vendor} 的版本："
+	},
+	"app.settings.java.download.version-label": {
+		"message": "Java {version}"
+	},
+	"app.settings.java.download.back": {
+		"message": "返回發行版列表"
+	},
+	"app.settings.java.download.loading": {
+		"message": "載入中……"
+	},
+	"app.settings.java.download.no-versions": {
+		"message": "沒有可用的版本。"
+	},
+	"app.settings.java.download.title": {
+		"message": "下載 Java"
 	},
 	"app.settings.resources.app-cache": {
 		"message": "應用程式快取"
@@ -3707,14 +2630,71 @@
 	"app.settings.resources.app-directory-description-portable": {
 		"message": "正在以便攜模式運行，所有數據已固定在程序目錄下，無法修改。"
 	},
-	"app.settings.resources.curseforge-mirror": {
-		"message": "CurseForge 服務"
-	},
 	"app.settings.resources.database-backups": {
 		"message": "應用程式資料庫備份"
 	},
 	"app.settings.resources.database-backups-description": {
 		"message": "重要應用程式的資料備份保存在這裡，以便日後需要時復原。"
+	},
+	"app.settings.resources.download-mirrors": {
+		"message": "下載來源"
+	},
+	"app.settings.resources.download-mirrors-description": {
+		"message": "為每項服務選擇下載來源。當鏡像來源請求失敗時，將自動退回至官方來源。"
+	},
+	"app.settings.resources.minecraft-metadata-source": {
+		"message": "Minecraft 元數據"
+	},
+	"app.settings.resources.minecraft-metadata-source-description": {
+		"message": "Minecraft 與受支援模組載入器的版本清單和元數據。"
+	},
+	"app.settings.resources.minecraft-file-source": {
+		"message": "Minecraft 文件、載入器與 Java"
+	},
+	"app.settings.resources.minecraft-file-source-description": {
+		"message": "遊戲文件、資源、依賴庫、模組載入器和 Java 運行時。"
+	},
+	"app.settings.resources.curseforge-mirror": {
+		"message": "CurseForge 服務"
+	},
+	"app.settings.resources.curseforge-mirror-description": {
+		"message": "CurseForge 檔案下載。"
+	},
+	"app.settings.resources.curseforge-restriction-bypass": {
+		"message": "自動下載受限的 CurseForge 檔案"
+	},
+	"app.settings.resources.curseforge-restriction-bypass-description": {
+		"message": "當 CurseForge 不提供下載地址時，根據檔案資訊推導其 CDN 地址並嘗試自動下載。關閉後將使用手動下載流程。"
+	},
+	"app.settings.resources.mojang-auth-service": {
+		"message": "Mojang 認證服務"
+	},
+	"app.settings.resources.mojang-auth-service-description": {
+		"message": "Mojang 登入、資料、皮膚、披風、會話驗證等。"
+	},
+	"app.settings.resources.concurrency.manual": {
+		"message": "手動"
+	},
+	"app.settings.resources.source.automatic": {
+		"message": "自動（推薦）"
+	},
+	"app.settings.resources.source.official-preferred": {
+		"message": "優先官方來源"
+	},
+	"app.settings.resources.source.official-only": {
+		"message": "僅原始來源（不使用鏡像）"
+	},
+	"app.settings.resources.source.open-bmcl-api": {
+		"message": "OpenBMCLAPI 鏡像"
+	},
+	"app.settings.resources.source.mojang-mirror-preferred": {
+		"message": "優先 Fallen Proxy"
+	},
+	"app.settings.resources.source.mojang-official-only": {
+		"message": "僅官方源"
+	},
+	"app.settings.resources.source.mojang-official-preferred": {
+		"message": "優先官方源"
 	},
 	"app.settings.resources.download-engine": {
 		"message": "下載引擎"
@@ -3728,11 +2708,8 @@
 	"app.settings.resources.download-engine.xmcl": {
 		"message": "XMCL 相容"
 	},
-	"app.settings.resources.download-mirrors": {
-		"message": "下載來源"
-	},
-	"app.settings.resources.download-mirrors-description": {
-		"message": "為每項服務選擇下載來源。當鏡像來源請求失敗時，將自動退回至官方來源。"
+	"app.settings.resources.maximum-downloads": {
+		"message": "最大同時下載數"
 	},
 	"app.settings.resources.maximum-downloads-description": {
 		"message": "啟動器同時下載檔案的最大數量。網路連線較差時請降低此值；變更需要重新啟動應用程式後生效。"
@@ -3742,18 +2719,6 @@
 	},
 	"app.settings.resources.maximum-writes-description": {
 		"message": "啟動器同時寫入磁碟的最大檔案數。如果經常出現 I/O 錯誤，請降低此值；變更將在重新啟動應用程式後生效。"
-	},
-	"app.settings.resources.minecraft-file-source": {
-		"message": "Minecraft 文件、載入器與 Java"
-	},
-	"app.settings.resources.minecraft-file-source-description": {
-		"message": "遊戲文件、資源、依賴庫、模組載入器和 Java 運行時。"
-	},
-	"app.settings.resources.minecraft-metadata-source": {
-		"message": "Minecraft 元數據"
-	},
-	"app.settings.resources.minecraft-metadata-source-description": {
-		"message": "Minecraft 與受支援模組載入器的版本清單和元數據。"
 	},
 	"app.settings.resources.missing-content-auto-import": {
 		"message": "自動匯入缺少的整合包檔案"
@@ -3767,6 +2732,15 @@
 	"app.settings.resources.missing-content-import-directory-description": {
 		"message": "未選擇自訂目錄時使用系統 Downloads 資料夾。不會掃描子目錄。"
 	},
+	"app.settings.resources.system-downloads-directory": {
+		"message": "系統 Downloads 資料夾"
+	},
+	"app.settings.resources.select-import-directory": {
+		"message": "選擇監控目錄"
+	},
+	"app.settings.resources.reset-import-directory": {
+		"message": "使用系統 Downloads 資料夾"
+	},
 	"app.settings.resources.open-backups-folder": {
 		"message": "開啟備份資料夾"
 	},
@@ -3779,41 +2753,8 @@
 	"app.settings.resources.purge-confirm-title": {
 		"message": "確定要清除快取嗎？"
 	},
-	"app.settings.resources.reset-import-directory": {
-		"message": "使用系統 Downloads 資料夾"
-	},
 	"app.settings.resources.select-directory": {
 		"message": "選擇新的應用程式目錄"
-	},
-	"app.settings.resources.select-import-directory": {
-		"message": "選擇監控目錄"
-	},
-	"app.settings.resources.source.automatic": {
-		"message": "自動（推薦）"
-	},
-	"app.settings.resources.source.official-only": {
-		"message": "僅原始來源（不使用鏡像）"
-	},
-	"app.settings.resources.source.official-preferred": {
-		"message": "優先官方來源"
-	},
-	"app.settings.resources.source.open-bmcl-api": {
-		"message": "OpenBMCLAPI 鏡像"
-	},
-	"app.settings.resources.system-downloads-directory": {
-		"message": "系統 Downloads 資料夾"
-	},
-	"app.settings.updates.announcements.description": {
-		"message": "查看當前版本的更新內容和歷史版本公告。"
-	},
-	"app.settings.updates.announcements.empty": {
-		"message": "當前沒有內建的更新公告。"
-	},
-	"app.settings.updates.announcements.history": {
-		"message": "歷史版本"
-	},
-	"app.settings.updates.announcements.title": {
-		"message": "更新公告"
 	},
 	"app.settings.updates.available": {
 		"message": "發現可用更新。"
@@ -3830,20 +2771,32 @@
 	"app.settings.updates.description": {
 		"message": "選擇 Axolotl 檢查啟動器更新的管道。"
 	},
+	"app.settings.updates.announcements.description": {
+		"message": "查看當前版本的更新內容和歷史版本公告。"
+	},
+	"app.settings.updates.announcements.empty": {
+		"message": "當前沒有內建的更新公告。"
+	},
+	"app.settings.updates.announcements.history": {
+		"message": "歷史版本"
+	},
+	"app.settings.updates.announcements.title": {
+		"message": "更新公告"
+	},
 	"app.settings.updates.disabled": {
 		"message": "此組建已停用更新功能。"
 	},
 	"app.settings.updates.failed": {
 		"message": "無法檢查更新。"
 	},
+	"app.settings.updates.portable": {
+		"message": "便攜模式暫時無法更新，請去GitHub手動更新。"
+	},
 	"app.settings.updates.github": {
 		"message": "GitHub 管道"
 	},
 	"app.settings.updates.offline": {
 		"message": "請連線至網際網路後再檢查更新。"
-	},
-	"app.settings.updates.portable": {
-		"message": "便攜模式暫時無法更新，請去GitHub手動更新。"
 	},
 	"app.settings.updates.preview-announcement": {
 		"message": "預覽更新公告彈出視窗"
@@ -3856,6 +2809,144 @@
 	},
 	"app.settings.updates.up-to-date": {
 		"message": "Axolotl 已是最新版本。"
+	},
+	"app.settings.logs.description": {
+		"message": "選擇用於分析和分享 Minecraft 日誌的服務。優先使用 LogShare.CN，不可用時自動回退到 mclo.gs，確保分享始終可用。"
+	},
+	"app.settings.logs.provider.auto": {
+		"message": "自動（推薦）"
+	},
+	"app.settings.groups.common": {
+		"message": "通用"
+	},
+	"app.settings.groups.minecraft": {
+		"message": "我的世界"
+	},
+	"app.settings.groups.system": {
+		"message": "系統"
+	},
+	"app.settings.groups.launcher": {
+		"message": "啟動器"
+	},
+	"app.settings.groups.game": {
+		"message": "遊戲"
+	},
+	"app.settings.groups.data-privacy": {
+		"message": "資料與隱私"
+	},
+	"app.settings.groups.support": {
+		"message": "應用與支援"
+	},
+	"app.settings.groups.developer": {
+		"message": "開發者"
+	},
+	"app.settings.tabs.appearance": {
+		"message": "外觀"
+	},
+	"app.settings.tabs.interface": {
+		"message": "介面與外觀"
+	},
+	"app.settings.tabs.home-navigation": {
+		"message": "首頁與導航"
+	},
+	"app.settings.tabs.language-translation": {
+		"message": "語言與翻譯"
+	},
+	"app.settings.tabs.java-performance": {
+		"message": "Java 與效能"
+	},
+	"app.settings.tabs.launch-defaults": {
+		"message": "啟動與例項預設值"
+	},
+	"app.settings.tabs.content-downloads": {
+		"message": "內容與下載"
+	},
+	"app.settings.tabs.network-multiplayer": {
+		"message": "網路與多人遊戲"
+	},
+	"app.settings.tabs.storage-backups": {
+		"message": "儲存與備份"
+	},
+	"app.settings.tabs.privacy-data": {
+		"message": "隱私與資料共享"
+	},
+	"app.settings.tabs.language": {
+		"message": "語言"
+	},
+	"app.settings.tabs.translation": {
+		"message": "翻譯"
+	},
+	"app.settings.tabs.ai": {
+		"message": "AI"
+	},
+	"app.settings.tabs.privacy-security": {
+		"message": "隱私與安全"
+	},
+	"app.settings.tabs.java-installations": {
+		"message": "Java 安裝"
+	},
+	"app.settings.tabs.default-instance-options": {
+		"message": "預設實例選項"
+	},
+	"app.settings.tabs.resource-management": {
+		"message": "資源管理"
+	},
+	"app.settings.tabs.multiplayer": {
+		"message": "多人聯機"
+	},
+	"app.settings.tabs.updates": {
+		"message": "更新"
+	},
+	"app.settings.tabs.about": {
+		"message": "關於"
+	},
+	"app.settings.logs.provider.auto-description": {
+		"message": "優先使用 LogShare.CN，不可用時自動切換到 mclo.gs。"
+	},
+	"app.settings.logs.provider.logshare": {
+		"message": "LogShare.CN"
+	},
+	"app.settings.logs.provider.logshare-description": {
+		"message": "使用 LogShare.CN 進行分析和分享（支援 AI 分析），不可用時回退到 mclo.gs。"
+	},
+	"app.settings.logs.provider.mclogs": {
+		"message": "mclo.gs"
+	},
+	"app.settings.logs.provider.mclogs-description": {
+		"message": "使用 mclo.gs 進行分析和分享，不支援 AI 分析。"
+	},
+	"app.settings.logs.title": {
+		"message": "日誌分析服務"
+	},
+	"app.settings.search.clear": {
+		"message": "清除設定搜尋"
+	},
+	"app.settings.search.empty": {
+		"message": "沒有與搜尋匹配的設定。"
+	},
+	"app.settings.search.placeholder": {
+		"message": "搜尋設定"
+	},
+	"app.settings.search.results": {
+		"message": "搜尋結果"
+	},
+	"app.settings.save-status.error": {
+		"message": "無法儲存"
+	},
+	"app.settings.save-status.retry": {
+		"message": "重試"
+	},
+	"app.settings.save-status.saved": {
+		"message": "已儲存"
+	},
+	"app.settings.save-status.saving": {
+		"message": "正在儲存…"
+	},
+	"app.sidebar.collapse": {
+		"message": "收起邊欄"
+	},
+	"app.sidebar.expand": {
+		"message": "展開邊欄"
 	},
 	"app.skins.add-button": {
 		"message": "新增外觀"
@@ -3938,6 +3029,18 @@
 	"app.skins.offline-account.compatibility-title": {
 		"message": "離線外觀相容性"
 	},
+	"app.skins.third-party-account.description": {
+		"message": "此帳號的外觀由其 Yggdrasil 驗證服務管理。請前往對應服務的網站更換外觀或披風。"
+	},
+	"app.skins.third-party-account.title": {
+		"message": "第三方外觀管理"
+	},
+	"app.skins.tabs.saved": {
+		"message": "已保存皮膚"
+	},
+	"app.skins.tabs.default": {
+		"message": "官方皮膚"
+	},
 	"app.skins.preview.edit-button": {
 		"message": "編輯外觀"
 	},
@@ -3992,29 +3095,17 @@
 	"app.skins.section.tiny-takeover": {
 		"message": "小鬼當家"
 	},
-	"app.skins.sign-in.axolotl-alt": {
-		"message": "Axolotl Launcher"
-	},
 	"app.skins.sign-in.button": {
 		"message": "登入"
 	},
 	"app.skins.sign-in.description": {
 		"message": "請登入你的 Minecraft 帳號以使用 Axolotl Launcher 的外觀管理功能。"
 	},
+	"app.skins.sign-in.axolotl-alt": {
+		"message": "Axolotl Launcher"
+	},
 	"app.skins.sign-in.title": {
 		"message": "請登入"
-	},
-	"app.skins.tabs.default": {
-		"message": "官方皮膚"
-	},
-	"app.skins.tabs.saved": {
-		"message": "已保存皮膚"
-	},
-	"app.skins.third-party-account.description": {
-		"message": "此帳號的外觀由其 Yggdrasil 驗證服務管理。請前往對應服務的網站更換外觀或披風。"
-	},
-	"app.skins.third-party-account.title": {
-		"message": "第三方外觀管理"
 	},
 	"app.skins.title": {
 		"message": "外觀選擇工具"
@@ -4024,30 +3115,6 @@
 	},
 	"app.splash.updating-app-directory": {
 		"message": "正在更新應用程式目錄……"
-	},
-	"app.symlink-capability.unsupported": {
-		"message": "系統不支持軟連結。"
-	},
-	"app.symlink-capability.unsupported.title": {
-		"message": "軟連結不支持"
-	},
-	"app.symlink-warning.delete.body": {
-		"message": "刪除此實例只會移除啟動器條目。「{path}」中的原始檔案將保留。"
-	},
-	"app.symlink-warning.delete.header": {
-		"message": "共享實例"
-	},
-	"app.symlink-warning.dismiss-permanently": {
-		"message": "Don"
-	},
-	"app.symlink-warning.shared-badge": {
-		"message": "共享"
-	},
-	"app.symlink-warning.write.body": {
-		"message": "此實例連結到「{path}」。此處的變更也會影響原始檔案。"
-	},
-	"app.symlink-warning.write.header": {
-		"message": "共享實例"
 	},
 	"app.translation-settings.auto-translate": {
 		"message": "自動翻譯專案頁面"
@@ -4097,8 +3164,17 @@
 	"app.translation-settings.style.background": {
 		"message": "背景色"
 	},
+	"app.translation-settings.style.blockquote": {
+		"message": "引用塊"
+	},
+	"app.translation-settings.style.blur": {
+		"message": "模糊"
+	},
 	"app.translation-settings.style.border": {
 		"message": "左邊框"
+	},
+	"app.translation-settings.style.dashed-line": {
+		"message": "虛線下劃線"
 	},
 	"app.translation-settings.style.default": {
 		"message": "預設"
@@ -4112,14 +3188,11 @@
 	"app.translation-settings.style.preview-text": {
 		"message": "在 Modrinth 上探索高品質的 Minecraft 內容。"
 	},
+	"app.translation-settings.style.text-color": {
+		"message": "文字顏色"
+	},
 	"app.translation-settings.style.weakened": {
 		"message": "弱化"
-	},
-	"app.translation-settings.system-prompt": {
-		"message": "系統提示詞"
-	},
-	"app.translation-settings.system-prompt-description": {
-		"message": "輸入你的自訂系統提示詞，留空則使用預設提示詞。"
 	},
 	"app.translation-settings.target-language": {
 		"message": "目標語言"
@@ -4223,8 +3296,335 @@
 	"app.url-install.version": {
 		"message": "正在安裝版本 {version}"
 	},
-	"app.warning.running-as-admin": {
-		"message": "Axolotl 正在以系統管理員身分執行。此模式無法拖曳匯入檔案，請以一般權限重新啟動啟動器。"
+	"app.world-editor.allow-commands.label": {
+		"message": "允許作弊"
+	},
+	"app.world-editor.badge.hardcore": {
+		"message": "極限模式"
+	},
+	"app.world-editor.badge.modded": {
+		"message": "模組存檔"
+	},
+	"app.world-editor.difficulty.easy": {
+		"message": "簡單"
+	},
+	"app.world-editor.difficulty.hard": {
+		"message": "困難"
+	},
+	"app.world-editor.difficulty.label": {
+		"message": "難度"
+	},
+	"app.world-editor.difficulty.locked-hint": {
+		"message": "（已在遊戲內鎖定）"
+	},
+	"app.world-editor.difficulty.normal": {
+		"message": "普通"
+	},
+	"app.world-editor.difficulty.peaceful": {
+		"message": "和平"
+	},
+	"app.world-editor.discard": {
+		"message": "放棄更改"
+	},
+	"app.world-editor.game-mode.label": {
+		"message": "遊戲模式"
+	},
+	"app.world-editor.game-rules.disabled": {
+		"message": "關閉"
+	},
+	"app.world-editor.game-rules.enabled": {
+		"message": "開啟"
+	},
+	"app.world-editor.game-rules.invalid-integer": {
+		"message": "該規則需要填寫整數"
+	},
+	"app.world-editor.game-rules.modified": {
+		"message": "已修改（非預設值）"
+	},
+	"app.world-editor.game-rules.no-results": {
+		"message": "沒有匹配的遊戲規則"
+	},
+	"app.world-editor.game-rules.reset-to-default": {
+		"message": "恢復預設值"
+	},
+	"app.world-editor.game-rules.search-placeholder": {
+		"message": "搜尋 {count} 條遊戲規則…"
+	},
+	"app.world-editor.gamerule-category.chat": {
+		"message": "聊天"
+	},
+	"app.world-editor.gamerule-category.commands": {
+		"message": "命令"
+	},
+	"app.world-editor.gamerule-category.drops": {
+		"message": "掉落物"
+	},
+	"app.world-editor.gamerule-category.mobs": {
+		"message": "生物"
+	},
+	"app.world-editor.gamerule-category.other": {
+		"message": "其他"
+	},
+	"app.world-editor.gamerule-category.player": {
+		"message": "玩家"
+	},
+	"app.world-editor.gamerule-category.world": {
+		"message": "世界更新"
+	},
+	"app.world-editor.gamerule.allowFireTicksAwayFromPlayer": {
+		"message": "遠離玩家的火焰蔓延"
+	},
+	"app.world-editor.gamerule.allow_entering_nether_using_portals": {
+		"message": "允許透過傳送門進入下界"
+	},
+	"app.world-editor.gamerule.announceAdvancements": {
+		"message": "進度通知"
+	},
+	"app.world-editor.gamerule.blockExplosionDropDecay": {
+		"message": "床/重生錨爆炸銷燬部分掉落物"
+	},
+	"app.world-editor.gamerule.commandBlockOutput": {
+		"message": "廣播命令方塊輸出"
+	},
+	"app.world-editor.gamerule.commandModificationBlockLimit": {
+		"message": "命令修改方塊數量上限"
+	},
+	"app.world-editor.gamerule.command_blocks_work": {
+		"message": "命令方塊生效"
+	},
+	"app.world-editor.gamerule.disableElytraMovementCheck": {
+		"message": "禁用鞘翅移動檢測"
+	},
+	"app.world-editor.gamerule.disablePlayerMovementCheck": {
+		"message": "禁用玩家移動檢測"
+	},
+	"app.world-editor.gamerule.disableRaids": {
+		"message": "禁用襲擊"
+	},
+	"app.world-editor.gamerule.doDaylightCycle": {
+		"message": "晝夜更替"
+	},
+	"app.world-editor.gamerule.doEntityDrops": {
+		"message": "非生物實體掉落"
+	},
+	"app.world-editor.gamerule.doFireTick": {
+		"message": "火焰蔓延"
+	},
+	"app.world-editor.gamerule.doImmediateRespawn": {
+		"message": "立即重生"
+	},
+	"app.world-editor.gamerule.doInsomnia": {
+		"message": "生成幻翼"
+	},
+	"app.world-editor.gamerule.doLimitedCrafting": {
+		"message": "合成需要配方"
+	},
+	"app.world-editor.gamerule.doMobLoot": {
+		"message": "生物戰利品掉落"
+	},
+	"app.world-editor.gamerule.doMobSpawning": {
+		"message": "生成生物"
+	},
+	"app.world-editor.gamerule.doPatrolSpawning": {
+		"message": "生成災厄巡邏隊"
+	},
+	"app.world-editor.gamerule.doTileDrops": {
+		"message": "方塊掉落"
+	},
+	"app.world-editor.gamerule.doTraderSpawning": {
+		"message": "生成流浪商人"
+	},
+	"app.world-editor.gamerule.doVinesSpread": {
+		"message": "藤蔓蔓延"
+	},
+	"app.world-editor.gamerule.doWardenSpawning": {
+		"message": "生成監守者"
+	},
+	"app.world-editor.gamerule.doWeatherCycle": {
+		"message": "天氣更替"
+	},
+	"app.world-editor.gamerule.drowningDamage": {
+		"message": "溺水傷害"
+	},
+	"app.world-editor.gamerule.elytra_movement_check": {
+		"message": "啟用鞘翅移動檢測"
+	},
+	"app.world-editor.gamerule.enderPearlsVanishOnDeath": {
+		"message": "死亡時擲出的末影珍珠消失"
+	},
+	"app.world-editor.gamerule.fallDamage": {
+		"message": "摔落傷害"
+	},
+	"app.world-editor.gamerule.fireDamage": {
+		"message": "火焰傷害"
+	},
+	"app.world-editor.gamerule.fire_spread_radius_around_player": {
+		"message": "玩家周圍火焰蔓延半徑"
+	},
+	"app.world-editor.gamerule.forgiveDeadPlayers": {
+		"message": "寬恕死亡玩家"
+	},
+	"app.world-editor.gamerule.freezeDamage": {
+		"message": "冰凍傷害"
+	},
+	"app.world-editor.gamerule.globalSoundEvents": {
+		"message": "全域性聲音事件"
+	},
+	"app.world-editor.gamerule.keepInventory": {
+		"message": "死亡不掉落"
+	},
+	"app.world-editor.gamerule.lavaSourceConversion": {
+		"message": "流動熔岩可轉化為熔岩源"
+	},
+	"app.world-editor.gamerule.locatorBar": {
+		"message": "玩家定位欄"
+	},
+	"app.world-editor.gamerule.logAdminCommands": {
+		"message": "通告管理員命令"
+	},
+	"app.world-editor.gamerule.maxCommandChainLength": {
+		"message": "命令連鎖執行數量上限"
+	},
+	"app.world-editor.gamerule.maxCommandForkCount": {
+		"message": "命令上下文數量上限"
+	},
+	"app.world-editor.gamerule.maxEntityCramming": {
+		"message": "實體擠壓上限"
+	},
+	"app.world-editor.gamerule.minecartMaxSpeed": {
+		"message": "礦車最大速度"
+	},
+	"app.world-editor.gamerule.mobExplosionDropDecay": {
+		"message": "生物爆炸銷燬部分掉落物"
+	},
+	"app.world-editor.gamerule.mobGriefing": {
+		"message": "生物破壞"
+	},
+	"app.world-editor.gamerule.naturalRegeneration": {
+		"message": "生命值自然恢復"
+	},
+	"app.world-editor.gamerule.player_movement_check": {
+		"message": "啟用玩家移動檢測"
+	},
+	"app.world-editor.gamerule.playersNetherPortalCreativeDelay": {
+		"message": "創造模式下界傳送門等待時間"
+	},
+	"app.world-editor.gamerule.playersNetherPortalDefaultDelay": {
+		"message": "非創造模式下界傳送門等待時間"
+	},
+	"app.world-editor.gamerule.playersSleepingPercentage": {
+		"message": "入睡佔比"
+	},
+	"app.world-editor.gamerule.projectilesCanBreakBlocks": {
+		"message": "彈射物可破壞方塊"
+	},
+	"app.world-editor.gamerule.pvp": {
+		"message": "玩家間傷害（PvP）"
+	},
+	"app.world-editor.gamerule.raids": {
+		"message": "啟用襲擊"
+	},
+	"app.world-editor.gamerule.randomTickSpeed": {
+		"message": "隨機刻速率"
+	},
+	"app.world-editor.gamerule.reducedDebugInfo": {
+		"message": "簡化除錯資訊"
+	},
+	"app.world-editor.gamerule.sendCommandFeedback": {
+		"message": "傳送命令反饋"
+	},
+	"app.world-editor.gamerule.showDeathMessages": {
+		"message": "顯示死亡訊息"
+	},
+	"app.world-editor.gamerule.snowAccumulationHeight": {
+		"message": "積雪厚度"
+	},
+	"app.world-editor.gamerule.spawnChunkRadius": {
+		"message": "出生點區塊半徑"
+	},
+	"app.world-editor.gamerule.spawnRadius": {
+		"message": "重生點半徑"
+	},
+	"app.world-editor.gamerule.spawn_monsters": {
+		"message": "生成怪物"
+	},
+	"app.world-editor.gamerule.spawner_blocks_work": {
+		"message": "刷怪籠生效"
+	},
+	"app.world-editor.gamerule.spectatorsGenerateChunks": {
+		"message": "允許旁觀者生成地形"
+	},
+	"app.world-editor.gamerule.tntExplodes": {
+		"message": "允許 TNT 爆炸"
+	},
+	"app.world-editor.gamerule.tntExplosionDropDecay": {
+		"message": "TNT 爆炸銷燬部分掉落物"
+	},
+	"app.world-editor.gamerule.universalAnger": {
+		"message": "無差別憤怒"
+	},
+	"app.world-editor.gamerule.waterSourceConversion": {
+		"message": "流動水可轉化為水源"
+	},
+	"app.world-editor.last-played": {
+		"message": "最後遊玩於 {ago}"
+	},
+	"app.world-editor.load-error": {
+		"message": "無法載入存檔"
+	},
+	"app.world-editor.locked.body": {
+		"message": "該存檔正在 Minecraft 中開啟。請先關閉該存檔，在此之前編輯器為只讀狀態。"
+	},
+	"app.world-editor.locked.heading": {
+		"message": "存檔正在使用中"
+	},
+	"app.world-editor.name.label": {
+		"message": "名稱"
+	},
+	"app.world-editor.name.placeholder": {
+		"message": "Minecraft 存檔"
+	},
+	"app.world-editor.name.required": {
+		"message": "存檔名稱不能為空"
+	},
+	"app.world-editor.reset-icon": {
+		"message": "重設圖示"
+	},
+	"app.world-editor.saved": {
+		"message": "存檔設定已儲存"
+	},
+	"app.world-editor.section.basic": {
+		"message": "基本設定"
+	},
+	"app.world-editor.section.game-rules": {
+		"message": "遊戲規則"
+	},
+	"app.world-editor.section.seed": {
+		"message": "世界種子"
+	},
+	"app.world-editor.seed.invalid": {
+		"message": "種子必須是 64 位整數範圍內的整數"
+	},
+	"app.world-editor.seed.warning-body": {
+		"message": "已生成的區塊不會重新生成，可能產生明顯的新舊地形邊界。"
+	},
+	"app.world-editor.seed.warning-heading": {
+		"message": "修改種子隻影響新地形"
+	},
+	"app.world-editor.unsaved-changes": {
+		"message": "你有未儲存的更改"
+	},
+	"app.world-editor.unsaved-modal.body": {
+		"message": "對該存檔的更改尚未儲存，離開後將會丟失。"
+	},
+	"app.world-editor.unsaved-modal.leave": {
+		"message": "放棄並離開"
+	},
+	"app.world-editor.unsaved-modal.stay": {
+		"message": "繼續編輯"
+	},
+	"app.world-editor.unsaved-modal.title": {
+		"message": "放棄未儲存的更改？"
 	},
 	"app.world.server-modal.placeholder-address": {
 		"message": "example.modrinth.gg"
@@ -4244,95 +3644,17 @@
 	"app.world.world-item.players-online": {
 		"message": "{count} 人在線上"
 	},
+	"app.worlds.install-map.invalid-project": {
+		"message": "所選專案不是 CurseForge 地圖。"
+	},
+	"app.worlds.install-map.instance-not-ready": {
+		"message": "請等待該例項安裝完成後再新增地圖。"
+	},
+	"app.worlds.install-map.unknown-instance": {
+		"message": "所選例項已不可用。"
+	},
 	"app.worlds.title": {
 		"message": "世界"
-	},
-	"create.back": {
-		"message": "返回庫"
-	},
-	"create.import.description": {
-		"message": "從其他啟動器導入實例，或安裝整合包。"
-	},
-	"create.import.title": {
-		"message": "導入已有"
-	},
-	"create.new.description": {
-		"message": "創建一個新的 Minecraft 實例，自選模組載入器。"
-	},
-	"create.new.title": {
-		"message": "全新創建"
-	},
-	"create.subtitle": {
-		"message": "實例是帶有特定載入器、遊戲版本和模組的一套 Minecraft 配置。"
-	},
-	"create.title": {
-		"message": "創建實例"
-	},
-	"drop.help.instances-desc": {
-		"message": "從其他啟動器（MultiMC、Prism Launcher等）拖放文件夾來導入 Minecraft 實例。或者拖入 HMCL、PCL、PCL-CE 的啟動器"
-	},
-	"drop.help.instances-formats": {
-		"message": "（MultiMC / Prism Launcher / PolyMC） 實例文件夾或直接放入 （HMCL / PCL / PCL-CE ）啟動器。"
-	},
-	"drop.help.instances-title": {
-		"message": "啟動器實例"
-	},
-	"drop.help.modpacks-desc": {
-		"message": "拖放整合包 ZIP/MRPACK 文件來導入整合包。"
-	},
-	"drop.help.modpacks-formats": {
-		"message": "格式：.mrpack / .zip"
-	},
-	"drop.help.modpacks-title": {
-		"message": "整合包"
-	},
-	"drop.help.mods-desc": {
-		"message": "拖放模組 JAR 文件來安裝到 Minecraft 實例。"
-	},
-	"drop.help.mods-formats": {
-		"message": "格式：.jar"
-	},
-	"drop.help.mods-title": {
-		"message": "模組"
-	},
-	"drop.help.resource-packs-desc": {
-		"message": "拖放資源包 ZIP 文件來安裝到實例。"
-	},
-	"drop.help.resource-packs-formats": {
-		"message": "格式：.zip"
-	},
-	"drop.help.resource-packs-title": {
-		"message": "資源包"
-	},
-	"drop.help.schematics-desc": {
-		"message": "拖放 .litematic 文件來導入投影。"
-	},
-	"drop.help.schematics-formats": {
-		"message": "格式：.litematic"
-	},
-	"drop.help.schematics-title": {
-		"message": "投影"
-	},
-	"drop.help.shader-packs-desc": {
-		"message": "拖放光影包 ZIP 文件來安裝到實例。"
-	},
-	"drop.help.shader-packs-formats": {
-		"message": "格式：.zip"
-	},
-	"drop.help.shader-packs-title": {
-		"message": "光影包"
-	},
-	"drop.help.title": {
-		"message": "我可以拖入什麼到 Axolotl？"
-	},
-	"drop.help.worlds-desc": {
-		"message": "拖放存檔文件夾來導入到實例。"
-	},
-	"drop.help.worlds-formats": {
-		"message": "Minecraft 存檔文件夾。"
-	},
-	"drop.help.worlds-title": {
-		"message": "存檔"
 	},
 	"friends.action.add-friend": {
 		"message": "新增好友"
@@ -4418,6 +3740,18 @@
 	"friends.sign-in-to-add-friends": {
 		"message": "<link>登入 Modrinth 帳號</link>即可新增好友並查看他們正在玩什麼！"
 	},
+	"instance.logs.delete.latest-running": {
+		"message": "實例執行時無法刪除 latest.log"
+	},
+	"instance.logs.source.live": {
+		"message": "即時日誌"
+	},
+	"instance.logs.source.numbered": {
+		"message": "日誌 {index}"
+	},
+	"instance.logs.source.unknown": {
+		"message": "未知"
+	},
 	"instance.add-server.add-and-play": {
 		"message": "新增並遊玩"
 	},
@@ -4442,20 +3776,110 @@
 	"instance.files.adding-files": {
 		"message": "正在新增檔案 ({completed}/{total})"
 	},
+	"instance.files.open-studio": {
+		"message": "開啟 Studio"
+	},
 	"instance.files.save-as": {
 		"message": "另存新檔..."
 	},
-	"instance.logs.delete.latest-running": {
-		"message": "實例執行時無法刪除 latest.log"
+	"instance.files.studio.back-to-files": {
+		"message": "退出"
 	},
-	"instance.logs.source.live": {
-		"message": "即時日誌"
+	"instance.files.studio.format": {
+		"message": "格式化"
 	},
-	"instance.logs.source.numbered": {
-		"message": "日誌 {index}"
+	"instance.files.studio.editor-loading": {
+		"message": "正在載入編輯器……"
 	},
-	"instance.logs.source.unknown": {
-		"message": "未知"
+	"instance.files.studio.empty-description": {
+		"message": "從資源管理器開啟檔案。"
+	},
+	"instance.files.studio.empty-title": {
+		"message": "選擇檔案"
+	},
+	"instance.files.studio.files": {
+		"message": "資源管理器"
+	},
+	"instance.files.studio.load-directory-failed": {
+		"message": "無法載入目錄"
+	},
+	"instance.files.studio.load-file-failed": {
+		"message": "無法開啟檔案"
+	},
+	"instance.files.studio.nbt-load-failed": {
+		"message": "無法解析 NBT 檔案"
+	},
+	"instance.files.studio.nbt.tree": {
+		"message": "樹"
+	},
+	"instance.files.studio.nbt.snbt": {
+		"message": "SNBT 模式"
+	},
+	"instance.files.studio.nbt.collapse": {
+		"message": "摺疊節點"
+	},
+	"instance.files.studio.nbt.expand": {
+		"message": "展開節點"
+	},
+	"instance.files.studio.nbt.add": {
+		"message": "新增子節點"
+	},
+	"instance.files.studio.nbt.remove": {
+		"message": "刪除節點"
+	},
+	"instance.files.studio.nbt.add-placeholder": {
+		"message": "名稱:值"
+	},
+	"instance.files.studio.not-text-file": {
+		"message": "此檔案不是文字檔案，無法在 Studio 中開啟。"
+	},
+	"instance.files.studio.non-text-file": {
+		"message": "此檔案非文字檔案，無法開啟。"
+	},
+	"instance.files.studio.open-in-system": {
+		"message": "從系統中開啟"
+	},
+	"instance.files.studio.open-path": {
+		"message": "開啟路徑"
+	},
+	"instance.files.studio.copy": {
+		"message": "複製"
+	},
+	"instance.files.studio.cut": {
+		"message": "剪下"
+	},
+	"instance.files.studio.paste": {
+		"message": "貼上"
+	},
+	"instance.files.studio.new-file": {
+		"message": "新建檔案"
+	},
+	"instance.files.studio.new-folder": {
+		"message": "新建資料夾"
+	},
+	"instance.files.studio.delete": {
+		"message": "移至回收站"
+	},
+	"instance.files.studio.create-item": {
+		"message": "新建專案"
+	},
+	"instance.files.studio.item-name": {
+		"message": "名稱"
+	},
+	"instance.files.studio.create": {
+		"message": "建立"
+	},
+	"instance.files.studio.operation-failed": {
+		"message": "檔案操作失敗"
+	},
+	"instance.files.studio.loading-file": {
+		"message": "正在載入檔案……"
+	},
+	"instance.files.studio.save-failed": {
+		"message": "無法儲存檔案"
+	},
+	"instance.files.studio.title": {
+		"message": "Studio"
 	},
 	"instance.server-modal.address": {
 		"message": "位址"
@@ -4586,9 +4010,6 @@
 	"instance.settings.tabs.java": {
 		"message": "Java 和記憶體"
 	},
-	"instance.settings.tabs.java.automatic-memory": {
-		"message": "啟動時自動分配記憶體"
-	},
 	"instance.settings.tabs.java.custom-environment-variables": {
 		"message": "自訂環境變數"
 	},
@@ -4600,6 +4021,9 @@
 	},
 	"instance.settings.tabs.java.custom-memory-allocation": {
 		"message": "自訂記憶體分配"
+	},
+	"instance.settings.tabs.java.automatic-memory": {
+		"message": "啟動時自動分配記憶體"
 	},
 	"instance.settings.tabs.java.enter-environment-variables": {
 		"message": "輸入環境變數..."
@@ -4621,6 +4045,12 @@
 	},
 	"instance.settings.tabs.java.java-path-placeholder": {
 		"message": "/path/to/java"
+	},
+	"instance.settings.tabs.java.optimize-memory-before-launch": {
+		"message": "啟動遊戲前最佳化記憶體"
+	},
+	"instance.settings.tabs.java.optimize-memory-before-launch-description": {
+		"message": "等待 Windows 記憶體最佳化完成後再啟動遊戲。"
 	},
 	"instance.settings.tabs.window": {
 		"message": "視窗"
@@ -4703,11 +4133,17 @@
 	"minecraft-account.add-third-party-account": {
 		"message": "新增第三方帳號"
 	},
+	"minecraft-account.copy-uuid": {
+		"message": "複製 UUID"
+	},
 	"minecraft-account.label": {
 		"message": "Minecraft 帳號"
 	},
 	"minecraft-account.not-signed-in": {
 		"message": "未登入"
+	},
+	"minecraft-account.official-badge": {
+		"message": "官方"
 	},
 	"minecraft-account.offline-account": {
 		"message": "Minecraft 離線帳號"
@@ -4715,11 +4151,29 @@
 	"minecraft-account.offline-badge": {
 		"message": "離線"
 	},
+	"minecraft-account.offline-modal.create": {
+		"message": "建立帳號"
+	},
 	"minecraft-account.offline-modal.chinese-username-warning": {
 		"message": "Minecraft 1.18 及以上版本可能會拒絕中文使用者名稱，導致無法進入單人世界或伺服器。請在舊版本中使用此帳號，或在新版本改用英文使用者名稱。"
 	},
-	"minecraft-account.offline-modal.create": {
-		"message": "建立帳號"
+	"minecraft-account.offline-modal.custom-uuid": {
+		"message": "自定義 UUID"
+	},
+	"minecraft-account.offline-modal.custom-uuid-duplicate": {
+		"message": "已存在使用此 UUID 的賬戶，請更換一個 UUID。"
+	},
+	"minecraft-account.offline-modal.custom-uuid-input-label": {
+		"message": "UUID 值"
+	},
+	"minecraft-account.offline-modal.custom-uuid-placeholder": {
+		"message": "00000000-0000-0000-0000-000000000000"
+	},
+	"minecraft-account.offline-modal.custom-uuid-validation": {
+		"message": "請輸入 32 位十六進位制字元，可包含連字元。"
+	},
+	"minecraft-account.offline-modal.custom-uuid-warning": {
+		"message": "如果您不瞭解這是什麼，請不要開啟此功能"
 	},
 	"minecraft-account.offline-modal.description": {
 		"message": "設定離線帳號的使用者名稱。此帳號僅能加入未啟用正版驗證的伺服器。"
@@ -4784,11 +4238,11 @@
 	"minecraft-account.third-party-modal.remember-password": {
 		"message": "在此裝置上儲存登入資訊"
 	},
-	"minecraft-account.third-party-modal.remove-saved-login": {
-		"message": "刪除已儲存的登入紀錄"
-	},
 	"minecraft-account.third-party-modal.saved-logins": {
 		"message": "已儲存的登入紀錄"
+	},
+	"minecraft-account.third-party-modal.remove-saved-login": {
+		"message": "刪除已儲存的登入紀錄"
 	},
 	"minecraft-account.third-party-modal.sign-in": {
 		"message": "登入"
@@ -4856,6 +4310,3591 @@
 	"unknown-pack-warning-modal.warning.title": {
 		"message": "未知檔案警告"
 	},
+	"app.instance.confirm-delete.symlink-warning": {
+		"message": "這是一個連結到「{path}」的共用實例。只會刪除連結，原始檔案不會被刪除。"
+	},
+	"app.symlink-warning.write.header": {
+		"message": "共享實例"
+	},
+	"app.symlink-warning.write.body": {
+		"message": "此實例連結到「{path}」。此處的變更也會影響原始檔案。"
+	},
+	"app.symlink-warning.delete.header": {
+		"message": "共享實例"
+	},
+	"app.symlink-warning.delete.body": {
+		"message": "刪除此實例只會移除啟動器條目。「{path}」中的原始檔案將保留。"
+	},
+	"app.symlink-warning.dismiss-permanently": {
+		"message": "Don"
+	},
+	"app.symlink-warning.shared-badge": {
+		"message": "共享"
+	},
+	"app.symlink-capability.unsupported": {
+		"message": "系統不支持軟連結。"
+	},
+	"app.symlink-capability.unsupported.title": {
+		"message": "軟連結不支持"
+	},
+	"app.warning.running-as-admin": {
+		"message": "Axolotl 正在以系統管理員身分執行。此模式無法拖曳匯入檔案，請以一般權限重新啟動啟動器。"
+	},
+	"drop.help.title": {
+		"message": "我可以拖入什麼到 Axolotl？"
+	},
+	"drop.help.instances-title": {
+		"message": "啟動器實例"
+	},
+	"drop.help.instances-desc": {
+		"message": "從其他啟動器（MultiMC、Prism Launcher等）拖放文件夾來導入 Minecraft 實例。或者拖入 HMCL、PCL、PCL-CE 的啟動器"
+	},
+	"drop.help.instances-formats": {
+		"message": "（MultiMC / Prism Launcher / PolyMC） 實例文件夾或直接放入 （HMCL / PCL / PCL-CE ）啟動器。"
+	},
+	"drop.help.mods-title": {
+		"message": "模組"
+	},
+	"drop.help.mods-desc": {
+		"message": "拖放模組 JAR 文件來安裝到 Minecraft 實例。"
+	},
+	"drop.help.mods-formats": {
+		"message": "格式：.jar"
+	},
+	"drop.help.modpacks-title": {
+		"message": "整合包"
+	},
+	"drop.help.modpacks-desc": {
+		"message": "拖放整合包 ZIP/MRPACK 文件來導入整合包。"
+	},
+	"drop.help.modpacks-formats": {
+		"message": "格式：.mrpack / .zip"
+	},
+	"drop.help.resource-packs-title": {
+		"message": "資源包"
+	},
+	"drop.help.resource-packs-desc": {
+		"message": "拖放資源包 ZIP 文件來安裝到實例。"
+	},
+	"drop.help.resource-packs-formats": {
+		"message": "格式：.zip"
+	},
+	"drop.help.data-packs-title": {
+		"message": "資料包"
+	},
+	"drop.help.data-packs-desc": {
+		"message": "拖放資料包 ZIP 檔案來安裝到世界的 datapacks 資料夾。"
+	},
+	"drop.help.data-packs-formats": {
+		"message": "格式：.zip"
+	},
+	"drop.help.shader-packs-title": {
+		"message": "光影包"
+	},
+	"drop.help.shader-packs-desc": {
+		"message": "拖放光影包 ZIP 文件來安裝到實例。"
+	},
+	"drop.help.shader-packs-formats": {
+		"message": "格式：.zip"
+	},
+	"drop.help.worlds-title": {
+		"message": "存檔"
+	},
+	"drop.help.worlds-desc": {
+		"message": "拖放存檔文件夾來導入到實例。"
+	},
+	"drop.help.worlds-formats": {
+		"message": "Minecraft 存檔文件夾。"
+	},
+	"drop.help.schematics-title": {
+		"message": "投影"
+	},
+	"drop.help.schematics-desc": {
+		"message": "拖放 .litematic 文件來導入投影。"
+	},
+	"drop.help.schematics-formats": {
+		"message": "格式：.litematic"
+	},
+	"create.title": {
+		"message": "創建實例"
+	},
+	"create.subtitle": {
+		"message": "實例是帶有特定載入器、遊戲版本和模組的一套 Minecraft 配置。"
+	},
+	"create.new.title": {
+		"message": "全新創建"
+	},
+	"create.new.description": {
+		"message": "創建一個新的 Minecraft 實例，自選模組載入器。"
+	},
+	"create.import.title": {
+		"message": "導入已有"
+	},
+	"create.import.description": {
+		"message": "從其他啟動器導入實例，或安裝整合包。"
+	},
+	"create.back": {
+		"message": "返回庫"
+	},
+	"app.drop.overlay-title": {
+		"message": "拖放以導入"
+	},
+	"app.drop.overlay-subtitle": {
+		"message": "Release to classify and import"
+	},
+	"app.drop.error.multiple-files-title": {
+		"message": "無法導入多個文件"
+	},
+	"app.drop.error.multiple-files-text": {
+		"message": "一次只能拖放一個文件或文件夾。"
+	},
+	"app.drop.error.shortcut-title": {
+		"message": "捷徑解析失敗"
+	},
+	"app.drop.error.shortcut-text": {
+		"message": "無法解析到捷徑的目標。"
+	},
+	"app.drop.error.unknown-title": {
+		"message": "未知文件類型"
+	},
+	"app.drop.error.unknown-text": {
+		"message": "類型暫不支持"
+	},
+	"app.drop.error.title": {
+		"message": "拖放錯誤"
+	},
+	"app.drop.world-imported-title": {
+		"message": "存檔已導入"
+	},
+	"app.drop.world-imported-text": {
+		"message": "存檔已成功導入。"
+	},
+	"app.drop.content-installed-title": {
+		"message": "內容已安裝"
+	},
+	"app.drop.content-installed-text": {
+		"message": "文件已安裝到實例。"
+	},
+	"app.drop.install-failed-title": {
+		"message": "安裝失敗"
+	},
+	"app.drop.instance-imported-title": {
+		"message": "實例已導入"
+	},
+	"app.drop.instance-imported-text": {
+		"message": "{name} 導入成功。"
+	},
+	"app.drop.import-failed-title": {
+		"message": "導入失敗"
+	},
+	"app.drop.import-failed-text": {
+		"message": "導入 {name} 失敗：{error}"
+	},
+	"app.drop.no-instances": {
+		"message": "未找到實例"
+	},
+	"app.drop.import-progress-title": {
+		"message": "正在導入實例…"
+	},
+	"app.drop.import-progress-text": {
+		"message": "已導入 {current} / {total} 個實例"
+	},
+	"app.drop.import-completed-title": {
+		"message": "導入完成"
+	},
+	"app.drop.import-completed-text": {
+		"message": "成功導入 {count} 個實例"
+	},
+	"app.drop.import-completed-partial-text": {
+		"message": "已導入 {completed} / {total} 個實例（{failed} 個失敗）"
+	},
+	"app.drop.mod-compatibility-title": {
+		"message": "版本不相符"
+	},
+	"app.drop.mod-compatibility-warning": {
+		"message": "{file} 的目標版本為 {modVersion}（{modLoader}），但實例的版本是 {instVersion}（{instLoader}）。"
+	},
+	"app.drop.unknown-force-analysis-title": {
+		"message": "無法識別檔案類型"
+	},
+	"app.drop.unknown-force-analysis-text": {
+		"message": "該壓縮檔無法通過快速掃描識別，需要完整解壓後進行深度分析。此操作可能需要一些時間，是否繼續？"
+	},
+	"app.drop.unknown-force-analysis-button": {
+		"message": "強力解析"
+	},
+	"app.drop.unknown-force-analyzing": {
+		"message": "正在強力解析壓縮檔..."
+	},
+	"app.drop.unknown-force-analysis-failed-title": {
+		"message": "分析失敗"
+	},
+	"app.drop.unknown-force-analysis-failed-text": {
+		"message": "深度分析後仍無法識別該檔案類型。"
+	},
+	"app.drop.processing": {
+		"message": "正在處理 {name}..."
+	},
+	"app.drop.modpack-installing": {
+		"message": "正在安裝整合包..."
+	},
+	"app.drop.modpack-installed-success": {
+		"message": "整合包安裝完成"
+	},
+	"app.drop.modpack-install-failed": {
+		"message": "整合包安裝失敗"
+	},
+	"app.translation-settings.system-prompt": {
+		"message": "系統提示詞"
+	},
+	"app.translation-settings.system-prompt-description": {
+		"message": "輸入你的自訂系統提示詞，留空則使用預設提示詞。"
+	},
+	"app.instance.mods.parsing-files": {
+		"message": "正在解析，較大的文件可能會耗費一些時間"
+	},
+	"app.instance.mods.drag-drop-hint": {
+		"message": "釋放文件以安裝到當前實例"
+	},
+	"app.instance.mods.parse-failed": {
+		"message": "解析失敗，這可能不是一個整合包"
+	},
+	"app.instance.mods.file-already-exists": {
+		"message": "添加失敗，該文件可能已存在"
+	},
+	"app.instance.mods.dismiss": {
+		"message": "知道了"
+	},
+	"app.lab.gradient-text.colors.add": {
+		"message": "添加顏色"
+	},
+	"app.lab.gradient-text.colors.import": {
+		"message": "導入顏色"
+	},
+	"app.lab.gradient-text.colors.import-placeholder": {
+		"message": "黏貼 HEX、RGB 或 CSS 漸變"
+	},
+	"app.lab.gradient-text.colors.invalid": {
+		"message": "請至少輸入一個有效顏色。"
+	},
+	"app.lab.gradient-text.colors.move-down": {
+		"message": "下移顏色"
+	},
+	"app.lab.gradient-text.colors.move-up": {
+		"message": "上移顏色"
+	},
+	"app.lab.gradient-text.colors.remove": {
+		"message": "刪除顏色"
+	},
+	"app.lab.gradient-text.colors.randomize": {
+		"message": "隨機生成顏色"
+	},
+	"app.lab.gradient-text.colors.title": {
+		"message": "顏色"
+	},
+	"app.lab.gradient-text.colors.stops": {
+		"message": "{count} 個顏色停靠點"
+	},
+	"app.lab.gradient-text.adapter.vanilla": {
+		"message": "原版"
+	},
+	"app.lab.gradient-text.adapter.vanilla-compatible": {
+		"message": "原版相容"
+	},
+	"app.lab.gradient-text.adapter.standard": {
+		"message": "標準 HEX"
+	},
+	"app.lab.gradient-text.adapter.cmi": {
+		"message": "CMI"
+	},
+	"app.lab.gradient-text.adapter.minimessage": {
+		"message": "MiniMessage"
+	},
+	"app.lab.gradient-text.adapter.minimessage-gradient": {
+		"message": "MiniMessage 漸變"
+	},
+	"app.lab.gradient-text.adapter.minedown": {
+		"message": "MineDown"
+	},
+	"app.lab.gradient-text.adapter.snbt": {
+		"message": "字串化 NBT"
+	},
+	"app.lab.gradient-text.adapter.trchat": {
+		"message": "TrChat"
+	},
+	"app.lab.gradient-text.adapter.taboolib": {
+		"message": "TabooLib"
+	},
+	"app.lab.gradient-text.adapter.taboolib-gradient": {
+		"message": "TabooLib 漸變"
+	},
+	"app.lab.gradient-text.adapter.rosegarden-gradient": {
+		"message": "RoseGarden 漸變"
+	},
+	"app.lab.gradient-text.adapter.chat-colors": {
+		"message": "聊天顏色"
+	},
+	"app.lab.gradient-text.adapter.motd": {
+		"message": "伺服器 MOTD"
+	},
+	"app.lab.gradient-text.adapter.bbcode": {
+		"message": "BBCode"
+	},
+	"app.lab.gradient-text.adapter.json": {
+		"message": "JSON 文本組件"
+	},
+	"app.lab.gradient-text.adapter.html": {
+		"message": "HTML"
+	},
+	"app.lab.gradient-text.adapter.csv": {
+		"message": "CSV"
+	},
+	"app.lab.gradient-text.adapter.terraria": {
+		"message": "泰拉瑞亞"
+	},
+	"app.lab.gradient-text.format.bold": {
+		"message": "粗體"
+	},
+	"app.lab.gradient-text.format.italic": {
+		"message": "斜體"
+	},
+	"app.lab.gradient-text.format.obfuscated": {
+		"message": "混淆"
+	},
+	"app.lab.gradient-text.format.simplify": {
+		"message": "簡化漸變標籤"
+	},
+	"app.lab.gradient-text.format.strikethrough": {
+		"message": "刪除線"
+	},
+	"app.lab.gradient-text.format.title": {
+		"message": "輸出格式"
+	},
+	"app.lab.gradient-text.format.underlined": {
+		"message": "下劃線"
+	},
+	"app.lab.gradient-text.format.vanilla-character": {
+		"message": "顏色控制符"
+	},
+	"app.lab.gradient-text.input.placeholder": {
+		"message": "在此輸入 Minecraft 文本"
+	},
+	"app.lab.gradient-text.input.title": {
+		"message": "文本"
+	},
+	"app.lab.gradient-text.output.copy": {
+		"message": "複製輸出"
+	},
+	"app.lab.gradient-text.output.copied": {
+		"message": "已複製輸出"
+	},
+	"app.lab.gradient-text.output.export": {
+		"message": "導出輸出"
+	},
+	"app.lab.gradient-text.output.title": {
+		"message": "輸出"
+	},
+	"app.lab.gradient-text.preview.title": {
+		"message": "預覽"
+	},
+	"app.lab.gradient-text.presets.delete": {
+		"message": "刪除預設"
+	},
+	"app.lab.gradient-text.presets.export": {
+		"message": "導出預設"
+	},
+	"app.lab.gradient-text.presets.import": {
+		"message": "導入預設"
+	},
+	"app.lab.gradient-text.presets.imported": {
+		"message": "已導入 {count} 個預設"
+	},
+	"app.lab.gradient-text.presets.invalid-file": {
+		"message": "該文件不包含有效預設。"
+	},
+	"app.lab.gradient-text.presets.name": {
+		"message": "預設名稱"
+	},
+	"app.lab.gradient-text.presets.count": {
+		"message": "已保存 {count} 個"
+	},
+	"app.lab.gradient-text.presets.save": {
+		"message": "保存預設"
+	},
+	"app.lab.gradient-text.presets.template": {
+		"message": "下載模板"
+	},
+	"app.lab.gradient-text.presets.title": {
+		"message": "預設"
+	},
+	"app.lab.gradient-text.presets.apply": {
+		"message": "應用預設"
+	},
+	"app.lab.gradient-text.title": {
+		"message": "漸變文字生成器"
+	},
+	"app.lab.gradient-text.description": {
+		"message": "無需瀏覽器即可創建適用於 Minecraft 的漸變文字。"
+	},
+	"app.lab.recipe-generator.cancel": {
+		"message": "取消"
+	},
+	"app.lab.recipe-generator.category.blocks": {
+		"message": "方塊"
+	},
+	"app.lab.recipe-generator.category.building": {
+		"message": "建築"
+	},
+	"app.lab.recipe-generator.category.equipment": {
+		"message": "裝備"
+	},
+	"app.lab.recipe-generator.category.food": {
+		"message": "食物"
+	},
+	"app.lab.recipe-generator.category.misc": {
+		"message": "雜項"
+	},
+	"app.lab.recipe-generator.category.redstone": {
+		"message": "紅石"
+	},
+	"app.lab.recipe-generator.copyright.disclaimer-body": {
+		"message": "Minecraft 素材版權歸 Mojang Studios / Microsoft 所有，僅用於識別相容的遊戲內容。Axolotl Launcher 與 Mojang Studios 或 Microsoft 無關聯，也未獲得其認可。"
+	},
+	"app.lab.recipe-generator.copyright.disclaimer-heading": {
+		"message": "非官方工具"
+	},
+	"app.lab.recipe-generator.copyright.open": {
+		"message": "版權與來源"
+	},
+	"app.lab.recipe-generator.copyright.tags-body": {
+		"message": "擴充套件物品標籤來自 destruc7i0n 的 crafting generator，採用 MIT 許可證。"
+	},
+	"app.lab.recipe-generator.copyright.tags-heading": {
+		"message": "原版標籤"
+	},
+	"app.lab.recipe-generator.copyright.textures-body": {
+		"message": "物品識別符號、可讀名稱和圖示來自 destruc7i0n 的 minecraft-textures，採用 GNU General Public License v3。"
+	},
+	"app.lab.recipe-generator.copyright.textures-heading": {
+		"message": "物品紋理與後設資料"
+	},
+	"app.lab.recipe-generator.copyright.title": {
+		"message": "版權與來源"
+	},
+	"app.lab.recipe-generator.copyright.view-tags": {
+		"message": "檢視原版標籤"
+	},
+	"app.lab.recipe-generator.copyright.view-textures": {
+		"message": "檢視 minecraft-textures"
+	},
+	"app.lab.recipe-generator.description": {
+		"message": "輕易地修改合成表，自定義配方，生成資料包。"
+	},
+	"app.lab.recipe-generator.instance-export.back": {
+		"message": "返回例項列表"
+	},
+	"app.lab.recipe-generator.instance-export.choose-instance": {
+		"message": "選擇包含世界的例項"
+	},
+	"app.lab.recipe-generator.instance-export.choose-world": {
+		"message": "選擇單機世界"
+	},
+	"app.lab.recipe-generator.instance-export.install-world": {
+		"message": "將資料包安裝到 {name}"
+	},
+	"app.lab.recipe-generator.instance-export.last-played": {
+		"message": "{ago}遊玩過"
+	},
+	"app.lab.recipe-generator.instance-export.never-played": {
+		"message": "尚未遊玩"
+	},
+	"app.lab.recipe-generator.instance-export.no-instances": {
+		"message": "沒有可用的已安裝例項。"
+	},
+	"app.lab.recipe-generator.instance-export.no-worlds": {
+		"message": "該例項還沒有單機世界。"
+	},
+	"app.lab.recipe-generator.instance-export.save-as": {
+		"message": "另存為"
+	},
+	"app.lab.recipe-generator.instance-export.title": {
+		"message": "將資料包安裝到世界"
+	},
+	"app.lab.recipe-generator.items.add": {
+		"message": "新增到配方"
+	},
+	"app.lab.recipe-generator.items.add-custom": {
+		"message": "新增自定義物品"
+	},
+	"app.lab.recipe-generator.items.custom-deleted": {
+		"message": "已刪除自定義物品"
+	},
+	"app.lab.recipe-generator.items.custom-id": {
+		"message": "物品 ID"
+	},
+	"app.lab.recipe-generator.items.custom-id-placeholder": {
+		"message": "minecraft:item_id（示例）"
+	},
+	"app.lab.recipe-generator.items.custom-name": {
+		"message": "顯示名稱"
+	},
+	"app.lab.recipe-generator.items.custom-saved": {
+		"message": "已儲存自定義物品"
+	},
+	"app.lab.recipe-generator.items.custom-texture": {
+		"message": "紋理 URL"
+	},
+	"app.lab.recipe-generator.items.custom-texture-placeholder": {
+		"message": "https://example.com/texture.png（示例）"
+	},
+	"app.lab.recipe-generator.items.custom-title": {
+		"message": "自定義物品"
+	},
+	"app.lab.recipe-generator.items.delete-custom": {
+		"message": "刪除自定義物品"
+	},
+	"app.lab.recipe-generator.items.edit-custom": {
+		"message": "編輯自定義物品"
+	},
+	"app.lab.recipe-generator.items.edit-custom-action": {
+		"message": "編輯自定義物品"
+	},
+	"app.lab.recipe-generator.items.empty": {
+		"message": "沒有匹配搜尋的物品。"
+	},
+	"app.lab.recipe-generator.items.invalid-custom": {
+		"message": "請輸入物品 ID。"
+	},
+	"app.lab.recipe-generator.items.loading": {
+		"message": "正在載入物品"
+	},
+	"app.lab.recipe-generator.items.search-placeholder": {
+		"message": "搜尋物品"
+	},
+	"app.lab.recipe-generator.loading-resources": {
+		"message": "正在載入版本資料"
+	},
+	"app.lab.recipe-generator.options.auto-name": {
+		"message": "自動名稱：{name}"
+	},
+	"app.lab.recipe-generator.options.category": {
+		"message": "分類"
+	},
+	"app.lab.recipe-generator.options.category-none": {
+		"message": "無"
+	},
+	"app.lab.recipe-generator.options.cooking-time": {
+		"message": "烹飪時間"
+	},
+	"app.lab.recipe-generator.options.default-time": {
+		"message": "預設時間"
+	},
+	"app.lab.recipe-generator.options.experience": {
+		"message": "經驗值"
+	},
+	"app.lab.recipe-generator.options.file-name": {
+		"message": "檔名"
+	},
+	"app.lab.recipe-generator.options.group": {
+		"message": "分組"
+	},
+	"app.lab.recipe-generator.options.keep-whitespace": {
+		"message": "保留精確槽位位置"
+	},
+	"app.lab.recipe-generator.options.manual-name-placeholder": {
+		"message": "recipe_name（示例）"
+	},
+	"app.lab.recipe-generator.options.name-mode-auto": {
+		"message": "自動"
+	},
+	"app.lab.recipe-generator.options.name-mode-manual": {
+		"message": "手動"
+	},
+	"app.lab.recipe-generator.options.shapeless": {
+		"message": "無序合成"
+	},
+	"app.lab.recipe-generator.options.show-notification": {
+		"message": "顯示配方通知"
+	},
+	"app.lab.recipe-generator.options.title": {
+		"message": "選項"
+	},
+	"app.lab.recipe-generator.options.trim-pattern": {
+		"message": "紋飾圖案"
+	},
+	"app.lab.recipe-generator.options.two-by-two": {
+		"message": "2x2 合成格"
+	},
+	"app.lab.recipe-generator.output.placeholder": {
+		"message": "配方 JSON 會顯示在這裡"
+	},
+	"app.lab.recipe-generator.output.save-json": {
+		"message": "儲存 JSON"
+	},
+	"app.lab.recipe-generator.output.saved": {
+		"message": "JSON 已儲存"
+	},
+	"app.lab.recipe-generator.output.title": {
+		"message": "JSON 輸出"
+	},
+	"app.lab.recipe-generator.panel.items": {
+		"message": "物品"
+	},
+	"app.lab.recipe-generator.panel.tags": {
+		"message": "標籤"
+	},
+	"app.lab.recipe-generator.preview.copy-image": {
+		"message": "複製圖片"
+	},
+	"app.lab.recipe-generator.preview.image-copied": {
+		"message": "預覽圖已複製"
+	},
+	"app.lab.recipe-generator.preview.title": {
+		"message": "預覽"
+	},
+	"app.lab.recipe-generator.recipe-type": {
+		"message": "配方型別"
+	},
+	"app.lab.recipe-generator.recipes.clone": {
+		"message": "複製配方"
+	},
+	"app.lab.recipe-generator.recipes.delete": {
+		"message": "刪除配方"
+	},
+	"app.lab.recipe-generator.recipes.export-datapack": {
+		"message": "匯出資料包"
+	},
+	"app.lab.recipe-generator.recipes.export-datapack-done": {
+		"message": "資料包已匯出"
+	},
+	"app.lab.recipe-generator.recipes.export-datapack-invalid": {
+		"message": "匯出前請先修復配方錯誤。"
+	},
+	"app.lab.recipe-generator.recipes.name": {
+		"message": "名稱：{name}"
+	},
+	"app.lab.recipe-generator.recipes.new": {
+		"message": "新建配方"
+	},
+	"app.lab.recipe-generator.recipes.title": {
+		"message": "配方"
+	},
+	"app.lab.recipe-generator.resource-error": {
+		"message": "無法載入版本資料。"
+	},
+	"app.lab.recipe-generator.save": {
+		"message": "儲存"
+	},
+	"app.lab.recipe-generator.save-as-done": {
+		"message": "資料包已儲存"
+	},
+	"app.lab.recipe-generator.scroll-to-adjust": {
+		"message": "使用滾輪調節數量"
+	},
+	"app.lab.recipe-generator.slots.clear": {
+		"message": "清空槽位"
+	},
+	"app.lab.recipe-generator.slots.empty": {
+		"message": "空槽位"
+	},
+	"app.lab.recipe-generator.slots.grid-full": {
+		"message": "合成格已滿，請先清空一個槽位。"
+	},
+	"app.lab.recipe-generator.tags.add": {
+		"message": "新增標籤"
+	},
+	"app.lab.recipe-generator.tags.custom": {
+		"message": "自定義標籤"
+	},
+	"app.lab.recipe-generator.tags.delete": {
+		"message": "刪除標籤"
+	},
+	"app.lab.recipe-generator.tags.empty": {
+		"message": "沒有匹配搜尋的標籤。"
+	},
+	"app.lab.recipe-generator.tags.id-placeholder": {
+		"message": "namespace:tag_id（示例）"
+	},
+	"app.lab.recipe-generator.tags.no-custom": {
+		"message": "還沒有自定義標籤。"
+	},
+	"app.lab.recipe-generator.tags.search-placeholder": {
+		"message": "搜尋標籤"
+	},
+	"app.lab.recipe-generator.tags.use": {
+		"message": "在配方中使用"
+	},
+	"app.lab.recipe-generator.tags.values-placeholder": {
+		"message": "每行一個物品或 #標籤"
+	},
+	"app.lab.recipe-generator.tags.vanilla": {
+		"message": "原版標籤"
+	},
+	"app.lab.recipe-generator.title": {
+		"message": "配方生成器"
+	},
+	"app.lab.recipe-generator.type.blasting": {
+		"message": "高爐燒煉"
+	},
+	"app.lab.recipe-generator.type.campfire-cooking": {
+		"message": "篝火烹飪"
+	},
+	"app.lab.recipe-generator.type.crafting": {
+		"message": "合成"
+	},
+	"app.lab.recipe-generator.type.smelting": {
+		"message": "熔爐燒煉"
+	},
+	"app.lab.recipe-generator.type.smithing": {
+		"message": "鍛造臺鍛造"
+	},
+	"app.lab.recipe-generator.type.smithing-transform": {
+		"message": "鍛造轉換"
+	},
+	"app.lab.recipe-generator.type.smithing-trim": {
+		"message": "鍛造紋飾"
+	},
+	"app.lab.recipe-generator.type.smoking": {
+		"message": "煙燻燒煉"
+	},
+	"app.lab.recipe-generator.type.stonecutter": {
+		"message": "切石機切制"
+	},
+	"app.lab.recipe-generator.validation.invalid-identifier": {
+		"message": "物品識別符號無效。"
+	},
+	"app.lab.recipe-generator.validation.missing-addition": {
+		"message": "請新增附加物品。"
+	},
+	"app.lab.recipe-generator.validation.missing-base": {
+		"message": "請新增基礎物品。"
+	},
+	"app.lab.recipe-generator.validation.missing-custom-item": {
+		"message": "配方引用了已刪除的自定義物品。"
+	},
+	"app.lab.recipe-generator.validation.missing-custom-tag": {
+		"message": "配方引用了已刪除的自定義標籤。"
+	},
+	"app.lab.recipe-generator.validation.missing-ingredient": {
+		"message": "請新增材料。"
+	},
+	"app.lab.recipe-generator.validation.missing-result": {
+		"message": "請新增產物物品。"
+	},
+	"app.lab.recipe-generator.validation.missing-template": {
+		"message": "請新增模板物品。"
+	},
+	"app.lab.recipe-generator.validation.missing-trim-pattern": {
+		"message": "請新增紋飾圖案。"
+	},
+	"app.lab.recipe-generator.validation.summary": {
+		"message": "{count} 個問題"
+	},
+	"app.lab.recipe-generator.validation.summary-plural": {
+		"message": "{count} 個問題"
+	},
+	"app.lab.recipe-generator.validation.tag-in-result": {
+		"message": "產物槽位不能包含標籤。"
+	},
+	"app.lab.recipe-generator.validation.tags-not-supported": {
+		"message": "此版本不支援物品標籤。"
+	},
+	"app.lab.recipe-generator.validation.unsupported-type": {
+		"message": "所選版本中不可用此配方型別。"
+	},
+	"app.lab.recipe-generator.version": {
+		"message": "版本"
+	},
+	"app.lab.recipe-generator.version-label": {
+		"message": "Java {version}"
+	},
+	"app.lab.seed-map.import-from-instance": {
+		"message": "從實例導入"
+	},
+	"app.lab.seed-map.world-seed-loaded": {
+		"message": "已載入世界 {world} 的種子"
+	},
+	"app.lab.seed-map.history": {
+		"message": "種子歷史記錄"
+	},
+	"app.lab.seed-map.history-empty": {
+		"message": "查看過的種子會出現在這裡"
+	},
+	"app.lab.seed-map.clear-history": {
+		"message": "清空歷史"
+	},
+	"app.lab.seed-map.remove-history-entry": {
+		"message": "從歷史中移除"
+	},
+	"app.lab.seed-map.history-source.manual": {
+		"message": "手動輸入"
+	},
+	"app.lab.seed-map.history-source.random": {
+		"message": "隨機種子"
+	},
+	"app.lab.seed-map.history-source.share": {
+		"message": "分享連結"
+	},
+	"app.lab.seed-map.elevation-locked": {
+		"message": "開啟地形估算時自動採用估算的地表高度"
+	},
+	"app.lab.seed-map.import-world.title": {
+		"message": "從實例世界載入種子"
+	},
+	"app.lab.seed-map.import-world.choose-instance": {
+		"message": "選擇包含該世界的實例"
+	},
+	"app.lab.seed-map.import-world.choose-world": {
+		"message": "選擇一個單人世界"
+	},
+	"app.lab.seed-map.import-world.back": {
+		"message": "返回實例列表"
+	},
+	"app.lab.seed-map.import-world.no-instances": {
+		"message": "未找到實例，請先安裝一個實例。"
+	},
+	"app.lab.seed-map.import-world.no-worlds": {
+		"message": "該實例還沒有單人世界。"
+	},
+	"app.lab.seed-map.import-world.last-played": {
+		"message": "{ago}遊玩過"
+	},
+	"app.lab.seed-map.import-world.never-played": {
+		"message": "尚未遊玩"
+	},
+	"app.lab.seed-map.add-marker": {
+		"message": "添加標記"
+	},
+	"app.lab.seed-map.approximate": {
+		"message": "估算"
+	},
+	"app.lab.seed-map.center-spawn": {
+		"message": "居中顯示出生點"
+	},
+	"app.lab.seed-map.chunk-coordinates": {
+		"message": "區塊坐標"
+	},
+	"app.lab.seed-map.close-panel": {
+		"message": "關閉面板"
+	},
+	"app.lab.seed-map.clear-ruler": {
+		"message": "清除測距"
+	},
+	"app.lab.seed-map.completed": {
+		"message": "已完成"
+	},
+	"app.lab.seed-map.contours": {
+		"message": "等高線"
+	},
+	"app.lab.seed-map.copyright.disclaimer-body": {
+		"message": "Minecraft 是 Mojang Synergies AB 的商標。Axolotl Launcher 與 Mojang 或 MinecraftSearch 均無隸屬關係，也未獲得其認可。"
+	},
+	"app.lab.seed-map.copyright.disclaimer-heading": {
+		"message": "非官方工具"
+	},
+	"app.lab.seed-map.copyright.engine-body": {
+		"message": "群系、地形、出生點與結構數據由 cubiomes 和 Axolotl 原生集成在本地生成。cubiomes 版權所有 (c) 2020 Cubitect，並依據 MIT 許可證提供。"
+	},
+	"app.lab.seed-map.copyright.engine-heading": {
+		"message": "本地地圖引擎"
+	},
+	"app.lab.seed-map.copyright.icons-body": {
+		"message": "本工具使用的部分結構與群系圖示取自 MinecraftSearch。相關圖稿的權利仍歸 MinecraftSearch 及相應創作者所有。"
+	},
+	"app.lab.seed-map.copyright.icons-heading": {
+		"message": "地圖圖稿"
+	},
+	"app.lab.seed-map.copyright.open": {
+		"message": "版權與來源說明"
+	},
+	"app.lab.seed-map.copyright.title": {
+		"message": "版權與來源說明"
+	},
+	"app.lab.seed-map.copyright.view-cubiomes": {
+		"message": "查看 cubiomes"
+	},
+	"app.lab.seed-map.copyright.visit-minecraft-search": {
+		"message": "訪問 MinecraftSearch"
+	},
+	"app.lab.seed-map.copy-teleport": {
+		"message": "複製 /tp"
+	},
+	"app.lab.seed-map.description": {
+		"message": "在本地查看 Minecraft 種子的群系、結構和保存的標記。"
+	},
+	"app.lab.seed-map.dimension": {
+		"message": "維度"
+	},
+	"app.lab.seed-map.dimension.end": {
+		"message": "終界"
+	},
+	"app.lab.seed-map.dimension.nether": {
+		"message": "下界"
+	},
+	"app.lab.seed-map.dimension.overworld": {
+		"message": "主世界"
+	},
+	"app.lab.seed-map.distance": {
+		"message": "{distance} 格"
+	},
+	"app.lab.seed-map.edition": {
+		"message": "版本類型"
+	},
+	"app.lab.seed-map.edition.java": {
+		"message": "Java 版"
+	},
+	"app.lab.seed-map.elevation": {
+		"message": "群系高度"
+	},
+	"app.lab.seed-map.feature.ancient-city": {
+		"message": "遠古城市"
+	},
+	"app.lab.seed-map.feature.mansion": {
+		"message": "林地府邸"
+	},
+	"app.lab.seed-map.feature.monument": {
+		"message": "海底神殿"
+	},
+	"app.lab.seed-map.feature.outpost": {
+		"message": "掠奪者前哨站"
+	},
+	"app.lab.seed-map.feature.ruined-portal": {
+		"message": "廢棄傳送門"
+	},
+	"app.lab.seed-map.feature.shipwreck": {
+		"message": "沉船"
+	},
+	"app.lab.seed-map.feature.slime-chunk": {
+		"message": "史萊姆區塊"
+	},
+	"app.lab.seed-map.feature.stronghold": {
+		"message": "要塞"
+	},
+	"app.lab.seed-map.feature.trail-ruins": {
+		"message": "古蹟廢墟"
+	},
+	"app.lab.seed-map.feature.trial-chambers": {
+		"message": "試煉密室"
+	},
+	"app.lab.seed-map.feature.village": {
+		"message": "村莊"
+	},
+	"app.lab.seed-map.layers": {
+		"message": "地圖圖層"
+	},
+	"app.lab.seed-map.loading": {
+		"message": "載入中"
+	},
+	"app.lab.seed-map.map-failed": {
+		"message": "地圖生成失敗"
+	},
+	"app.lab.seed-map.location": {
+		"message": "位置"
+	},
+	"app.lab.seed-map.map-scale": {
+		"message": "1 像素 = {scale} 格"
+	},
+	"app.lab.seed-map.marker-name": {
+		"message": "標記名稱"
+	},
+	"app.lab.seed-map.marker-color": {
+		"message": "標記顏色"
+	},
+	"app.lab.seed-map.markers": {
+		"message": "標記"
+	},
+	"app.lab.seed-map.random-seed": {
+		"message": "隨機種子"
+	},
+	"app.lab.seed-map.remove-marker": {
+		"message": "刪除標記"
+	},
+	"app.lab.seed-map.ruler": {
+		"message": "測量距離"
+	},
+	"app.lab.seed-map.search-nearby": {
+		"message": "搜索附近"
+	},
+	"app.lab.seed-map.seed": {
+		"message": "種子"
+	},
+	"app.lab.seed-map.seed-placeholder": {
+		"message": "輸入數字或文本種子"
+	},
+	"app.lab.seed-map.settings": {
+		"message": "地圖設定"
+	},
+	"app.lab.seed-map.share": {
+		"message": "複製地圖連結"
+	},
+	"app.lab.seed-map.share-copied": {
+		"message": "已複製地圖連結"
+	},
+	"app.lab.seed-map.show-grid": {
+		"message": "顯示網格"
+	},
+	"app.lab.seed-map.teleport-copied": {
+		"message": "已複製傳送命令"
+	},
+	"app.lab.seed-map.terrain": {
+		"message": "地形估算"
+	},
+	"app.lab.seed-map.title": {
+		"message": "種子地圖"
+	},
+	"app.lab.seed-map.version": {
+		"message": "遊戲版本"
+	},
+	"app.lab.seed-map.zoom-in": {
+		"message": "放大"
+	},
+	"app.lab.seed-map.zoom-out": {
+		"message": "縮小"
+	},
+	"app.lab.seed-map.biome-highlight": {
+		"message": "群系高亮"
+	},
+	"app.lab.seed-map.biome-tag": {
+		"message": "生物群系"
+	},
+	"app.lab.seed-map.biome-selection-count": {
+		"message": "已選 {selected} / {total}"
+	},
+	"app.lab.seed-map.biome-group.beach": {
+		"message": "沙灘"
+	},
+	"app.lab.seed-map.biome-group.cave": {
+		"message": "洞穴"
+	},
+	"app.lab.seed-map.biome-group.desert": {
+		"message": "沙漠"
+	},
+	"app.lab.seed-map.biome-group.end": {
+		"message": "終界"
+	},
+	"app.lab.seed-map.biome-group.forest": {
+		"message": "森林"
+	},
+	"app.lab.seed-map.biome-group.jungle": {
+		"message": "叢林"
+	},
+	"app.lab.seed-map.biome-group.ice": {
+		"message": "冰雪群系"
+	},
+	"app.lab.seed-map.biome-group.mesa": {
+		"message": "惡地"
+	},
+	"app.lab.seed-map.biome-group.mountains": {
+		"message": "山地"
+	},
+	"app.lab.seed-map.biome-group.mushroom": {
+		"message": "蘑菇島"
+	},
+	"app.lab.seed-map.biome-group.nether": {
+		"message": "下界"
+	},
+	"app.lab.seed-map.biome-group.ocean": {
+		"message": "海洋"
+	},
+	"app.lab.seed-map.biome-group.plains": {
+		"message": "平原"
+	},
+	"app.lab.seed-map.biome-group.river": {
+		"message": "河流"
+	},
+	"app.lab.seed-map.biome-group.savanna": {
+		"message": "熱帶草原"
+	},
+	"app.lab.seed-map.biome-group.swamp": {
+		"message": "沼澤"
+	},
+	"app.lab.seed-map.biome-group.taiga": {
+		"message": "針葉林"
+	},
+	"app.lab.seed-map.search-biomes": {
+		"message": "搜索群系"
+	},
+	"app.lab.seed-map.invert-selection": {
+		"message": "反選"
+	},
+	"app.lab.seed-map.no-matching-biomes": {
+		"message": "沒有匹配的群系"
+	},
+	"app.lab.seed-map.mode.structures": {
+		"message": "結構"
+	},
+	"app.lab.seed-map.mode.ores": {
+		"message": "礦物"
+	},
+	"app.lab.seed-map.ore-layers": {
+		"message": "礦物圖層"
+	},
+	"app.lab.seed-map.zoom-to-scan-ores": {
+		"message": "放大地圖以掃描礦物"
+	},
+	"app.lab.seed-map.no-ores-in-end": {
+		"message": "終界不支持礦物掃描"
+	},
+	"app.lab.seed-map.ores-require-modern": {
+		"message": "礦物預測需要 Java 版 1.18 或更新版本"
+	},
+	"app.lab.seed-map.ore-y-range": {
+		"message": "Y 範圍"
+	},
+	"app.lab.seed-map.ore-min-y": {
+		"message": "最低 Y"
+	},
+	"app.lab.seed-map.ore-max-y": {
+		"message": "最高 Y"
+	},
+	"app.lab.seed-map.reset-y-range": {
+		"message": "重設 Y 範圍"
+	},
+	"app.lab.seed-map.scanning-ores": {
+		"message": "正在掃描礦物 {processed}/{total}"
+	},
+	"app.lab.seed-map.ore-scan-failed": {
+		"message": "礦物掃描失敗，請刷新地圖後重試。"
+	},
+	"app.lab.seed-map.ore-verified": {
+		"message": "已驗證"
+	},
+	"app.lab.seed-map.ore-likely": {
+		"message": "可能存在"
+	},
+	"app.lab.seed-map.ore-precision": {
+		"message": "精度 {precision}%"
+	},
+	"app.lab.seed-map.ore-coverage": {
+		"message": "Y {min} 到 {max}"
+	},
+	"app.lab.seed-map.mined": {
+		"message": "已挖掘"
+	},
+	"app.lab.seed-map.ore.diamond": {
+		"message": "鑽石礦石"
+	},
+	"app.lab.seed-map.ore.netherite": {
+		"message": "遠古遺骸"
+	},
+	"app.lab.seed-map.ore.iron": {
+		"message": "鐵礦石"
+	},
+	"app.lab.seed-map.ore.iron-vein": {
+		"message": "鐵礦脈"
+	},
+	"app.lab.seed-map.ore.copper": {
+		"message": "銅礦石"
+	},
+	"app.lab.seed-map.ore.copper-vein": {
+		"message": "銅礦脈"
+	},
+	"app.lab.seed-map.ore.gold": {
+		"message": "金礦石"
+	},
+	"app.lab.seed-map.ore.redstone": {
+		"message": "紅石礦石"
+	},
+	"app.lab.seed-map.ore.lapis": {
+		"message": "青金石礦石"
+	},
+	"app.lab.seed-map.ore.coal": {
+		"message": "煤礦石"
+	},
+	"app.lab.seed-map.choose-biome": {
+		"message": "選擇群系"
+	},
+	"app.lab.seed-map.clear": {
+		"message": "清除"
+	},
+	"app.lab.seed-map.collapse-layers": {
+		"message": "收起圖層"
+	},
+	"app.lab.seed-map.coordinates": {
+		"message": "坐標"
+	},
+	"app.lab.seed-map.edition.java-large-biomes": {
+		"message": "Java 版：大型生物群系"
+	},
+	"app.lab.seed-map.exit-fullscreen": {
+		"message": "退出全螢幕"
+	},
+	"app.lab.seed-map.expand-layers": {
+		"message": "展開圖層"
+	},
+	"app.lab.seed-map.feature.bastion": {
+		"message": "堡壘遺跡"
+	},
+	"app.lab.seed-map.feature.buried-treasure": {
+		"message": "埋藏的寶藏"
+	},
+	"app.lab.seed-map.feature.desert-pyramid": {
+		"message": "沙漠神殿"
+	},
+	"app.lab.seed-map.feature.desert-well": {
+		"message": "沙漠水井"
+	},
+	"app.lab.seed-map.feature.end-city": {
+		"message": "終界城"
+	},
+	"app.lab.seed-map.feature.end-city-with-ship": {
+		"message": "終界城（有終界船）"
+	},
+	"app.lab.seed-map.feature.end-city-without-ship": {
+		"message": "終界城（無終界船）"
+	},
+	"app.lab.seed-map.feature.end-gateway": {
+		"message": "終界折躍門"
+	},
+	"app.lab.seed-map.feature.fortress": {
+		"message": "下界要塞"
+	},
+	"app.lab.seed-map.feature.geode": {
+		"message": "紫晶洞"
+	},
+	"app.lab.seed-map.feature.igloo": {
+		"message": "雪屋"
+	},
+	"app.lab.seed-map.feature.jungle-temple": {
+		"message": "叢林神廟"
+	},
+	"app.lab.seed-map.feature.mineshaft": {
+		"message": "廢棄礦井"
+	},
+	"app.lab.seed-map.feature.ocean-ruin": {
+		"message": "海底廢墟"
+	},
+	"app.lab.seed-map.feature.swamp-hut": {
+		"message": "沼澤小屋"
+	},
+	"app.lab.seed-map.fullscreen": {
+		"message": "全螢幕"
+	},
+	"app.lab.seed-map.go": {
+		"message": "前往"
+	},
+	"app.lab.seed-map.hide-layer-names": {
+		"message": "隱藏圖層名稱"
+	},
+	"app.lab.seed-map.marker-saved": {
+		"message": "標記已保存"
+	},
+	"app.lab.seed-map.no-markers": {
+		"message": "暫無保存的標記"
+	},
+	"app.lab.seed-map.reset": {
+		"message": "重設"
+	},
+	"app.lab.seed-map.select-all": {
+		"message": "全選"
+	},
+	"app.lab.seed-map.selected-biomes": {
+		"message": "已選擇 {count} 個群系"
+	},
+	"app.lab.seed-map.show-layer-names": {
+		"message": "顯示圖層名稱"
+	},
+	"app.lab.seed-map.spawn-point": {
+		"message": "出生點"
+	},
+	"app.lab.seed-map.zoom-to-show": {
+		"message": "放大以顯示{layer}"
+	},
+	"app.lab.category.all": {
+		"message": "全部工具"
+	},
+	"app.lab.category.creation": {
+		"message": "創作"
+	},
+	"app.lab.category.maintenance": {
+		"message": "維護"
+	},
+	"app.lab.category.world": {
+		"message": "世界"
+	},
+	"app.lab.no-results": {
+		"message": "沒有匹配的工具。"
+	},
+	"app.lab.search": {
+		"message": "搜索工具"
+	},
+	"app.lab.title": {
+		"message": "實驗室"
+	},
+	"app.lab.tool-count": {
+		"message": "{count} 個工具"
+	},
+	"app.lab.tool-count-plural": {
+		"message": "{count} 個工具"
+	},
+	"app.navigation.lab": {
+		"message": "實驗室"
+	},
+	"app.onboarding.action.click-lab": {
+		"message": "點擊實驗室，繼續"
+	},
+	"app.onboarding.action.open-gradient-text": {
+		"message": "打開漸變文字生成器，繼續"
+	},
+	"app.onboarding.action.open-recipe-generator": {
+		"message": "開啟配方生成器，繼續"
+	},
+	"app.onboarding.action.open-seed-map": {
+		"message": "打開種子地圖，繼續"
+	},
+	"app.onboarding.action.return-lab": {
+		"message": "點擊實驗室，查看另一個項目"
+	},
+	"app.onboarding.lab-editor.description": {
+		"message": "編輯文本、選擇顏色、即時預覽，並複製適用於 Minecraft 配置的格式。"
+	},
+	"app.onboarding.lab-editor.title": {
+		"message": "在同一處編輯和複製"
+	},
+	"app.onboarding.lab-recipe-generator.description": {
+		"message": "選擇 Java 版本、填充配方槽位，然後在本地複製或匯出 JSON。"
+	},
+	"app.onboarding.lab-recipe-generator.title": {
+		"message": "製作資料包配方"
+	},
+	"app.onboarding.lab-seed-map.description": {
+		"message": "輸入種子或從實例載入，然後在本地地圖中查看群系、結構與礦物圖層。"
+	},
+	"app.onboarding.lab-seed-map.title": {
+		"message": "載入世界前先找到它"
+	},
+	"app.onboarding.lab-tools.description": {
+		"message": "生成帶格式的漸變文字，或用本地種子地圖探索 Java 世界。"
+	},
+	"app.onboarding.lab-tools.title": {
+		"message": "首批兩個項目"
+	},
+	"app.onboarding.lab.description": {
+		"message": "實驗室將本地 Minecraft 工具放進啟動器，無需打開其他網站或註冊額外帳號。"
+	},
+	"app.onboarding.lab.title": {
+		"message": "內建的實用工具"
+	},
+	"app.appearance-settings.auto-hide-downloads-button.description": {
+		"message": "沒有進行中的下載任務時隱藏側邊欄中的下載按鈕，有任務時自動顯示。"
+	},
+	"app.appearance-settings.auto-hide-downloads-button.title": {
+		"message": "自動隱藏下載按鈕"
+	},
+	"app.appearance-settings.home-layout.description": {
+		"message": "在資訊首頁和專注的實例啟動頁之間選擇。"
+	},
+	"app.appearance-settings.home-layout.minimal": {
+		"message": "極簡"
+	},
+	"app.appearance-settings.home-layout.standard": {
+		"message": "資訊"
+	},
+	"app.appearance-settings.home-layout.title": {
+		"message": "首頁布局"
+	},
+	"app.curseforge.automatic-downloads-failed.notification-body": {
+		"message": "重試後仍有 {failed, number} 個文件下載失敗（{list}）。可在“下載”中查看已記錄的錯誤。"
+	},
+	"app.curseforge.automatic-downloads-failed.notification-title": {
+		"message": "部分 CurseForge 文件下載失敗"
+	},
+	"app.curseforge.dependency-notes.notification-body": {
+		"message": "{optional, plural, =0 {沒有跳過可選前置模組。} other {跳過了 # 個可選前置模組。}} {incompatible, plural, =0 {未檢測到不相容的前置模組。} other {檢測到 # 個不相容的前置模組。}} {skipped, plural, =0 {沒有跳過其他前置模組。} other {跳過了 # 個其他前置模組。}}"
+	},
+	"app.curseforge.dependency-notes.notification-title": {
+		"message": "CurseForge 前置模組提示"
+	},
+	"app.curseforge.network-download-failed.notification-body": {
+		"message": "無法連線 CurseForge 下載該檔案。當前網路或代理可能阻止了 CurseForge。請關閉或更換 VPN/代理，改用其他網路後重試。"
+	},
+	"app.curseforge.network-download-failed.notification-title": {
+		"message": "CurseForge 下載失敗"
+	},
+	"app.home.greeting.with-player": {
+		"message": "{name}，{greeting}"
+	},
+	"app.home.greeting.welcome": {
+		"message": "歡迎回來。"
+	},
+	"app.home.greeting.welcome-with-player": {
+		"message": "歡迎回來，{name}。"
+	},
+	"app.home.greeting.settings.font": {
+		"message": "字型"
+	},
+	"app.home.greeting.settings.font-size": {
+		"message": "字號"
+	},
+	"app.home.greeting.settings.font.minecraft": {
+		"message": "Minecraft 畫素字型"
+	},
+	"app.home.greeting.settings.font.mono": {
+		"message": "等寬字型"
+	},
+	"app.home.greeting.settings.font.sans": {
+		"message": "啟動器字型"
+	},
+	"app.home.greeting.settings.font.serif": {
+		"message": "襯線字型"
+	},
+	"app.home.greeting.settings.mode": {
+		"message": "顯示方式"
+	},
+	"app.home.greeting.settings.mode.greeting": {
+		"message": "僅自動問候"
+	},
+	"app.home.greeting.settings.mode.greeting-description": {
+		"message": "根據一天中的時間顯示輪換問候語。"
+	},
+	"app.home.greeting.settings.mode.text": {
+		"message": "僅自定義文字"
+	},
+	"app.home.greeting.settings.mode.text-description": {
+		"message": "使用你自己的文字替換自動問候語。"
+	},
+	"app.home.greeting.settings.mode.text-and-greeting": {
+		"message": "文字 + 自動問候"
+	},
+	"app.home.greeting.settings.mode.text-and-greeting-description": {
+		"message": "在輪換問候語前顯示你的自定義文字。"
+	},
+	"app.home.greeting.settings.prefix-placeholder": {
+		"message": "歡迎回來，{name}。"
+	},
+	"app.home.greeting.settings.preview": {
+		"message": "預覽"
+	},
+	"app.home.greeting.settings.text": {
+		"message": "自定義文字"
+	},
+	"app.home.greeting.settings.text-fallback": {
+		"message": "留空時使用當前的自動問候語。"
+	},
+	"app.home.greeting.settings.text-placeholder": {
+		"message": "下一場冒險從這裡開始。"
+	},
+	"app.home.greeting.settings.title": {
+		"message": "自定義問候語"
+	},
+	"app.home.greeting.minimal.afternoon": {
+		"message": "午安"
+	},
+	"app.home.greeting.minimal.dawn": {
+		"message": "清晨好"
+	},
+	"app.home.greeting.minimal.evening": {
+		"message": "傍晚好"
+	},
+	"app.home.greeting.minimal.late-night": {
+		"message": "夜深了"
+	},
+	"app.home.greeting.minimal.morning": {
+		"message": "早安"
+	},
+	"app.home.greeting.minimal.night": {
+		"message": "晚上好"
+	},
+	"app.home.greeting.minimal.with-player": {
+		"message": "{greeting}，{name}"
+	},
+	"app.home.greeting.late-night": {
+		"message": "月亮還在加班。\n安靜的世界正等著你。\n夜班總能寫出好故事。\n黎明前再放一塊方塊？\n星光會看顧好你的伺服器。\n深夜時段，也能留下傳奇存檔。\n現在的火把光格外好看。\n下一場冒險還沒睡。\n午夜後的礦洞更安靜。\n和平的出生點在等你。\n耐心的建造者屬於夜晚。\n把音樂調低，把靈感調高。\n每一座好基地都從一塊方塊開始。\n終界可以等等，除非它等不了。\n短短一局也算數。\n這個世界已經為你保存好了。"
+	},
+	"app.home.greeting.dawn": {
+		"message": "天剛亮，區塊正新。\n新的一天正在載入。\n日出增益已生效。\n清晨的世界總像全新的。\n先喝咖啡，再挖鑽石。\n你的基地想你一整晚了。\n從容開局，也能成就好冒險。\n主世界正在甦醒。\n新鮮空氣，新鮮資源包。\n今天很適合去探索。\n村莊已經開門交易了。\n安靜的早晨適合大工程。\n新的一天，新的坐標。\n苦力怕也不太像早起的人。\n先從小事開始，看看會去向何處。\n下一局已經準備好，等你出發。"
+	},
+	"app.home.greeting.morning": {
+		"message": "早安，冒險家。\n今天還有許多未探索的區塊。\n正適合重新開始。\n你的工具已為今天就緒。\n主世界有不少好計劃。\n造點未來的你會喜歡的東西。\n新的一局像一張乾淨畫布。\n太陽升起了，村民也是。\n讓今天多一點方塊感。\n礦井安靜得有點可疑。\n下一個項目只差一次啟動。\n好早晨，配好世界。\n總能再裝下一個新點子。\n工作台正在待命。\n地圖在等新的標記。\n坐穩，做點進度。"
+	},
+	"app.home.greeting.afternoon": {
+		"message": "午後休息，時機正好。\n短短一局也可能很精彩。\n世界已準備好接住你的下一步。\n該去看看那座半成品建築了。\n一點探索就能走很遠。\n下一個生物群系正在呼喚。\n你的背包耐心等候很久了。\n村莊市場還沒關門。\n這一小時適合專心做個項目。\n紅石今天大概會聽話。\n你的鎬子準備開工。\n出生點外還有新路線。\n午後天生適合支線任務。\n要不要快速回世界看看？\n下一章從這裡開始。\n花一點時間，做點東西。"
+	},
+	"app.home.greeting.evening": {
+		"message": "傍晚正是建造的黃金時間。\n白天將盡，世界剛剛展開。\n熟悉的世界是個好去處。\n該回到你最愛的項目了。\n從新塔上看日落更美。\n基地的燈正等著你。\n輕鬆玩一局正合適。\n村民很快要收攤了。\n你的下一座建築值得一層暮色。\n適合沒有計劃地四處走走。\n營火已經點好了。\n基地要不要再加一間房？\n地平線看起來格外誘人。\n安靜的夜晚從好世界開始。\n下一塊方塊該你放下。\n讓今晚的進度算數。"
+	},
+	"app.home.greeting.night": {
+		"message": "夜班準備好了。\n熟悉的世界適合這個夜晚。\n你最愛的實例就在附近。\n星星出來了，計劃也定好了。\n平靜的一局能好好結束今天。\n天黑後世界更安靜。\n該再放幾塊方塊了。\n遠處的基地正在發光。\n下一場冒險從日落開始。\n一個好存檔配得上一個好夜晚。\n不知何處，營火正噼啪作響。\n月光讓每座建築都更有戲劇感。\n明天之前來一點 Minecraft。\n你的世界隨時歡迎你回去。\n按區塊算，夜還很長。\n開始一段值得的遊戲時光吧。"
+	},
+	"app.home.instances.empty": {
+		"message": "還沒有實例"
+	},
+	"app.home.instances.create": {
+		"message": "創建實例"
+	},
+	"app.home.instances.pin": {
+		"message": "固定到首頁"
+	},
+	"app.home.instances.pinned": {
+		"message": "固定的實例"
+	},
+	"app.home.instances.pinned-empty": {
+		"message": "在實例卡片菜單或實例庫中選擇「固定到首頁」，實例就會顯示在這裡。"
+	},
+	"app.home.instances.unpin": {
+		"message": "取消固定"
+	},
+	"app.home.instances.view-all": {
+		"message": "查看全部實例"
+	},
+	"app.home.layout.switch-to-information": {
+		"message": "切換到資訊首頁"
+	},
+	"app.home.layout.switch-to-minimal": {
+		"message": "切換到極簡首頁"
+	},
+	"app.home.layout.toggle": {
+		"message": "極簡首頁"
+	},
+	"app.home.minimal.change-instance": {
+		"message": "更換首頁實例"
+	},
+	"app.home.minimal.choose-instance": {
+		"message": "選擇實例"
+	},
+	"app.home.minimal.picker.no-results": {
+		"message": "沒有匹配的實例"
+	},
+	"app.home.minimal.picker.no-instances": {
+		"message": "沒有可用例項"
+	},
+	"app.home.minimal.picker.search": {
+		"message": "搜索實例"
+	},
+	"app.home.minimal.picker.select": {
+		"message": "選擇 {name}"
+	},
+	"app.home.minimal.picker.title": {
+		"message": "選擇首頁實例"
+	},
+	"app.home.recent.title": {
+		"message": "從最近的項目開始"
+	},
+	"app.home.recent.empty": {
+		"message": "還沒有最近活動。"
+	},
+	"app.home.worlds.pinned": {
+		"message": "固定的世界"
+	},
+	"app.home.worlds.empty": {
+		"message": "將世界標記為收藏後，就會固定在這裡。"
+	},
+	"app.home.servers.pinned": {
+		"message": "固定的伺服器"
+	},
+	"app.home.servers.empty": {
+		"message": "將伺服器標記為收藏後，就會固定在這裡。"
+	},
+	"app.home.servers.players-online": {
+		"message": "{online}/{max} 人在線"
+	},
+	"app.home.servers.offline": {
+		"message": "離線"
+	},
+	"app.home.servers.join": {
+		"message": "加入伺服器"
+	},
+	"app.home.servers.stop": {
+		"message": "停止"
+	},
+	"app.home.servers.unpin": {
+		"message": "取消固定"
+	},
+	"app.home.servers.more-options": {
+		"message": "更多選項"
+	},
+	"app.home.shortcut.kind.instance": {
+		"message": "例項"
+	},
+	"app.home.shortcut.kind.server": {
+		"message": "伺服器"
+	},
+	"app.home.shortcut.kind.world": {
+		"message": "世界"
+	},
+	"app.home.shortcut.server.offline": {
+		"message": "伺服器離線"
+	},
+	"app.home.shortcut.server.players-online": {
+		"message": "{count} 人線上"
+	},
+	"app.home.widgets.add": {
+		"message": "新增小元件"
+	},
+	"app.home.widgets.add-title": {
+		"message": "新增小元件"
+	},
+	"app.home.widgets.back": {
+		"message": "返回"
+	},
+	"app.home.widgets.calendar": {
+		"message": "日曆"
+	},
+	"app.home.widgets.calendar-description": {
+		"message": "快速檢視本月日期與遊玩記錄。"
+	},
+	"app.home.widgets.choose-instance": {
+		"message": "選擇例項"
+	},
+	"app.home.widgets.choose-server": {
+		"message": "選擇伺服器"
+	},
+	"app.home.widgets.choose-world": {
+		"message": "選擇世界"
+	},
+	"app.home.widgets.customize": {
+		"message": "自定義小元件"
+	},
+	"app.home.widgets.done": {
+		"message": "完成編輯"
+	},
+	"app.home.widgets.drag": {
+		"message": "拖動小元件"
+	},
+	"app.home.widgets.empty": {
+		"message": "新增小元件來佈置你的主頁。"
+	},
+	"app.home.widgets.greeting": {
+		"message": "問候"
+	},
+	"app.home.widgets.greeting-description": {
+		"message": "隨一天中的時間變化的個性化歡迎語。"
+	},
+	"app.home.widgets.group.collections": {
+		"message": "收藏內容集合"
+	},
+	"app.home.widgets.group.overview": {
+		"message": "概覽"
+	},
+	"app.home.widgets.group.shortcuts": {
+		"message": "單項快捷入口"
+	},
+	"app.home.widgets.instance": {
+		"message": "單個例項入口"
+	},
+	"app.home.widgets.instance-description": {
+		"message": "選擇一個例項，建立獨立的快速啟動入口。"
+	},
+	"app.home.widgets.layout.switch-to-free": {
+		"message": "切換到自由小元件佈局"
+	},
+	"app.home.widgets.layout.switch-to-grid": {
+		"message": "切換到網格小元件佈局"
+	},
+	"app.home.widgets.layout.toggle": {
+		"message": "小元件佈局模式"
+	},
+	"app.home.widgets.loading": {
+		"message": "正在載入……"
+	},
+	"app.home.widgets.move-earlier": {
+		"message": "向前移動"
+	},
+	"app.home.widgets.move-later": {
+		"message": "向後移動"
+	},
+	"app.home.widgets.no-results": {
+		"message": "沒有匹配項"
+	},
+	"app.home.widgets.options": {
+		"message": "小元件選項"
+	},
+	"app.home.widgets.pinned-instances": {
+		"message": "全部固定例項"
+	},
+	"app.home.widgets.pinned-instances-description": {
+		"message": "自動彙總所有固定到主頁的例項。"
+	},
+	"app.home.widgets.pinned-servers": {
+		"message": "全部收藏伺服器"
+	},
+	"app.home.widgets.pinned-servers-description": {
+		"message": "自動彙總所有收藏的多人伺服器。"
+	},
+	"app.home.widgets.pinned-worlds": {
+		"message": "全部收藏世界"
+	},
+	"app.home.widgets.pinned-worlds-description": {
+		"message": "自動彙總所有收藏的單人世界。"
+	},
+	"app.home.widgets.recent": {
+		"message": "最近遊玩"
+	},
+	"app.home.widgets.recent-description": {
+		"message": "繼續遊玩最近開啟過的世界或例項。"
+	},
+	"app.home.widgets.recent-items": {
+		"message": "顯示最近 {count} 項"
+	},
+	"app.home.widgets.remove": {
+		"message": "刪除小元件"
+	},
+	"app.home.widgets.replace": {
+		"message": "替換目標"
+	},
+	"app.home.widgets.reset": {
+		"message": "恢復預設小元件"
+	},
+	"app.home.widgets.reset-confirm": {
+		"message": "要恢復預設小元件佈局嗎？"
+	},
+	"app.home.widgets.search": {
+		"message": "搜尋"
+	},
+	"app.home.widgets.server": {
+		"message": "單個伺服器入口"
+	},
+	"app.home.widgets.server-description": {
+		"message": "選擇一個伺服器，建立獨立的快速加入入口。"
+	},
+	"app.home.widgets.size": {
+		"message": "尺寸 {size}"
+	},
+	"app.home.widgets.unavailable": {
+		"message": "內容已不可用"
+	},
+	"app.home.widgets.world": {
+		"message": "單個世界入口"
+	},
+	"app.home.widgets.world-description": {
+		"message": "選擇一個世界，建立獨立的快速遊玩入口。"
+	},
+	"app.home.calendar.title": {
+		"message": "日曆"
+	},
+	"app.home.calendar.this-month": {
+		"message": "回到本月"
+	},
+	"app.home.calendar.previous": {
+		"message": "上個月"
+	},
+	"app.home.calendar.next": {
+		"message": "下個月"
+	},
+	"app.home.calendar.played-on": {
+		"message": "{date}你遊玩了："
+	},
+	"app.home.calendar.no-activity": {
+		"message": "這一天沒有遊玩記錄。"
+	},
+	"app.home.calendar.play": {
+		"message": "啟動"
+	},
+	"app.home.calendar.stop": {
+		"message": "停止"
+	},
+	"app.home.insights.title": {
+		"message": "遊玩洞察"
+	},
+	"app.home.insights.this-week": {
+		"message": "本週遊玩 {duration}"
+	},
+	"app.home.insights.this-week-more": {
+		"message": "本週遊玩 {duration}（比上週多 {percent}%）"
+	},
+	"app.home.insights.this-week-less": {
+		"message": "本週遊玩 {duration}（比上週少 {percent}%）"
+	},
+	"app.home.insights.this-week-same": {
+		"message": "本週遊玩 {duration}（與上週持平）"
+	},
+	"app.home.insights.streak": {
+		"message": "已連續遊玩 {days} 天"
+	},
+	"app.home.insights.week-top": {
+		"message": "本週常玩：{name}"
+	},
+	"app.home.insights.empty": {
+		"message": "開始遊玩後，這裡會顯示你的統計。"
+	},
+	"app.home.challenge.title": {
+		"message": "每日小挑戰"
+	},
+	"app.home.challenge.shuffle": {
+		"message": "換一個"
+	},
+	"app.home.challenge.easy": {
+		"message": "簡單"
+	},
+	"app.home.challenge.medium": {
+		"message": "中等"
+	},
+	"app.home.challenge.hard": {
+		"message": "困難"
+	},
+	"app.home.news.title": {
+		"message": "Minecraft 新聞"
+	},
+	"app.home.news.open-article": {
+		"message": "在 minecraft.net 上閱讀"
+	},
+	"app.home.playtime.minutes": {
+		"message": "{minutes} 分鐘"
+	},
+	"app.home.playtime.hours-minutes": {
+		"message": "{hours} 小時 {minutes} 分鐘"
+	},
+	"app.home.playtime.seconds": {
+		"message": "{seconds} 秒"
+	},
+	"app.home.playtime.sessions": {
+		"message": "成功啟動 {count} 次"
+	},
+	"app.home.playtime.most-played": {
+		"message": "當天常玩：{name}"
+	},
+	"app.instances.pin-to-home": {
+		"message": "固定到首頁"
+	},
+	"app.instances.unpin-from-home": {
+		"message": "取消固定"
+	},
+	"app.onboarding.home-customize.title": {
+		"message": "按你的方式排列"
+	},
+	"app.onboarding.home-customize.description": {
+		"message": "使用右下角的編輯控制元件新增、調整和配置小元件。編輯時可在自動排滿的網格與保留空格的自由網格之間切換。"
+	},
+	"app.onboarding.home-layout.description": {
+		"message": "隨時使用這個懸浮按鈕，在資訊首頁和極簡首頁之間切換。"
+	},
+	"app.onboarding.home-layout.title": {
+		"message": "切換資訊密度"
+	},
+	"app.onboarding.home-widgets.title": {
+		"message": "你的主頁，你的佈局"
+	},
+	"app.onboarding.home-widgets.description": {
+		"message": "資訊主頁由最近活動、遊玩時間、例項、世界和伺服器小元件組成。視窗或賬號側邊欄變化時，網格會自動重排。"
+	},
+	"app.instance-item.already-open": {
+		"message": "實例已經在運行"
+	},
+	"app.instance-item.loading-modpack": {
+		"message": "正在載入整合包……"
+	},
+	"app.instance-item.not-played-yet": {
+		"message": "還沒有遊玩過"
+	},
+	"app.instance-item.view-instance": {
+		"message": "查看實例"
+	},
+	"app.navigation.multiplayer": {
+		"message": "多人遊戲"
+	},
+	"app.multiplayer.title": {
+		"message": "多人遊戲"
+	},
+	"app.multiplayer.host": {
+		"message": "創建房間"
+	},
+	"app.multiplayer.join": {
+		"message": "加入房間"
+	},
+	"app.multiplayer.host-description": {
+		"message": "創建虛擬區域網路房間，讓好友直接連接到你的遊戲。"
+	},
+	"app.multiplayer.join-description": {
+		"message": "輸入房間碼加入好友的虛擬區域網路房間。"
+	},
+	"app.multiplayer.player-name": {
+		"message": "玩家名"
+	},
+	"app.multiplayer.room-code": {
+		"message": "房間碼"
+	},
+	"app.multiplayer.room-code-invalid": {
+		"message": "請輸入 U/XXXX-XXXX-XXXX-XXXX 格式的房間碼。"
+	},
+	"app.multiplayer.room-code-placeholder": {
+		"message": "例如 U/ABCD-EFGH-IJKL-MNOP"
+	},
+	"app.multiplayer.start-hosting": {
+		"message": "創建房間"
+	},
+	"app.multiplayer.join-room": {
+		"message": "加入房間"
+	},
+	"app.multiplayer.copy-room-code": {
+		"message": "複製房間碼"
+	},
+	"app.multiplayer.status.idle": {
+		"message": "未連接"
+	},
+	"app.multiplayer.status.starting": {
+		"message": "啟動中..."
+	},
+	"app.multiplayer.status.host-scanning": {
+		"message": "正在掃描..."
+	},
+	"app.multiplayer.status.host-ready": {
+		"message": "房間已就緒"
+	},
+	"app.multiplayer.status.guest-connecting": {
+		"message": "正在加入..."
+	},
+	"app.multiplayer.status.guest-ready": {
+		"message": "已連接到房間"
+	},
+	"app.multiplayer.status.error": {
+		"message": "錯誤"
+	},
+	"app.multiplayer.players": {
+		"message": "玩家"
+	},
+	"app.multiplayer.players-in-room": {
+		"message": "{count} 位玩家在房間中"
+	},
+	"app.multiplayer.not-running": {
+		"message": "聯機服務未運行。請創建房間或加入房間以開始聯機。"
+	},
+	"app.multiplayer.not-running-title": {
+		"message": "開始聯機會話"
+	},
+	"app.multiplayer.share-code": {
+		"message": "將此代碼分享給好友："
+	},
+	"app.multiplayer.server-address": {
+		"message": "備用連接地址"
+	},
+	"app.multiplayer.host-label": {
+		"message": "房主"
+	},
+	"app.multiplayer.guest-label": {
+		"message": "訪客"
+	},
+	"app.multiplayer.unknown-player-role": {
+		"message": "未知身份"
+	},
+	"app.multiplayer.platform-info": {
+		"message": "當前平台：{platform}"
+	},
+	"app.multiplayer.binary-not-found": {
+		"message": "未找到陶瓦聯機程序，請放置於："
+	},
+	"app.multiplayer.download-terracotta": {
+		"message": "下載陶瓦聯機"
+	},
+	"app.multiplayer.terracotta.update": {
+		"message": "更新陶瓦聯機"
+	},
+	"app.multiplayer.terracotta.update-available": {
+		"message": "陶瓦聯機 {version} 已可安裝。"
+	},
+	"app.multiplayer.status.downloading": {
+		"message": "下載中..."
+	},
+	"app.multiplayer.status.fatal": {
+		"message": "嚴重錯誤"
+	},
+	"app.multiplayer.status.guest-starting": {
+		"message": "正在連接..."
+	},
+	"app.multiplayer.status.host-starting": {
+		"message": "正在啟動主機..."
+	},
+	"app.multiplayer.status.waiting": {
+		"message": "等待中..."
+	},
+	"app.multiplayer.check-network": {
+		"message": "檢查網路連接"
+	},
+	"app.multiplayer.connecting": {
+		"message": "連線中..."
+	},
+	"app.multiplayer.disconnect": {
+		"message": "斷開連接"
+	},
+	"app.multiplayer.download-progress": {
+		"message": "下載進度"
+	},
+	"app.multiplayer.error.install": {
+		"message": "安裝錯誤"
+	},
+	"app.multiplayer.error.network": {
+		"message": "網路錯誤"
+	},
+	"app.multiplayer.error.os": {
+		"message": "系統錯誤"
+	},
+	"app.multiplayer.error.terracotta": {
+		"message": "陶瓦聯機錯誤"
+	},
+	"app.multiplayer.error.unknown": {
+		"message": "未知錯誤"
+	},
+	"app.multiplayer.retry": {
+		"message": "重試"
+	},
+	"app.multiplayer.export-error-report": {
+		"message": "匯出錯誤報告"
+	},
+	"app.multiplayer.verifying": {
+		"message": "驗證中..."
+	},
+	"app.multiplayer.extracting": {
+		"message": "正在解壓..."
+	},
+	"app.multiplayer.installing": {
+		"message": "正在安裝..."
+	},
+	"app.multiplayer.powered-by-terracotta": {
+		"message": "由 Terracotta | 陶瓦聯機 強力驅動"
+	},
+	"app.multiplayer.back": {
+		"message": "返回"
+	},
+	"app.multiplayer.start-terracotta": {
+		"message": "啟動陶瓦聯機"
+	},
+	"app.multiplayer.start-description": {
+		"message": "啟動聯機服務以創建房間或加入好友的房間。"
+	},
+	"app.multiplayer.lan-hint": {
+		"message": "請打開 Minecraft 進入世界，按 ESC → 對區域網路開放 → 選擇一個埠，陶瓦聯機會自動檢測。"
+	},
+	"app.multiplayer.loading": {
+		"message": "初始化中..."
+	},
+	"app.multiplayer.no-players": {
+		"message": "暫無玩家"
+	},
+	"app.multiplayer.provider.terracotta": {
+		"message": "陶瓦聯機"
+	},
+	"app.multiplayer.provider.hongshi": {
+		"message": "紅石聯機"
+	},
+	"app.multiplayer.hongshi.unsupported": {
+		"message": "紅石聯機暫不支援當前作業系統或處理器架構。"
+	},
+	"app.multiplayer.switch-warning": {
+		"message": "切換服務會斷開當前聯機會話，是否繼續？"
+	},
+	"app.multiplayer.hongshi.local-port": {
+		"message": "本地 Minecraft 埠"
+	},
+	"app.multiplayer.hongshi.detected-port": {
+		"message": "{instance} — 埠 {port}"
+	},
+	"app.multiplayer.hongshi.manual-port": {
+		"message": "手動輸入埠"
+	},
+	"app.multiplayer.hongshi.port-hint": {
+		"message": "請先將世界開放至區域網。啟動器會自動檢測埠，外部啟動的遊戲也可手動填寫。"
+	},
+	"app.multiplayer.hongshi.node": {
+		"message": "中轉節點"
+	},
+	"app.multiplayer.hongshi.node-auto": {
+		"message": "自動優選 — 最低延遲"
+	},
+	"app.multiplayer.hongshi.node-label": {
+		"message": "{name} — {latency} 毫秒{cached}"
+	},
+	"app.multiplayer.hongshi.cached": {
+		"message": "（快取）"
+	},
+	"app.multiplayer.hongshi.unreachable": {
+		"message": "不可用"
+	},
+	"app.multiplayer.hongshi.refresh-nodes": {
+		"message": "重新整理節點"
+	},
+	"app.multiplayer.hongshi.create": {
+		"message": "建立公網房間"
+	},
+	"app.multiplayer.hongshi.creating": {
+		"message": "正在建立隧道..."
+	},
+	"app.multiplayer.hongshi.public-address": {
+		"message": "公網地址"
+	},
+	"app.multiplayer.hongshi.public-address-hint": {
+		"message": "好友可直接在 Minecraft 中輸入此地址，無需執行紅石核心。"
+	},
+	"app.multiplayer.hongshi.limits": {
+		"message": "隧道無玩家 10 分鐘或執行滿 6 小時後自動關閉；最多 10 名玩家，共享 10Mbps 頻寬。"
+	},
+	"app.multiplayer.hongshi.port-changed": {
+		"message": "Minecraft 已開放新的區域網埠，請重啟隧道後再分享地址。"
+	},
+	"app.multiplayer.hongshi.restart": {
+		"message": "重啟隧道"
+	},
+	"app.multiplayer.hongshi.open-logs": {
+		"message": "開啟紅石日誌"
+	},
+	"app.multiplayer.hongshi.closed": {
+		"message": "紅石房間已關閉。重新建立後會獲得新的聯機地址。"
+	},
+	"app.multiplayer.hongshi.selecting-node": {
+		"message": "正在選擇最佳中轉節點..."
+	},
+	"instance.files.open-in-schematic-workshop": {
+		"message": "在投影工坊中開啟"
+	},
+	"app.lab.schematic-preview.author": {
+		"message": "作者"
+	},
+	"app.lab.schematic-preview.block-entities": {
+		"message": "方塊實體"
+	},
+	"app.lab.schematic-preview.block-picker.cancel": {
+		"message": "取消"
+	},
+	"app.lab.schematic-preview.block-picker.confirm": {
+		"message": "替換 {count} 個方塊"
+	},
+	"app.lab.schematic-preview.block-picker.description": {
+		"message": "選擇用於替換當前 {count} 個已選方塊的目標方塊。"
+	},
+	"app.lab.schematic-preview.block-picker.empty": {
+		"message": "沒有匹配的方塊"
+	},
+	"app.lab.schematic-preview.block-picker.results": {
+		"message": "{count} 個方塊"
+	},
+	"app.lab.schematic-preview.block-picker.search": {
+		"message": "按名稱或 ID 搜尋方塊"
+	},
+	"app.lab.schematic-preview.block-picker.title": {
+		"message": "替換方塊"
+	},
+	"app.lab.schematic-preview.blocks": {
+		"message": "方塊"
+	},
+	"app.lab.schematic-preview.bounds": {
+		"message": "顯示區域邊界"
+	},
+	"app.lab.schematic-preview.clear-recent": {
+		"message": "清空最近記錄"
+	},
+	"app.lab.schematic-preview.coordinates": {
+		"message": "座標"
+	},
+	"app.lab.schematic-preview.data-version": {
+		"message": "資料版本"
+	},
+	"app.lab.schematic-preview.description": {
+		"message": "快速預覽、編輯你的投影"
+	},
+	"app.lab.schematic-preview.drop": {
+		"message": "鬆開以開啟投影"
+	},
+	"app.lab.schematic-preview.empty.description": {
+		"message": "開啟 Litematica 或 Sponge 投影，在本地進行 3D 檢視和編輯。"
+	},
+	"app.lab.schematic-preview.empty.title": {
+		"message": "編輯 Minecraft 投影"
+	},
+	"app.lab.schematic-preview.entities": {
+		"message": "實體"
+	},
+	"app.lab.schematic-preview.export-complete": {
+		"message": "匯出完成"
+	},
+	"app.lab.schematic-preview.export-litematic": {
+		"message": "Litematica 投影（.litematic）"
+	},
+	"app.lab.schematic-preview.focus-region": {
+		"message": "聚焦區域"
+	},
+	"app.lab.schematic-preview.format": {
+		"message": "格式"
+	},
+	"app.lab.schematic-preview.from-instance": {
+		"message": "從例項選擇"
+	},
+	"app.lab.schematic-preview.grid": {
+		"message": "顯示網格"
+	},
+	"app.lab.schematic-preview.info.title": {
+		"message": "投影資訊"
+	},
+	"app.lab.schematic-preview.inspector": {
+		"message": "檢查器"
+	},
+	"app.lab.schematic-preview.instance-picker.back": {
+		"message": "返回例項列表"
+	},
+	"app.lab.schematic-preview.instance-picker.choose-instance": {
+		"message": "選擇包含投影的例項"
+	},
+	"app.lab.schematic-preview.instance-picker.collapse-folder": {
+		"message": "摺疊資料夾 {name}"
+	},
+	"app.lab.schematic-preview.instance-picker.empty": {
+		"message": "該例項中沒有找到 .litematic 或 .schem 檔案。"
+	},
+	"app.lab.schematic-preview.instance-picker.expand-folder": {
+		"message": "展開資料夾 {name}"
+	},
+	"app.lab.schematic-preview.instance-picker.no-instances": {
+		"message": "沒有可用的已安裝例項。"
+	},
+	"app.lab.schematic-preview.instance-picker.no-matching-instances": {
+		"message": "沒有匹配搜尋條件的例項。"
+	},
+	"app.lab.schematic-preview.instance-picker.no-matching-schematics": {
+		"message": "沒有匹配搜尋條件的投影。"
+	},
+	"app.lab.schematic-preview.instance-picker.open": {
+		"message": "開啟 {name}"
+	},
+	"app.lab.schematic-preview.instance-picker.search": {
+		"message": "搜尋投影"
+	},
+	"app.lab.schematic-preview.instance-picker.search-instances": {
+		"message": "搜尋例項"
+	},
+	"app.lab.schematic-preview.instance-picker.select-instance": {
+		"message": "瀏覽 {name} 中的投影"
+	},
+	"app.lab.schematic-preview.instance-picker.title": {
+		"message": "從例項開啟"
+	},
+	"app.lab.schematic-preview.layers.all": {
+		"message": "全部"
+	},
+	"app.lab.schematic-preview.layers.spacing": {
+		"message": "層間距"
+	},
+	"app.lab.schematic-preview.layers.visible": {
+		"message": "Y {current} · 顯示 {visible}/{total} 層"
+	},
+	"app.lab.schematic-preview.loading.mesh": {
+		"message": "正在生成模型"
+	},
+	"app.lab.schematic-preview.loading.parse": {
+		"message": "正在解析投影"
+	},
+	"app.lab.schematic-preview.loading.resources": {
+		"message": "正在讀取資源"
+	},
+	"app.lab.schematic-preview.materials-csv": {
+		"message": "匯出材料表 CSV"
+	},
+	"app.lab.schematic-preview.materials.empty": {
+		"message": "沒有匹配的材料"
+	},
+	"app.lab.schematic-preview.materials.search": {
+		"message": "搜尋材料"
+	},
+	"app.lab.schematic-preview.metadata": {
+		"message": "後設資料"
+	},
+	"app.lab.schematic-preview.missing-file": {
+		"message": "檔案不存在"
+	},
+	"app.lab.schematic-preview.missing-models": {
+		"message": "有 {count} 個方塊模型使用缺失紋理佔位。"
+	},
+	"app.lab.schematic-preview.more-actions": {
+		"message": "更多操作"
+	},
+	"app.lab.schematic-preview.open": {
+		"message": "開啟"
+	},
+	"app.lab.schematic-preview.open-file": {
+		"message": "開啟檔案"
+	},
+	"app.lab.schematic-preview.projection": {
+		"message": "切換相機投影"
+	},
+	"app.lab.schematic-preview.recent": {
+		"message": "最近的投影"
+	},
+	"app.lab.schematic-preview.regions": {
+		"message": "區域"
+	},
+	"app.lab.schematic-preview.reload": {
+		"message": "重新載入"
+	},
+	"app.lab.schematic-preview.remove-recent": {
+		"message": "從最近記錄移除"
+	},
+	"app.lab.schematic-preview.reset-view": {
+		"message": "復位視角"
+	},
+	"app.lab.schematic-preview.screenshot": {
+		"message": "匯出 PNG"
+	},
+	"app.lab.schematic-preview.seamless-glass": {
+		"message": "無縫玻璃"
+	},
+	"app.lab.schematic-preview.selected-block": {
+		"message": "已選方塊"
+	},
+	"app.lab.schematic-preview.tab.materials": {
+		"message": "材料"
+	},
+	"app.lab.schematic-preview.title": {
+		"message": "投影工坊"
+	},
+	"app.lab.schematic-preview.translucent": {
+		"message": "顯示透明方塊"
+	},
+	"app.lab.schematic-preview.warnings": {
+		"message": "警告"
+	},
+	"app.lab.schematic-preview.webgl-lost": {
+		"message": "WebGL 上下文已丟失，恢復後將繼續渲染。"
+	},
+	"app.lab.schematic-preview.edit.delete": {
+		"message": "刪除所選"
+	},
+	"app.lab.schematic-preview.edit.redo": {
+		"message": "重做"
+	},
+	"app.lab.schematic-preview.edit.replace": {
+		"message": "替換所選"
+	},
+	"app.lab.schematic-preview.edit.undo": {
+		"message": "撤銷"
+	},
+	"app.lab.schematic-preview.export-schematic": {
+		"message": "匯出投影"
+	},
+	"app.lab.schematic-preview.export-sponge": {
+		"message": "Sponge 投影（.schem）"
+	},
+	"app.lab.schematic-preview.fullscreen": {
+		"message": "切換全屏"
+	},
+	"app.lab.schematic-preview.materials-json": {
+		"message": "匯出材料表 JSON"
+	},
+	"app.lab.schematic-preview.materials.select-all": {
+		"message": "全選此材料"
+	},
+	"app.lab.schematic-preview.materials.use-replace": {
+		"message": "設為替換材料"
+	},
+	"app.lab.schematic-preview.measure": {
+		"message": "測量"
+	},
+	"app.lab.schematic-preview.measure.clear": {
+		"message": "清除測量"
+	},
+	"app.lab.schematic-preview.measure.distance": {
+		"message": "距離"
+	},
+	"app.lab.schematic-preview.measure.end": {
+		"message": "終點"
+	},
+	"app.lab.schematic-preview.measure.size": {
+		"message": "方塊跨度"
+	},
+	"app.lab.schematic-preview.measure.start": {
+		"message": "起點"
+	},
+	"app.lab.schematic-preview.orbit-view": {
+		"message": "軌道視角"
+	},
+	"app.lab.schematic-preview.selection.box": {
+		"message": "框選"
+	},
+	"app.lab.schematic-preview.selection.box-pending": {
+		"message": "請選擇另一對角"
+	},
+	"app.lab.schematic-preview.selection.clear": {
+		"message": "清除選擇"
+	},
+	"app.lab.schematic-preview.selection.connected": {
+		"message": "連通方塊"
+	},
+	"app.lab.schematic-preview.selection.count": {
+		"message": "已選 {count} 個"
+	},
+	"app.lab.schematic-preview.selection.layer": {
+		"message": "同一層"
+	},
+	"app.lab.schematic-preview.selection.material": {
+		"message": "相同材料"
+	},
+	"app.lab.schematic-preview.selection.single": {
+		"message": "單選"
+	},
+	"app.lab.schematic-preview.tab.edit": {
+		"message": "編輯"
+	},
+	"app.lab.schematic-preview.transform": {
+		"message": "整體變換"
+	},
+	"app.lab.schematic-preview.transform.mirror-x": {
+		"message": "沿 X 軸映象"
+	},
+	"app.lab.schematic-preview.transform.mirror-z": {
+		"message": "沿 Z 軸映象"
+	},
+	"app.lab.schematic-preview.transform.rotate-clockwise": {
+		"message": "順時針旋轉"
+	},
+	"app.lab.schematic-preview.transform.rotate-counter-clockwise": {
+		"message": "逆時針旋轉"
+	},
+	"app.lab.schematic-preview.tools": {
+		"message": "工作區工具"
+	},
+	"app.lab.schematic-preview.visibility": {
+		"message": "可見性"
+	},
+	"app.lab.schematic-preview.visibility.hide": {
+		"message": "隱藏所選"
+	},
+	"app.lab.schematic-preview.visibility.isolate": {
+		"message": "僅顯示所選"
+	},
+	"app.lab.schematic-preview.visibility.show-all": {
+		"message": "全部顯示"
+	},
+	"app.lab.schematic-preview.walk-view": {
+		"message": "漫遊視角"
+	},
+	"app.lab.schematic-preview.walk-preview": {
+		"message": "只讀漫遊預覽"
+	},
+	"app.lab.schematic-preview.walk-speed": {
+		"message": "速度 {speed} · 滾輪調速"
+	},
+	"app.onboarding.action.open-schematic-workshop": {
+		"message": "開啟投影工坊，繼續"
+	},
+	"app.onboarding.lab-schematic.description": {
+		"message": "開啟本地 .litematic 或 .schem 檔案，也可以從已安裝例項中選擇。3D 工作區集中提供檢視、測量、圖層控制、材料統計和本地編輯。"
+	},
+	"app.onboarding.lab-schematic.title": {
+		"message": "放置前先檢查建築"
+	},
+	"app.drop.error.unknown-depth-text": {
+		"message": "壓縮檔嵌套層級過深，無法分析。請先解壓到資料夾後重試。"
+	},
+	"app.drop.error.unknown-encrypted-text": {
+		"message": "壓縮檔包含加密檔案，無法分析。"
+	},
+	"app.drop.extract-failed": {
+		"message": "壓縮檔解壓失敗"
+	},
+	"app.drop.installing-file": {
+		"message": "正在安裝 {name}…"
+	},
+	"app.drop.nested-unpack-button": {
+		"message": "繼續分析"
+	},
+	"app.drop.nested-unpack-text": {
+		"message": "此壓縮檔內含嵌套壓縮檔（{size}），需要解壓後才能分析，可能需要一些時間。是否繼續？"
+	},
+	"app.drop.nested-unpack-title": {
+		"message": "偵測到嵌套壓縮檔"
+	},
+	"app.drop.process-failed-title": {
+		"message": "處理檔案失敗"
+	},
+	"app.drop.scan-failed": {
+		"message": "實例掃描失敗"
+	},
+	"app.drop.scanning": {
+		"message": "正在掃描實例…"
+	},
+	"app.drop.temporary-file-text": {
+		"message": "檔案「{file}」似乎是暫存副本。請嘗試從檔案的原始位置拖入，而不是從瀏覽器、壓縮檔或雲端儲存。"
+	},
+	"app.drop.temporary-file-title": {
+		"message": "偵測到暫存檔案"
+	},
+	"app.drop.unexpected-type": {
+		"message": "意外的類型：{type}"
+	},
+	"app.ai-settings.add-model": {
+		"message": "新增模型"
+	},
+	"app.ai-settings.all-providers": {
+		"message": "全部"
+	},
+	"app.ai-settings.api-key": {
+		"message": "API 金鑰"
+	},
+	"app.ai-settings.api-key-configured": {
+		"message": "金鑰已安全儲存在作業系統憑據庫中。"
+	},
+	"app.ai-settings.api-key-optional": {
+		"message": "尚未儲存金鑰；本地服務可無需金鑰執行。"
+	},
+	"app.ai-settings.bedrock.access-key-id": {
+		"message": "AWS 訪問金鑰 ID"
+	},
+	"app.ai-settings.bedrock.api-key": {
+		"message": "API 金鑰"
+	},
+	"app.ai-settings.bedrock.authentication": {
+		"message": "身份驗證"
+	},
+	"app.ai-settings.bedrock.aws-credentials": {
+		"message": "AWS 憑據"
+	},
+	"app.ai-settings.bedrock.secret-access-key": {
+		"message": "AWS 秘密訪問金鑰"
+	},
+	"app.ai-settings.bedrock.session-token": {
+		"message": "AWS 會話令牌（可選）"
+	},
+	"app.ai-settings.clear-credential": {
+		"message": "清除憑據"
+	},
+	"app.ai-settings.clear-key": {
+		"message": "清除金鑰"
+	},
+	"app.ai-settings.credential-configured": {
+		"message": "已安全儲存在作業系統憑據庫中。"
+	},
+	"app.ai-settings.configured-models": {
+		"message": "{count} 個文字模型"
+	},
+	"app.ai-settings.description": {
+		"message": "統一配置文字模型，然後在啟動器的各項功能中使用。"
+	},
+	"app.ai-settings.disabled": {
+		"message": "已禁用"
+	},
+	"app.ai-settings.disabled-providers": {
+		"message": "未啟用的供應商"
+	},
+	"app.ai-settings.enabled": {
+		"message": "已啟用"
+	},
+	"app.ai-settings.enabled-providers": {
+		"message": "已啟用的供應商"
+	},
+	"app.ai-settings.endpoint": {
+		"message": "API 端點"
+	},
+	"app.ai-settings.field.account-id": {
+		"message": "賬戶 ID"
+	},
+	"app.ai-settings.field.api-version": {
+		"message": "API 版本"
+	},
+	"app.ai-settings.field.deployment": {
+		"message": "部署名稱"
+	},
+	"app.ai-settings.field.location": {
+		"message": "位置"
+	},
+	"app.ai-settings.field.project": {
+		"message": "專案 ID"
+	},
+	"app.ai-settings.field.region": {
+		"message": "區域"
+	},
+	"app.ai-settings.master-switch": {
+		"message": "啟用 AI 功能"
+	},
+	"app.ai-settings.master-switch-description": {
+		"message": "關閉後，啟動器中的 AI 操作和供應商選項將全部隱藏。"
+	},
+	"app.ai-settings.model-id": {
+		"message": "模型 ID"
+	},
+	"app.ai-settings.model-name": {
+		"message": "顯示名稱（可選）"
+	},
+	"app.ai-settings.models": {
+		"message": "文字模型"
+	},
+	"app.ai-settings.no-matching-models": {
+		"message": "沒有符合搜尋條件的模型。"
+	},
+	"app.ai-settings.no-models": {
+		"message": "沒有可用模型，請先新增模型 ID。"
+	},
+	"app.ai-settings.no-providers": {
+		"message": "未找到供應商。"
+	},
+	"app.ai-settings.oauth.code": {
+		"message": "授權碼"
+	},
+	"app.ai-settings.oauth.check": {
+		"message": "立即檢查授權狀態"
+	},
+	"app.ai-settings.oauth.checking": {
+		"message": "正在檢查授權狀態"
+	},
+	"app.ai-settings.oauth.connect": {
+		"message": "連線賬戶"
+	},
+	"app.ai-settings.oauth.connected": {
+		"message": "賬戶已連線"
+	},
+	"app.ai-settings.oauth.copy-code": {
+		"message": "複製授權碼"
+	},
+	"app.ai-settings.oauth.denied": {
+		"message": "授權已被拒絕。"
+	},
+	"app.ai-settings.oauth.disconnect": {
+		"message": "斷開連線"
+	},
+	"app.ai-settings.oauth.expired": {
+		"message": "授權碼已過期，請重新開始。"
+	},
+	"app.ai-settings.oauth.open": {
+		"message": "開啟授權頁面"
+	},
+	"app.ai-settings.oauth.pending": {
+		"message": "請在瀏覽器中完成授權，本頁面會自動更新。"
+	},
+	"app.ai-settings.oauth.reconnect": {
+		"message": "重新連線賬戶"
+	},
+	"app.ai-settings.refresh-models": {
+		"message": "獲取模型"
+	},
+	"app.ai-settings.refreshing-models": {
+		"message": "正在獲取……"
+	},
+	"app.ai-settings.save-credential": {
+		"message": "儲存憑據"
+	},
+	"app.ai-settings.save-key": {
+		"message": "儲存金鑰"
+	},
+	"app.ai-settings.save-provider": {
+		"message": "儲存供應商"
+	},
+	"app.ai-settings.saved": {
+		"message": "供應商設定已儲存。"
+	},
+	"app.ai-settings.search": {
+		"message": "搜尋供應商"
+	},
+	"app.ai-settings.search-models": {
+		"message": "搜尋模型"
+	},
+	"app.ai-settings.test": {
+		"message": "測試供應商"
+	},
+	"app.ai-settings.test-model": {
+		"message": "測試模型"
+	},
+	"app.ai-settings.test-success": {
+		"message": "連線成功：{response}"
+	},
+	"app.ai-settings.testing": {
+		"message": "正在測試……"
+	},
+	"app.ai-settings.title": {
+		"message": "AI 供應商"
+	},
+	"app.ai-settings.vertex.service-account": {
+		"message": "服務賬號 JSON"
+	},
+	"app.ai-settings.vertex.service-account-description": {
+		"message": "貼上完整的 Google Cloud 服務賬號 JSON 文件。"
+	},
+	"app.onboarding.ai.description": {
+		"message": "統一連線文字模型供應商、選擇要使用的模型，也可在這裡一鍵關閉所有 AI 功能。"
+	},
+	"app.onboarding.ai.title": {
+		"message": "連線你的 AI 供應商"
+	},
+	"app.translation-settings.ai-model": {
+		"message": "文字模型"
+	},
+	"app.translation-settings.ai-provider": {
+		"message": "AI 供應商"
+	},
+	"app.translation-settings.provider.ai": {
+		"message": "AI 模型"
+	},
+	"app.action-bar.exporting-modpack": {
+		"message": "正在匯出整合包"
+	},
+	"app.lab.mod-translation.title": {
+		"message": "模組翻譯"
+	},
+	"app.lab.mod-translation.description": {
+		"message": "把任意 Minecraft 模組 JAR 翻譯成簡體中文。"
+	},
+	"app.lab.mod-translation.input-section": {
+		"message": "輸入"
+	},
+	"app.lab.mod-translation.ai-section": {
+		"message": "AI 與選項"
+	},
+	"app.lab.mod-translation.jobs-section": {
+		"message": "任務"
+	},
+	"app.lab.mod-translation.start-hint": {
+		"message": "先選擇 JAR 和 AI 模型再開始。"
+	},
+	"app.lab.mod-translation.output-path": {
+		"message": "輸出：{path}"
+	},
+	"app.lab.mod-translation.select-file": {
+		"message": "選擇模組 JAR"
+	},
+	"app.lab.mod-translation.analyze": {
+		"message": "分析"
+	},
+	"app.lab.mod-translation.analyzing": {
+		"message": "分析中…"
+	},
+	"app.lab.mod-translation.analyzing-elapsed": {
+		"message": "已分析 {seconds} 秒"
+	},
+	"app.lab.mod-translation.analyzing-hint": {
+		"message": "本地預檢：正在解包並掃描模組文字，不消耗 AI token。"
+	},
+	"app.lab.mod-translation.ai-load-error": {
+		"message": "AI 設定載入失敗，請檢查網路後重試。"
+	},
+	"app.lab.mod-translation.analysis": {
+		"message": "分析結果"
+	},
+	"app.lab.mod-translation.loader": {
+		"message": "載入器"
+	},
+	"app.lab.mod-translation.language-entries": {
+		"message": "語言條目"
+	},
+	"app.lab.mod-translation.language-characters": {
+		"message": "字元數"
+	},
+	"app.lab.mod-translation.class-candidates": {
+		"message": "Class 文字候選"
+	},
+	"app.lab.mod-translation.estimated-quote": {
+		"message": "預計消耗"
+	},
+	"app.lab.mod-translation.points": {
+		"message": "{points} 點"
+	},
+	"app.lab.mod-translation.provider": {
+		"message": "AI 提供商"
+	},
+	"app.lab.mod-translation.model": {
+		"message": "文字模型"
+	},
+	"app.lab.mod-translation.ai-not-configured": {
+		"message": "AI 尚未配置。請先在 AI 設定中啟用提供商和模型。"
+	},
+	"app.lab.mod-translation.options": {
+		"message": "選項"
+	},
+	"app.lab.mod-translation.batch-size": {
+		"message": "批次大小"
+	},
+	"app.lab.mod-translation.generate-mod-name": {
+		"message": "AI 生成中文模組名"
+	},
+	"app.lab.mod-translation.repair-enabled": {
+		"message": "複驗後批次修復疑難翻譯"
+	},
+	"app.lab.mod-translation.class-text-enabled": {
+		"message": "改寫高階 .class 文字候選"
+	},
+	"app.lab.mod-translation.start": {
+		"message": "開始翻譯"
+	},
+	"app.lab.mod-translation.cancel": {
+		"message": "取消"
+	},
+	"app.lab.mod-translation.cancelling": {
+		"message": "取消中…"
+	},
+	"app.lab.mod-translation.no-jobs": {
+		"message": "開始的任務會顯示在這裡。"
+	},
+	"app.lab.mod-translation.open-output": {
+		"message": "開啟輸出目錄"
+	},
+	"app.lab.mod-translation.done": {
+		"message": "完成"
+	},
+	"app.lab.mod-translation.failed": {
+		"message": "失敗"
+	},
+	"app.lab.mod-translation.signed-mod": {
+		"message": "該模組帶有數字簽名，無法修改。"
+	},
+	"app.lab.mod-translation.phase.prepare": {
+		"message": "準備"
+	},
+	"app.lab.mod-translation.phase.research": {
+		"message": "生成名稱"
+	},
+	"app.lab.mod-translation.phase.language": {
+		"message": "語言"
+	},
+	"app.lab.mod-translation.phase.repair": {
+		"message": "質量檢查"
+	},
+	"app.lab.mod-translation.phase.class": {
+		"message": "Class 文字"
+	},
+	"app.lab.mod-translation.phase.validation": {
+		"message": "驗收"
+	},
+	"app.lab.mod-translation.phase.packaging": {
+		"message": "打包"
+	},
+	"app.lab.mod-translation.operation-failed": {
+		"message": "模組翻譯操作失敗。"
+	},
+	"app.lab.mod-translation.language-sources": {
+		"message": "語言原始檔"
+	},
+	"app.lab.mod-translation.preparing": {
+		"message": "準備中…"
+	},
+	"app.lab.mod-translation.estimated-tokens": {
+		"message": "{tokens} 個 token"
+	},
+	"app.lab.mod-translation.estimated-tokens-detail": {
+		"message": "約 {calls} 次呼叫 · 輸入 {input} / 輸出 {output}"
+	},
+	"app.lab.mod-translation.active-count": {
+		"message": "{count} 個任務進行中"
+	},
+	"app.lab.mod-translation.completed-count": {
+		"message": "{count} 個已完成"
+	},
+	"app.lab.mod-translation.failed-count": {
+		"message": "{count} 個失敗"
+	},
+	"app.lab.mod-translation.all-finished": {
+		"message": "所有任務已結束"
+	},
+	"app.lab.mod-translation.background-running": {
+		"message": "任務仍在後臺執行"
+	},
+	"app.curseforge.manual-downloads.choose-file": {
+		"message": "選擇本機檔案"
+	},
+	"app.instance.mods.skipped-files-warning.complete": {
+		"message": "補齊缺失檔案"
+	},
+	"app.downloads.item-status.failed": {
+		"message": "失敗"
+	},
+	"app.multiplayer.hongshi.download": {
+		"message": "下載紅石聯機"
+	},
+	"app.multiplayer.hongshi.binary-missing": {
+		"message": "建立房間前，請先下載適用於當前裝置的紅石聯機核心。"
+	},
+	"app.multiplayer.terracotta.public-nodes": {
+		"message": "陶瓦公共節點"
+	},
+	"app.multiplayer.terracotta.public-nodes-description": {
+		"message": "每行輸入一個節點 URI。變更將在下次建立或加入房間時生效。留空則僅使用陶瓦內建節點。"
+	},
+	"app.multiplayer.terracotta.public-nodes-placeholder": {
+		"message": "wss://center.node.1tmc.top"
+	},
+	"app.multiplayer.terracotta.public-node-invalid": {
+		"message": "節點 URI 無效：{node}。請使用 http、https、tcp、tls、udp、ws 或 wss。"
+	},
+	"app.multiplayer.terracotta.save-public-nodes": {
+		"message": "儲存節點"
+	},
+	"app.multiplayer.terracotta.public-nodes-saved": {
+		"message": "陶瓦公共節點已儲存"
+	},
+	"app.onboarding.privacy.description": {
+		"message": "匿名遙測、Discord 活動狀態與 Minecraft 日誌分析服務都可以在這裡調整。"
+	},
+	"app.onboarding.privacy.title": {
+		"message": "你的資料，由你決定"
+	},
+	"app.privacy-consent.continue": {
+		"message": "儲存並繼續"
+	},
+	"app.privacy-consent.discord-rpc": {
+		"message": "Discord 活動狀態"
+	},
+	"app.privacy-consent.discord-rpc-description": {
+		"message": "Discord 執行時顯示你當前使用啟動器或遊玩的狀態。"
+	},
+	"app.privacy-consent.intro": {
+		"message": "選擇 Axolotl 可以傳送或展示的內容。確認前不會傳送任何遙測。"
+	},
+	"app.privacy-consent.privacy-policy": {
+		"message": "閱讀隱私政策"
+	},
+	"app.privacy-consent.telemetry": {
+		"message": "允許匿名遙測"
+	},
+	"app.privacy-consent.telemetry-description": {
+		"message": "透過脫敏且限長的報告統計選擇加入的安裝量並排查啟動器錯誤。不會上傳完整 Minecraft 日誌或賬戶憑據。"
+	},
+	"app.privacy-consent.title": {
+		"message": "隱私與安全"
+	},
+	"app.settings.about.preview-privacy-consent-modal": {
+		"message": "預覽隱私與安全彈窗"
+	},
+	"app.settings.privacy.data-handling": {
+		"message": "遙測使用隨機安裝標識。錯誤上下文離開裝置前會經過脫敏和長度限制。關閉遙測會立即清空待傳送報告。"
+	},
+	"app.settings.privacy.discord-rpc": {
+		"message": "Discord 活動狀態"
+	},
+	"app.settings.privacy.discord-rpc-description": {
+		"message": "在 Discord 中顯示你當前使用啟動器或遊玩的狀態。"
+	},
+	"app.settings.privacy.telemetry": {
+		"message": "允許遙測"
+	},
+	"app.settings.privacy.telemetry-description": {
+		"message": "傳送匿名每日活躍訊號和脫敏的啟動器錯誤報告。絕不上傳 Minecraft 日誌或賬戶憑據。"
+	},
+	"app.curseforge.manual-downloads.state-changed": {
+		"message": "下載狀態已變更，正在等待同步。"
+	},
+	"app.instances.selected-count": {
+		"message": "已選擇 {count} 個"
+	},
+	"app.instances.select-all": {
+		"message": "全選"
+	},
+	"app.instances.edit-groups": {
+		"message": "編輯分組"
+	},
+	"app.instances.deselect-all": {
+		"message": "取消全選"
+	},
+	"app.instances.batch-edit-groups.header": {
+		"message": "編輯分組"
+	},
+	"app.instances.batch-edit-groups.enter-group-name": {
+		"message": "分組名稱"
+	},
+	"app.instances.batch-edit-groups.description": {
+		"message": "為 {count} 個實例設定分組"
+	},
+	"app.instances.batch-edit-groups.create-group": {
+		"message": "建立新分組"
+	},
+	"app.instances.batch-edit-groups.apply": {
+		"message": "套用"
+	},
+	"app.content-install.preview.unavailable-curseforge-project": {
+		"message": "CurseForge 專案不可用"
+	},
+	"app.content-install.preview.skip.dependency-cycle": {
+		"message": "檢測到前置迴圈依賴"
+	},
+	"app.content-install.preview.skip.dependency-depth-exceeded": {
+		"message": "已達到前置解析深度上限"
+	},
+	"app.content-install.preview.skip.modrinth-lookup-failed": {
+		"message": "無法驗證 Modrinth 兜底版本"
+	},
+	"app.content-install.preview.sha1-verified-modrinth-fallback": {
+		"message": "已透過 SHA-1 驗證的 Modrinth 兜底版本"
+	},
+	"app.content-install.preview.install-resolved": {
+		"message": "安裝已解析內容"
+	},
+	"app.browse.display-mode.switch": {
+		"message": "切換檢視"
+	},
+	"app.browse.display-mode.list": {
+		"message": "列表"
+	},
+	"app.browse.display-mode.grid": {
+		"message": "網格"
+	},
+	"app.browse.display-mode.compact-list": {
+		"message": "緊湊列表"
+	},
+	"app.browse.add": {
+		"message": "新增"
+	},
+	"app.settings.resources.source.tianpao": {
+		"message": "Tianpao 鏡像"
+	},
+	"app.settings.resources.modrinth-mirror-description": {
+		"message": "Modrinth 檔案下載。"
+	},
+	"app.settings.resources.modrinth-mirror": {
+		"message": "Modrinth"
+	},
+	"app.downloads.source.tianpao": {
+		"message": "Tianpao 鏡像"
+	},
+	"app.browse.choose-instance": {
+		"message": "選擇例項"
+	},
+	"app.browse.install-selected": {
+		"message": "安裝 {count} 個內容"
+	},
+	"app.browse.preparing-selected": {
+		"message": "正在準備 {completed}/{total}"
+	},
+	"app.browse.selected": {
+		"message": "已選擇"
+	},
+	"app.browse.no-compatible-version": {
+		"message": "未找到與所選例項相容的版本。"
+	},
+	"app.browse.instance-selector.title": {
+		"message": "選擇一個例項"
+	},
+	"app.browse.instance-selector.search": {
+		"message": "搜尋例項"
+	},
+	"app.browse.instance-selector.no-instances": {
+		"message": "請先建立例項再安裝內容"
+	},
+	"app.browse.instance-selector.no-results": {
+		"message": "沒有匹配的例項"
+	},
+	"app.browse.instance-selector.select": {
+		"message": "選擇 {name}"
+	},
+	"app.browse.instance-selector.create": {
+		"message": "建立例項"
+	},
+	"app.browse.instance-selector.switch-title": {
+		"message": "更改安裝目標？"
+	},
+	"app.browse.instance-selector.switch-description": {
+		"message": "{count, plural, other {已為當前目標解析 # 個選定專案。切換後會丟棄已解析的版本。}}"
+	},
+	"app.browse.instance-selector.current-target": {
+		"message": "當前目標"
+	},
+	"app.browse.instance-selector.new-target": {
+		"message": "新目標"
+	},
+	"app.browse.instance-selector.install-current": {
+		"message": "安裝到當前例項"
+	},
+	"app.browse.instance-selector.installing-current": {
+		"message": "正在準備安裝…"
+	},
+	"app.browse.instance-selector.clear-and-switch": {
+		"message": "清空並切換"
+	},
+	"app.browse.instance-selector.cancel": {
+		"message": "取消"
+	},
+	"app.content-install.preview.batch-description": {
+		"message": "請確認將在 {instance} 中安裝 {projectCount, plural, other {# 個內容}} 和 {dependencyCount, plural, other {# 個前置}}。"
+	},
+	"app.content-install.preview.selected-content-header": {
+		"message": "已選內容"
+	},
+	"app.content-install.preview.remove-project": {
+		"message": "從本次安裝中移除 {project}"
+	},
+	"app.content-install.preview.conflict-header": {
+		"message": "可能重複的內容"
+	},
+	"app.content-install.preview.conflict-description": {
+		"message": "{candidate} 可能與已安裝或已選擇的內容相同，仍要繼續嗎？"
+	},
+	"app.content-install.preview.continue-anyway": {
+		"message": "仍然安裝"
+	},
+	"app.content-install.preview.existing-content": {
+		"message": "已有內容"
+	},
+	"app.content-selection.preview-failed": {
+		"message": "部分所選內容無法準備安裝。請移除後重試。"
+	},
+	"app.settings.storage.total": {
+		"message": "總大小"
+	},
+	"app.settings.storage.total-description": {
+		"message": "總大小包含符號連結與 Junction 引用的大小"
+	},
+	"app.settings.storage.instance-data": {
+		"message": "例項資料"
+	},
+	"app.settings.storage.cache-data": {
+		"message": "快取資料"
+	},
+	"app.settings.storage.meta-data": {
+		"message": "Meta 資料"
+	},
+	"app.settings.storage.database": {
+		"message": "資料庫"
+	},
+	"app.settings.storage.other": {
+		"message": "其他"
+	},
+	"app.settings.storage.instance": {
+		"message": "例項"
+	},
+	"app.settings.storage.mods": {
+		"message": "模組"
+	},
+	"app.settings.storage.replay": {
+		"message": "回放"
+	},
+	"app.settings.storage.resourcepacks": {
+		"message": "資源包"
+	},
+	"app.settings.storage.saves": {
+		"message": "存檔"
+	},
+	"app.settings.storage.world": {
+		"message": "世界"
+	},
+	"app.settings.storage.schematics": {
+		"message": "投影"
+	},
+	"app.settings.storage.screenshots": {
+		"message": "截圖"
+	},
+	"app.settings.storage.shaderpacks": {
+		"message": "光影包"
+	},
+	"app.settings.storage.minimap": {
+		"message": "小地圖"
+	},
+	"app.settings.storage.distant-horizons": {
+		"message": "虛擬視距快取"
+	},
+	"app.settings.storage.db-file": {
+		"message": "資料庫檔案"
+	},
+	"app.settings.storage.db-backup": {
+		"message": "資料庫備份"
+	},
+	"app.settings.storage.item-count": {
+		"message": "{count} 個"
+	},
+	"app.settings.storage.instance-count": {
+		"message": "{count} 個例項"
+	},
+	"app.settings.storage.actual-size-tooltip": {
+		"message": "實際大小：{size}"
+	},
+	"app.settings.storage.symlink-size-tooltip": {
+		"message": "符號連結或 Junction 引用的大小：{size}"
+	},
+	"app.settings.storage.open-action": {
+		"message": "在啟動器中開啟或開啟位置"
+	},
+	"app.settings.storage.symlink-label": {
+		"message": "軟連結"
+	},
+	"app.settings.storage.symlink-help": {
+		"message": "什麼是軟連結？"
+	},
+	"app.settings.storage.symlink-help-tooltip": {
+		"message": "軟連結指本啟動器從其它位置引用的MC資源，這些檔案可能實際位於其它啟動器的目錄\n例如“20MB + 1.2GB”指本啟動器目錄中有20MB檔案，引用外部1.2GB檔案"
+	},
+	"app.content-selection.queue-failed": {
+		"message": "部分內容未能加入安裝佇列，仍保留在已選列表中。"
+	},
+	"app.content-selection.dependency-conflict": {
+		"message": "{dependency} 在當前選擇中解析出了衝突版本。"
+	},
+	"app.content-selection.unknown-dependency": {
+		"message": "前置 {id}"
+	},
+	"app.settings.storage.last-updated-label": {
+		"message": "上次更新："
+	},
+	"app.settings.storage.update": {
+		"message": "更新"
+	},
+	"app.settings.storage.updating": {
+		"message": "更新中…"
+	},
+	"app.settings.storage.scanning": {
+		"message": "正在掃描儲存…"
+	},
+	"app.content-selection.unknown-reason": {
+		"message": "無法解析"
+	},
+	"app.content-selection.target-changed": {
+		"message": "所選內容屬於另一個例項。請切換回該例項或先清空選擇。"
+	},
+	"app.content-selection.duplicate-content": {
+		"message": "{project} 已從另一個來源安裝或選中。"
+	},
+	"app.content-selection.conflict-unavailable": {
+		"message": "無法確認該內容是否與另一個來源重複。"
+	},
+	"app.project.install-button.no-compatible-version": {
+		"message": "當前例項沒有相容版本。"
+	},
+	"app.settings.tabs.storage": {
+		"message": "儲存"
+	},
+	"app.instance.icon-picker.use-icon": {
+		"message": "使用此圖示"
+	},
+	"app.instance.icon-picker.surprise-me": {
+		"message": "隨機生成"
+	},
+	"app.instance.icon-picker.saving": {
+		"message": "儲存中……"
+	},
+	"app.instance.icon-picker.modrinth-3d.zombie": {
+		"message": "殭屍"
+	},
+	"app.instance.icon-picker.modrinth-3d.wrench-rinth": {
+		"message": "Modrinth 扳手"
+	},
+	"app.instance.icon-picker.modrinth-3d.wrench": {
+		"message": "扳手"
+	},
+	"app.instance.icon-picker.modrinth-3d.tnt": {
+		"message": "TNT"
+	},
+	"app.instance.icon-picker.modrinth-3d.tire": {
+		"message": "輪胎"
+	},
+	"app.instance.icon-picker.modrinth-3d.tiny-potato": {
+		"message": "小土豆"
+	},
+	"app.instance.icon-picker.modrinth-3d.terminal": {
+		"message": "終端"
+	},
+	"app.instance.icon-picker.modrinth-3d.sword": {
+		"message": "劍"
+	},
+	"app.instance.icon-picker.modrinth-3d.sticky-piston": {
+		"message": "黏性活塞"
+	},
+	"app.instance.icon-picker.modrinth-3d.space-helmet": {
+		"message": "太空頭盔"
+	},
+	"app.instance.icon-picker.modrinth-3d.slime-block": {
+		"message": "黏液塊"
+	},
+	"app.instance.icon-picker.modrinth-3d.skillet": {
+		"message": "煎鍋"
+	},
+	"app.instance.icon-picker.modrinth-3d.skeleton": {
+		"message": "骷髏"
+	},
+	"app.instance.icon-picker.modrinth-3d.sculk-sensor": {
+		"message": "幽匿感測體"
+	},
+	"app.instance.icon-picker.modrinth-3d.redstone-block": {
+		"message": "紅石塊"
+	},
+	"app.instance.icon-picker.modrinth-3d.poke-ball": {
+		"message": "精靈球"
+	},
+	"app.instance.icon-picker.modrinth-3d.pickaxe": {
+		"message": "鎬"
+	},
+	"app.instance.icon-picker.modrinth-3d.pancakes": {
+		"message": "煎餅"
+	},
+	"app.instance.icon-picker.modrinth-3d.oxygen-distributor": {
+		"message": "氧氣分配器"
+	},
+	"app.instance.icon-picker.modrinth-3d.orb": {
+		"message": "起源之球"
+	},
+	"app.instance.icon-picker.modrinth-3d.mr-pack": {
+		"message": "Mr-Pack"
+	},
+	"app.instance.icon-picker.modrinth-3d.moobloom": {
+		"message": "哞花"
+	},
+	"app.instance.icon-picker.modrinth-3d.lantern": {
+		"message": "燈籠"
+	},
+	"app.instance.icon-picker.modrinth-3d.grass-block": {
+		"message": "草方塊"
+	},
+	"app.instance.icon-picker.modrinth-3d.globe": {
+		"message": "地球儀"
+	},
+	"app.instance.icon-picker.modrinth-3d.gizmo": {
+		"message": "小裝置"
+	},
+	"app.instance.icon-picker.modrinth-3d.furnace": {
+		"message": "熔爐"
+	},
+	"app.instance.icon-picker.modrinth-3d.engine": {
+		"message": "引擎"
+	},
+	"app.instance.icon-picker.modrinth-3d.ender-dragon": {
+		"message": "末影龍"
+	},
+	"app.instance.icon-picker.modrinth-3d.ender-chest": {
+		"message": "末影箱"
+	},
+	"app.instance.icon-picker.modrinth-3d.enchanting-table": {
+		"message": "附魔臺"
+	},
+	"app.instance.icon-picker.modrinth-3d.creeper": {
+		"message": "苦力怕"
+	},
+	"app.instance.icon-picker.modrinth-3d.crafting-table": {
+		"message": "工作臺"
+	},
+	"app.instance.icon-picker.modrinth-3d.couch": {
+		"message": "沙發"
+	},
+	"app.instance.icon-picker.modrinth-3d.cooking-pot": {
+		"message": "烹飪鍋"
+	},
+	"app.instance.icon-picker.modrinth-3d.command-block": {
+		"message": "命令方塊"
+	},
+	"app.instance.icon-picker.modrinth-3d.cogwheel": {
+		"message": "齒輪"
+	},
+	"app.instance.icon-picker.modrinth-3d.chest": {
+		"message": "箱子"
+	},
+	"app.instance.icon-picker.modrinth-3d.campfire": {
+		"message": "營火"
+	},
+	"app.instance.icon-picker.modrinth-3d.cake": {
+		"message": "蛋糕"
+	},
+	"app.instance.icon-picker.modrinth-3d.brown-bear": {
+		"message": "棕熊"
+	},
+	"app.instance.icon-picker.modrinth-3d.bookshelf": {
+		"message": "書架"
+	},
+	"app.instance.icon-picker.modrinth-3d.blue-shark": {
+		"message": "藍鯊"
+	},
+	"app.instance.icon-picker.modrinth-3d.beacon": {
+		"message": "信標"
+	},
+	"app.instance.icon-picker.modrinth-3d.backpack": {
+		"message": "揹包"
+	},
+	"app.instance.icon-picker.group.original": {
+		"message": "原版圖示"
+	},
+	"app.instance.icon-picker.group.modrinth-3d": {
+		"message": "Modrinth 3D 圖示"
+	},
+	"app.instance.icon-picker.background.transparent": {
+		"message": "透明"
+	},
+	"app.instance.icon-picker.background.sunset": {
+		"message": "日落"
+	},
+	"app.instance.icon-picker.background.stone": {
+		"message": "石頭"
+	},
+	"app.instance.icon-picker.background.slime": {
+		"message": "史萊姆"
+	},
+	"app.instance.icon-picker.background.ocean": {
+		"message": "海洋"
+	},
+	"app.instance.icon-picker.background.nether": {
+		"message": "下界"
+	},
+	"app.instance.icon-picker.background.midnight": {
+		"message": "午夜"
+	},
+	"app.instance.icon-picker.background.grass": {
+		"message": "草地"
+	},
+	"app.instance.icon-picker.background.deep-dark": {
+		"message": "深暗之域"
+	},
+	"app.instance.icon-picker.background.cherry": {
+		"message": "櫻花"
+	},
+	"app.instance.icon-picker.background.amethyst": {
+		"message": "紫水晶"
+	},
+	"app.instance.icon-picker.background": {
+		"message": "背景"
+	},
+	"app.export-modal.export-complete-description": {
+		"message": "{name} 已成功匯出。"
+	},
+	"app.export-modal.export-complete": {
+		"message": "匯出完成"
+	},
+	"app.drop.batch.target-label": {
+		"message": "為該批次選擇目標例項"
+	},
+	"app.drop.compatible-mode-cancel": {
+		"message": "取消"
+	},
+	"app.drop.compatible-mode-desc": {
+		"message": "要以相容模式匯入此例項嗎？"
+	},
+	"app.drop.compatible-mode-import": {
+		"message": "相容模式匯入"
+	},
+	"app.drop.compatible-mode-old-way": {
+		"message": "按舊版方式匯入"
+	},
+	"app.drop.compatible-mode-title": {
+		"message": "這似乎是一個未啟用版本隔離的例項"
+	},
+	"app.drop.batch.nothing-importable-title": {
+		"message": "沒有可匯入的內容"
+	},
+	"app.drop.batch.nothing-importable-text": {
+		"message": "{count, plural, one {# 個檔案} other {# 個檔案}}無法識別。"
+	},
+	"app.drop.batch.import-cancelled-title": {
+		"message": "匯入已取消"
+	},
+	"app.drop.batch.import-cancelled-text": {
+		"message": "未匯入任何內容。"
+	},
+	"app.drop.batch.group-file-label": {
+		"message": "{count, plural, one {# 個檔案} other {# 個檔案}}：{names}"
+	},
+	"app.drop.batch.completed-title": {
+		"message": "匯入完成"
+	},
+	"app.drop.batch.completed-text": {
+		"message": "已匯入 {succeeded} / {total}（{failed} 失敗，{skipped} 跳過）。"
+	},
+	"app.settings.resources.proxy-username-placeholder": {
+		"message": "使用者名稱（可選）"
+	},
+	"app.settings.resources.proxy-username": {
+		"message": "使用者名稱"
+	},
+	"app.settings.resources.proxy-url-placeholder": {
+		"message": "支援http、https或socks5，eg: socks5://localhost:1080"
+	},
+	"app.settings.resources.proxy-url": {
+		"message": "代理地址"
+	},
+	"app.settings.resources.proxy-url-required": {
+		"message": "代理地址不能為空"
+	},
+	"app.settings.resources.proxy-testing": {
+		"message": "測試中..."
+	},
+	"app.settings.resources.proxy-test-success-latency": {
+		"message": "連線成功（{latency} 毫秒）"
+	},
+	"app.settings.resources.proxy-test-success": {
+		"message": "連線成功"
+	},
+	"app.settings.resources.proxy-test-failed": {
+		"message": "連線失敗"
+	},
+	"app.settings.resources.proxy-test": {
+		"message": "測試連線"
+	},
+	"app.settings.resources.proxy-settings-description": {
+		"message": "配置啟動器連線網際網路的方式。系統代理遵循作業系統設定。自定義代理允許指定代理地址及可選的認證資訊。"
+	},
+	"app.settings.resources.proxy-settings": {
+		"message": "代理設定"
+	},
+	"app.settings.resources.proxy-password-placeholder": {
+		"message": "密碼（可選）"
+	},
+	"app.settings.resources.proxy-password": {
+		"message": "密碼"
+	},
+	"app.settings.resources.proxy-mode.system": {
+		"message": "使用系統代理"
+	},
+	"app.settings.resources.proxy-mode.none": {
+		"message": "不使用代理（直連）"
+	},
+	"app.settings.resources.proxy-mode.custom": {
+		"message": "自定義代理"
+	},
+	"app.settings.resources.proxy-mode": {
+		"message": "代理模式"
+	},
+	"app.java-arguments.presets.gc.auto.verified": {
+		"message": "上次啟動：{chosen}"
+	},
+	"app.instance.icon-picker.icon.optifine": {
+		"message": "OptiFine"
+	},
+	"app.instance.icon-picker.icon.liteloader": {
+		"message": "LiteLoader"
+	},
+	"app.instance.icon-picker.icon.cleanroom": {
+		"message": "Cleanroom"
+	},
+	"app.gc-notice.fallback": {
+		"message": "Java 不接受 {preferred}，已改用 {chosen}。"
+	},
+	"app.browse.project-type.favorites": {
+		"message": "收藏夾"
+	},
+	"app.content-favorites.add": {
+		"message": "新增到收藏夾"
+	},
+	"app.content-favorites.empty-description": {
+		"message": "收藏模組、資源包、資料包和光影包，之後隨時安裝。"
+	},
+	"app.content-favorites.empty-title": {
+		"message": "暫無收藏"
+	},
+	"app.content-favorites.loading": {
+		"message": "正在更新收藏夾…"
+	},
+	"app.content-favorites.no-matches-description": {
+		"message": "換個搜尋詞或內容型別試試。"
+	},
+	"app.content-favorites.no-matches-title": {
+		"message": "沒有匹配的收藏"
+	},
+	"app.content-favorites.remove": {
+		"message": "從收藏夾移除"
+	},
+	"app.content-favorites.search": {
+		"message": "搜尋收藏夾"
+	},
+	"app.content-favorites.sort.recently-saved": {
+		"message": "最近收藏"
+	},
+	"app.content-favorites.title": {
+		"message": "收藏夾"
+	},
+	"app.content-favorites.type.all": {
+		"message": "全部內容型別"
+	},
+	"app.content-favorites.unavailable-description": {
+		"message": "該專案當前暫時不可用。你可以從收藏夾中移除它。"
+	},
+	"app.content-favorites.unavailable-title": {
+		"message": "{provider} 專案 {projectId}"
+	},
+	"app.onboarding.action.click-favorites": {
+		"message": "點選收藏夾，繼續"
+	},
+	"app.onboarding.favorites.description": {
+		"message": "開啟收藏夾，回看儲存的模組、資源包、資料包和光影包。啟動器會重新整理專案詳情；隨後你可以選擇例項，並把不同來源的內容加入同一個安裝購物車。"
+	},
+	"app.onboarding.favorites.title": {
+		"message": "留個清單"
+	},
+	"app.settings.about.survey-description": {
+		"message": "幫助我們改進 Axolotl Launcher"
+	},
+	"app.settings.about.survey": {
+		"message": "調查問卷"
+	},
+	"app.library.view.standard": {
+		"message": "標準網格"
+	},
+	"app.library.view.cards": {
+		"message": "例項庫卡片"
+	},
+	"app.library.view": {
+		"message": "檢視"
+	},
 	"app.translation-settings.provider.deepl": {
 		"message": "DeepL 翻譯"
 	},
@@ -4889,8 +7928,32 @@
 	"app.survey-promotion.defer-hint": {
 		"message": "關閉此彈窗後，你仍可以隨時在「設定 → 關於」頁面中找到並填寫問卷。"
 	},
-	"app.instances.exit-select-mode": {
-		"message": "退出"
+	"browse.selected-projects-floating-bar.hide-projects": {
+		"message": "隱藏已選擇的專案"
+	},
+	"browse.selected-projects-floating-bar.show-projects": {
+		"message": "顯示 {count, plural, one {# selected project} other {# selected projects}}"
+	},
+	"app.translation-settings.provider.microsoft": {
+		"message": "Microsoft 翻譯（無法使用）"
+	},
+	"instance.files.studio.unsaved-switch-blocked": {
+		"message": "請先儲存或放棄當前更改，再開啟其他檔案。"
+	},
+	"app.settings.resources.source.mcim": {
+		"message": "MCIM 鏡像"
+	},
+	"app.settings.storage.collapse-action": {
+		"message": "摺疊"
+	},
+	"app.settings.storage.expand-action": {
+		"message": "展開"
+	},
+	"app.multiplayer.tab.rooms": {
+		"message": "聯機房間"
+	},
+	"app.multiplayer.tab.servers": {
+		"message": "伺服器"
 	},
 	"app.servers.action.open-folder": {
 		"message": "開啟資料夾"
@@ -4910,26 +7973,17 @@
 	"app.servers.card.type": {
 		"message": "{type} · {version}"
 	},
-	"app.servers.console.command-echo": {
-		"message": "> {command}"
-	},
-	"app.servers.console.not-running": {
-		"message": "伺服器未執行"
+	"app.servers.create.title": {
+		"message": "建立伺服器"
 	},
 	"app.servers.count": {
 		"message": "{count, plural, =0 {還沒有伺服器} other {共 # 個伺服器}}"
-	},
-	"app.servers.create.title": {
-		"message": "建立伺服器"
 	},
 	"app.servers.detail.back": {
 		"message": "伺服器"
 	},
 	"app.servers.detail.console": {
 		"message": "主控台"
-	},
-	"app.servers.detail.files": {
-		"message": "檔案"
 	},
 	"app.servers.detail.not-found": {
 		"message": "該伺服器已不存在。"
@@ -4958,44 +8012,182 @@
 	"app.servers.loading": {
 		"message": "載入中"
 	},
-	"app.servers.files.busy-tooltip": {
-		"message": "停止伺服器後才能修改檔案"
+	"app.servers.properties.load-failed": {
+		"message": "載入伺服器設定失敗。"
 	},
-	"app.servers.files.save-as": {
-		"message": "另存為..."
+	"app.servers.properties.missing": {
+		"message": "啟動一次伺服器即可產生此檔案。"
 	},
-	"app.servers.icon.change": {
-		"message": "變更圖示"
+	"app.servers.properties.mode.form": {
+		"message": "表單"
 	},
-	"app.servers.icon.edit": {
-		"message": "編輯圖示"
+	"app.servers.properties.mode.text": {
+		"message": "文字"
 	},
-	"app.servers.icon.remove": {
-		"message": "移除圖示"
+	"app.servers.properties.save": {
+		"message": "儲存變更"
 	},
-	"app.servers.icon.select": {
-		"message": "選擇圖示"
+	"app.servers.properties.saved": {
+		"message": "伺服器設定已儲存"
 	},
-	"app.servers.port.change": {
-		"message": "修改連接埠"
+	"app.servers.properties.title": {
+		"message": "伺服器屬性"
 	},
-	"app.servers.port.conflict-description": {
-		"message": "{process} 正在佔用此連接埠，伺服器無法啟動。建議修改伺服器連接埠，也可以強制結束佔用程序後再啟動。"
+	"app.servers.refresh": {
+		"message": "重新整理"
 	},
-	"app.servers.port.conflict-title": {
-		"message": "連接埠 {port} 已被佔用"
+	"app.servers.settings.config": {
+		"message": "設定檔"
 	},
-	"app.servers.port.force-quit": {
-		"message": "強制結束佔用程序"
+	"app.servers.settings.delete": {
+		"message": "刪除伺服器"
 	},
-	"app.servers.port.force-quit-failed": {
-		"message": "結束佔用連接埠的程序失敗"
+	"app.servers.settings.delete-confirm": {
+		"message": "刪除 {name} 及其所有檔案？此操作無法復原。"
 	},
-	"app.servers.port.recheck": {
-		"message": "重新偵測"
+	"app.servers.settings.delete-hint": {
+		"message": "永久刪除該伺服器及其所有檔案。"
 	},
-	"app.servers.port.unknown-process": {
-		"message": "未知程序（PID {pid}）"
+	"app.servers.settings.delete-proceed": {
+		"message": "刪除"
+	},
+	"app.servers.settings.general": {
+		"message": "一般"
+	},
+	"app.servers.settings.icon": {
+		"message": "圖示"
+	},
+	"app.servers.settings.java": {
+		"message": "Java"
+	},
+	"app.servers.settings.java-none": {
+		"message": "系統預設"
+	},
+	"app.servers.settings.jvm-args": {
+		"message": "JVM 參數"
+	},
+	"app.servers.settings.jvm-args-hint": {
+		"message": "以空格分隔的參數，例如 -XX:+UseG1GC"
+	},
+	"app.servers.settings.memory": {
+		"message": "記憶體"
+	},
+	"app.servers.settings.name": {
+		"message": "伺服器名稱"
+	},
+	"app.servers.settings.running-hint": {
+		"message": "您的變更在下次啟動伺服器後才會生效。"
+	},
+	"app.servers.settings.running-title": {
+		"message": "伺服器執行中"
+	},
+	"app.servers.settings.save": {
+		"message": "儲存變更"
+	},
+	"app.servers.settings.saved": {
+		"message": "伺服器設定已儲存"
+	},
+	"app.servers.status.crashed": {
+		"message": "已崩潰"
+	},
+	"app.servers.status.created": {
+		"message": "未設定"
+	},
+	"app.servers.status.eula-pending": {
+		"message": "待同意 EULA"
+	},
+	"app.servers.status.ready": {
+		"message": "就緒"
+	},
+	"app.servers.status.running": {
+		"message": "執行中"
+	},
+	"app.servers.status.starting": {
+		"message": "啟動中"
+	},
+	"app.servers.wizard.configure-heading": {
+		"message": "調整伺服器設定，或直接完成，稍後再編輯。"
+	},
+	"app.servers.wizard.configure-title": {
+		"message": "設定"
+	},
+	"app.servers.wizard.done": {
+		"message": "伺服器已就緒"
+	},
+	"app.servers.wizard.downloading": {
+		"message": "正在下載伺服器端檔案…"
+	},
+	"app.servers.wizard.eula-wait": {
+		"message": "等待確認 EULA"
+	},
+	"app.servers.wizard.failed": {
+		"message": "建立失敗"
+	},
+	"app.servers.wizard.finish": {
+		"message": "完成"
+	},
+	"app.servers.wizard.first-run": {
+		"message": "正在首次啟動…"
+	},
+	"app.servers.wizard.game-version": {
+		"message": "遊戲版本"
+	},
+	"app.servers.wizard.install-java": {
+		"message": "安裝 Java"
+	},
+	"app.servers.wizard.install-title": {
+		"message": "安裝"
+	},
+	"app.servers.wizard.java-missing": {
+		"message": "未找到已安裝的 Java。"
+	},
+	"app.servers.wizard.java-missing-hint": {
+		"message": "系統中未找到相容的 Java,下一步將自動安裝所需的 Java。"
+	},
+	"app.servers.wizard.java-placeholder": {
+		"message": "選擇 Java 版本"
+	},
+	"app.servers.wizard.loader-version": {
+		"message": "載入器版本"
+	},
+	"app.servers.wizard.log": {
+		"message": "輸出"
+	},
+	"app.servers.wizard.memory-value": {
+		"message": "{value} MB"
+	},
+	"app.servers.wizard.name": {
+		"message": "伺服器名稱"
+	},
+	"app.servers.wizard.name-placeholder": {
+		"message": "生存服"
+	},
+	"app.servers.wizard.next": {
+		"message": "下一步"
+	},
+	"app.servers.wizard.retry": {
+		"message": "重試"
+	},
+	"app.servers.wizard.setup-title": {
+		"message": "設定"
+	},
+	"app.servers.wizard.show-snapshots": {
+		"message": "顯示快照版本"
+	},
+	"app.servers.wizard.type-coming-soon": {
+		"message": "即將支援"
+	},
+	"app.servers.wizard.type-heading": {
+		"message": "選擇伺服器端類型"
+	},
+	"app.servers.wizard.type-title": {
+		"message": "伺服器端類型"
+	},
+	"app.servers.console.command-echo": {
+		"message": "> {command}"
+	},
+	"app.servers.console.not-running": {
+		"message": "伺服器未執行"
 	},
 	"app.servers.properties.field.accepts-transfers": {
 		"message": "接受玩家轉移"
@@ -5231,24 +8423,6 @@
 	"app.servers.properties.field.white-list": {
 		"message": "白名單"
 	},
-	"app.servers.properties.load-failed": {
-		"message": "載入伺服器設定失敗。"
-	},
-	"app.servers.properties.missing": {
-		"message": "啟動一次伺服器即可產生此檔案。"
-	},
-	"app.servers.properties.mode.form": {
-		"message": "表單"
-	},
-	"app.servers.properties.mode.text": {
-		"message": "文字"
-	},
-	"app.servers.properties.save": {
-		"message": "儲存變更"
-	},
-	"app.servers.properties.saved": {
-		"message": "伺服器設定已儲存"
-	},
 	"app.servers.properties.section.advanced": {
 		"message": "進階"
 	},
@@ -5267,190 +8441,49 @@
 	"app.servers.properties.section.world": {
 		"message": "世界"
 	},
-	"app.servers.properties.title": {
-		"message": "伺服器屬性"
-	},
-	"app.servers.refresh": {
-		"message": "重新整理"
-	},
 	"app.servers.settings.cancel": {
 		"message": "取消"
 	},
-	"app.servers.settings.config": {
-		"message": "設定檔"
+	"app.servers.detail.files": {
+		"message": "檔案"
 	},
-	"app.servers.settings.delete": {
-		"message": "刪除伺服器"
+	"app.servers.files.busy-tooltip": {
+		"message": "停止伺服器後才能修改檔案"
 	},
-	"app.servers.settings.delete-confirm": {
-		"message": "刪除 {name} 及其所有檔案？此操作無法復原。"
+	"app.servers.files.save-as": {
+		"message": "另存為..."
 	},
-	"app.servers.settings.delete-hint": {
-		"message": "永久刪除該伺服器及其所有檔案。"
+	"app.servers.icon.change": {
+		"message": "變更圖示"
 	},
-	"app.servers.settings.delete-proceed": {
-		"message": "刪除"
+	"app.servers.icon.edit": {
+		"message": "編輯圖示"
 	},
-	"app.servers.settings.general": {
-		"message": "一般"
+	"app.servers.icon.remove": {
+		"message": "移除圖示"
 	},
-	"app.servers.settings.icon": {
-		"message": "圖示"
+	"app.servers.icon.select": {
+		"message": "選擇圖示"
 	},
-	"app.servers.settings.java": {
-		"message": "Java"
+	"app.servers.port.change": {
+		"message": "修改連接埠"
 	},
-	"app.servers.settings.java-none": {
-		"message": "系統預設"
+	"app.servers.port.conflict-description": {
+		"message": "{process} 正在佔用此連接埠，伺服器無法啟動。建議修改伺服器連接埠，也可以強制結束佔用程序後再啟動。"
 	},
-	"app.servers.settings.jvm-args": {
-		"message": "JVM 參數"
+	"app.servers.port.conflict-title": {
+		"message": "連接埠 {port} 已被佔用"
 	},
-	"app.servers.settings.jvm-args-hint": {
-		"message": "以空格分隔的參數，例如 -XX:+UseG1GC"
+	"app.servers.port.force-quit": {
+		"message": "強制結束佔用程序"
 	},
-	"app.servers.settings.memory": {
-		"message": "記憶體"
+	"app.servers.port.force-quit-failed": {
+		"message": "結束佔用連接埠的程序失敗"
 	},
-	"app.servers.settings.name": {
-		"message": "伺服器名稱"
+	"app.servers.port.recheck": {
+		"message": "重新偵測"
 	},
-	"app.servers.settings.running-hint": {
-		"message": "您的變更在下次啟動伺服器後才會生效。"
-	},
-	"app.servers.settings.running-title": {
-		"message": "伺服器執行中"
-	},
-	"app.servers.settings.save": {
-		"message": "儲存變更"
-	},
-	"app.servers.settings.saved": {
-		"message": "伺服器設定已儲存"
-	},
-	"app.servers.status.crashed": {
-		"message": "已崩潰"
-	},
-	"app.servers.status.created": {
-		"message": "未設定"
-	},
-	"app.servers.status.eula-pending": {
-		"message": "待同意 EULA"
-	},
-	"app.servers.status.ready": {
-		"message": "就緒"
-	},
-	"app.servers.status.running": {
-		"message": "執行中"
-	},
-	"app.servers.status.starting": {
-		"message": "啟動中"
-	},
-	"app.servers.wizard.configure-heading": {
-		"message": "調整伺服器設定，或直接完成，稍後再編輯。"
-	},
-	"app.servers.wizard.configure-title": {
-		"message": "設定"
-	},
-	"app.servers.wizard.done": {
-		"message": "伺服器已就緒"
-	},
-	"app.servers.wizard.downloading": {
-		"message": "正在下載伺服器端檔案…"
-	},
-	"app.servers.wizard.eula-wait": {
-		"message": "等待確認 EULA"
-	},
-	"app.servers.wizard.failed": {
-		"message": "建立失敗"
-	},
-	"app.servers.wizard.finish": {
-		"message": "完成"
-	},
-	"app.servers.wizard.first-run": {
-		"message": "正在首次啟動…"
-	},
-	"app.servers.wizard.game-version": {
-		"message": "遊戲版本"
-	},
-	"app.servers.wizard.install-title": {
-		"message": "安裝"
-	},
-	"app.servers.wizard.loader-version": {
-		"message": "載入器版本"
-	},
-	"app.servers.wizard.log": {
-		"message": "輸出"
-	},
-	"app.servers.wizard.memory-value": {
-		"message": "{value} MB"
-	},
-	"app.servers.wizard.name": {
-		"message": "伺服器名稱"
-	},
-	"app.servers.wizard.name-placeholder": {
-		"message": "生存服"
-	},
-	"app.servers.wizard.next": {
-		"message": "下一步"
-	},
-	"app.servers.wizard.retry": {
-		"message": "重試"
-	},
-	"app.servers.wizard.setup-title": {
-		"message": "設定"
-	},
-	"app.servers.wizard.show-snapshots": {
-		"message": "顯示快照版本"
-	},
-	"app.servers.wizard.type-heading": {
-		"message": "選擇伺服器端類型"
-	},
-	"app.servers.wizard.type-title": {
-		"message": "伺服器端類型"
-	},
-	"app.settings.resources.source.mcim": {
-		"message": "MCIM 鏡像"
-	},
-	"app.settings.tabs.about": {
-		"message": "關於"
-	},
-	"app.settings.tabs.appearance": {
-		"message": "外觀"
-	},
-	"app.settings.tabs.default-instance-options": {
-		"message": "預設實例選項"
-	},
-	"app.settings.tabs.java-installations": {
-		"message": "Java 安裝"
-	},
-	"app.settings.tabs.language": {
-		"message": "語言"
-	},
-	"app.settings.tabs.multiplayer": {
-		"message": "多人聯機"
-	},
-	"app.settings.tabs.resource-management": {
-		"message": "資源管理"
-	},
-	"app.settings.tabs.translation": {
-		"message": "翻譯"
-	},
-	"app.settings.tabs.updates": {
-		"message": "更新"
-	},
-	"app.translation-settings.provider.microsoft": {
-		"message": "Microsoft 翻譯（無法使用）"
-	},
-	"instance.settings.tabs.general.library-groups": {
-		"message": "遊戲庫群組"
-	},
-	"instance.settings.tabs.general.library-groups.create": {
-		"message": "建立新的群組"
-	},
-	"instance.settings.tabs.general.library-groups.description": {
-		"message": "遊戲庫群組讓你可以將實例整理到遊戲庫中的不同分類。"
-	},
-	"instance.settings.tabs.general.library-groups.enter-name": {
-		"message": "輸入群組名稱"
+	"app.servers.port.unknown-process": {
+		"message": "未知程序（PID {pid}）"
 	}
 }

--- a/packages/ui/src/locales/zh-TW/index.json
+++ b/packages/ui/src/locales/zh-TW/index.json
@@ -1,4504 +1,4504 @@
 {
-	"action.no-permission": {
-		"defaultMessage": "你沒有權限。"
-	},
-	"badge.alpha": {
-		"defaultMessage": "Alpha 版"
-	},
-	"badge.beta": {
-		"defaultMessage": "Beta 版"
-	},
-	"badge.beta-release": {
-		"defaultMessage": "Beta 版發布"
-	},
-	"badge.new": {
-		"defaultMessage": "新功能"
-	},
-	"badge.release": {
-		"defaultMessage": "正式版"
-	},
-	"browse.filter-results": {
-		"defaultMessage": "篩選結果..."
-	},
-	"browse.no-results": {
-		"defaultMessage": "找不到符合你查詢的結果！"
-	},
-	"browse.offline": {
-		"defaultMessage": "你目前處於離線狀態，請連線至網路以瀏覽 Modrinth！"
-	},
-	"browse.search.placeholder": {
-		"defaultMessage": "搜尋{projectType}..."
-	},
-	"browse.selected-projects-floating-bar.aria-label": {
-		"defaultMessage": "已選取專案"
-	},
-	"browse.selected-projects-floating-bar.install": {
-		"defaultMessage": "安裝 {count, plural, other {# 個專案}}"
-	},
-	"browse.selected-projects-floating-bar.selected-count": {
-		"defaultMessage": "{count, plural, other {已選取 # 個專案}}"
-	},
-	"browse.selected-projects-leave-modal.admonition-body": {
-		"defaultMessage": "你已選取 {count, plural, other {# 個專案}}來安裝。立即安裝專案，或返回而不安裝。"
-	},
-	"browse.selected-projects-leave-modal.admonition-header": {
-		"defaultMessage": "你選取的專案尚未安裝"
-	},
-	"browse.selected-projects-leave-modal.discard": {
-		"defaultMessage": "捨棄"
-	},
-	"browse.selected-projects-leave-modal.header": {
-		"defaultMessage": "你選取的專案尚未安裝"
-	},
-	"browse.view-prefix": {
-		"defaultMessage": "檢視模式："
-	},
-	"button.accept": {
-		"defaultMessage": "接受"
-	},
-	"button.add-server-to-instance": {
-		"defaultMessage": "將伺服器新增至實例"
-	},
-	"button.affiliate-links": {
-		"defaultMessage": "聯盟連結"
-	},
-	"button.analytics": {
-		"defaultMessage": "數據分析"
-	},
-	"button.back": {
-		"defaultMessage": "返回"
-	},
-	"button.cancel": {
-		"defaultMessage": "取消"
-	},
-	"button.change-version": {
-		"defaultMessage": "變更版本"
-	},
-	"button.clear": {
-		"defaultMessage": "清除"
-	},
-	"button.close": {
-		"defaultMessage": "關閉"
-	},
-	"button.continue": {
-		"defaultMessage": "繼續"
-	},
-	"button.copy-filename": {
-		"defaultMessage": "複製檔案名稱"
-	},
-	"button.copy-full-path": {
-		"defaultMessage": "複製完整路徑"
-	},
-	"button.copy-id": {
-		"defaultMessage": "複製 ID"
-	},
-	"button.copy-link": {
-		"defaultMessage": "複製連結"
-	},
-	"button.copy-permalink": {
-		"defaultMessage": "複製永久連結"
-	},
-	"button.create-a-project": {
-		"defaultMessage": "建立專案"
-	},
-	"button.decline": {
-		"defaultMessage": "拒絕"
-	},
-	"button.disable": {
-		"defaultMessage": "停用"
-	},
-	"button.download": {
-		"defaultMessage": "下載"
-	},
-	"button.downloading": {
-		"defaultMessage": "下載中"
-	},
-	"button.edit": {
-		"defaultMessage": "編輯"
-	},
-	"button.enable": {
-		"defaultMessage": "啟用"
-	},
-	"button.extract": {
-		"defaultMessage": "解壓縮"
-	},
-	"button.follow": {
-		"defaultMessage": "追蹤"
-	},
-	"button.hide-snapshots": {
-		"defaultMessage": "隱藏快照版本"
-	},
-	"button.install": {
-		"defaultMessage": "安裝"
-	},
-	"button.max": {
-		"defaultMessage": "最大值"
-	},
-	"button.more-options": {
-		"defaultMessage": "更多選項"
-	},
-	"button.move": {
-		"defaultMessage": "移動"
-	},
-	"button.next": {
-		"defaultMessage": "下一步"
-	},
-	"button.open-folder": {
-		"defaultMessage": "開啟資料夾"
-	},
-	"button.open-in-folder": {
-		"defaultMessage": "在資料夾中開啟"
-	},
-	"button.open-in-modrinth": {
-		"defaultMessage": "在 Modrinth 中開啟"
-	},
-	"button.play": {
-		"defaultMessage": "遊玩"
-	},
-	"button.refresh": {
-		"defaultMessage": "重新整理"
-	},
-	"button.reinstall-modpack": {
-		"defaultMessage": "重新安裝模組包"
-	},
-	"button.remove": {
-		"defaultMessage": "刪除通行金鑰"
-	},
-	"button.remove-image": {
-		"defaultMessage": "移除圖片"
-	},
-	"button.rename": {
-		"defaultMessage": "重新命名"
-	},
-	"button.repair": {
-		"defaultMessage": "修復"
-	},
-	"button.repairing": {
-		"defaultMessage": "修復中..."
-	},
-	"button.report": {
-		"defaultMessage": "檢舉"
-	},
-	"button.reset": {
-		"defaultMessage": "重設"
-	},
-	"button.reset-server": {
-		"defaultMessage": "重設伺服器"
-	},
-	"button.retry": {
-		"defaultMessage": "重試"
-	},
-	"button.save": {
-		"defaultMessage": "儲存"
-	},
-	"button.save-changes": {
-		"defaultMessage": "儲存變更"
-	},
-	"button.saving": {
-		"defaultMessage": "儲存中"
-	},
-	"button.show-all-versions": {
-		"defaultMessage": "顯示所有版本"
-	},
-	"button.show-file": {
-		"defaultMessage": "顯示檔案"
-	},
-	"button.sign-in": {
-		"defaultMessage": "登入"
-	},
-	"button.sign-out": {
-		"defaultMessage": "登出"
-	},
-	"button.sign-up": {
-		"defaultMessage": "註冊"
-	},
-	"button.stop": {
-		"defaultMessage": "停止"
-	},
-	"button.switch-version": {
-		"defaultMessage": "切換版本"
-	},
-	"button.unfollow": {
-		"defaultMessage": "取消追蹤"
-	},
-	"button.unlink-modpack": {
-		"defaultMessage": "取消連結模組包"
-	},
-	"button.update": {
-		"defaultMessage": "更新"
-	},
-	"button.upload-image": {
-		"defaultMessage": "上傳圖片"
-	},
-	"collections.label.private": {
-		"defaultMessage": "私人"
-	},
-	"console.action.collapse": {
-		"defaultMessage": "收合"
-	},
-	"console.action.expand": {
-		"defaultMessage": "展開"
-	},
-	"console.action.share": {
-		"defaultMessage": "分享"
-	},
-	"console.command.disabled-placeholder": {
-		"defaultMessage": "指令輸入已停用"
-	},
-	"console.command.server-not-running-placeholder": {
-		"defaultMessage": "伺服器未執行"
-	},
-	"console.crash.export-context": {
-		"defaultMessage": "匯出崩潰內容"
-	},
-	"console.crash.finding.amd-driver.action": {
-		"defaultMessage": "全新安裝最新版 AMD 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
-	},
-	"console.crash.finding.amd-driver.title": {
-		"defaultMessage": "AMD 顯示卡驅動程式崩潰"
-	},
-	"console.crash.finding.content-verification.action": {
-		"defaultMessage": "從可信來源重新安裝證據中指出的檔案。"
-	},
-	"console.crash.finding.content-verification.title": {
-		"defaultMessage": "jar 簽章驗證失敗"
-	},
-	"console.crash.finding.definite-mod-fabric.action": {
-		"defaultMessage": "更新或暫時移除 Fabric 載入器證據中指出的模組。"
-	},
-	"console.crash.finding.definite-mod-fabric.title": {
-		"defaultMessage": "Fabric 發現特定模組故障"
-	},
-	"console.crash.finding.definite-mod.action": {
-		"defaultMessage": "更新、修復或暫時移除證據和相符 jar 中指出的模組。"
-	},
-	"console.crash.finding.definite-mod.title": {
-		"defaultMessage": "特定模組導致崩潰"
-	},
-	"console.crash.finding.duplicate-mod.action": {
-		"defaultMessage": "在 mods 資料夾中，每個模組只保留一個相容版本。"
-	},
-	"console.crash.finding.duplicate-mod.title": {
-		"defaultMessage": "安裝了重複模組"
-	},
-	"console.crash.finding.extracted-mod.action": {
-		"defaultMessage": "從 mods 資料夾移除解壓縮後的目錄，並安裝原始 jar 檔案。"
-	},
-	"console.crash.finding.extracted-mod.title": {
-		"defaultMessage": "發現已解壓縮的模組"
-	},
-	"console.crash.finding.fabric-solution.action": {
-		"defaultMessage": "依證據中列出的相依性變更處理後再啟動。"
-	},
-	"console.crash.finding.fabric-solution.title": {
-		"defaultMessage": "Fabric 發現不相容模組或缺少相依性"
-	},
-	"console.crash.finding.fallback-action": {
-		"defaultMessage": "檢視下方證據和本機實例中相符的模組。"
-	},
-	"console.crash.finding.fallback-title": {
-		"defaultMessage": "未知診斷：{finding}"
-	},
-	"console.crash.finding.forge-error.action": {
-		"defaultMessage": "檢視 Forge 故障證據，並在撤銷近期變更後測試指出的模組。"
-	},
-	"console.crash.finding.forge-error.title": {
-		"defaultMessage": "Forge 回報了遊戲錯誤"
-	},
-	"console.crash.finding.forge-incomplete.action": {
-		"defaultMessage": "修復或重新安裝此實例的 Forge 載入器。"
-	},
-	"console.crash.finding.forge-incomplete.title": {
-		"defaultMessage": "Forge 安裝不完整"
-	},
-	"console.crash.finding.forge-java-incompatible.action": {
-		"defaultMessage": "使用此 Forge 版本所需的 Java 版本，或更新 Forge。"
-	},
-	"console.crash.finding.forge-java-incompatible.title": {
-		"defaultMessage": "此 Forge 版本與所選 Java 執行環境不相容"
-	},
-	"console.crash.finding.incompatible-mods.action": {
-		"defaultMessage": "依證據中的相容性詳情更新、移除或替換衝突模組。"
-	},
-	"console.crash.finding.incompatible-mods.title": {
-		"defaultMessage": "已安裝的模組互不相容"
-	},
-	"console.crash.finding.intel-driver.action": {
-		"defaultMessage": "安裝最新版 Intel 顯示卡驅動程式，或改用其他可用 GPU 執行 Minecraft。"
-	},
-	"console.crash.finding.intel-driver.title": {
-		"defaultMessage": "Intel 顯示卡驅動程式崩潰"
-	},
-	"console.crash.finding.java-11-required.action": {
-		"defaultMessage": "選擇 Java 11，或安裝與所選 Java 版本相容的模組版本。"
-	},
-	"console.crash.finding.java-11-required.title": {
-		"defaultMessage": "模組需要 Java 11"
-	},
-	"console.crash.finding.java-32bit.action": {
-		"defaultMessage": "安裝並選擇 64 位元 Java 執行環境，然後重試啟動。"
-	},
-	"console.crash.finding.java-32bit.title": {
-		"defaultMessage": "32 位元 Java 執行環境無法配置所需記憶體"
-	},
-	"console.crash.finding.java-incompatible.action": {
-		"defaultMessage": "使用相容的 Java 執行環境，或安裝適用於此 Java 版本的模組版本。"
-	},
-	"console.crash.finding.java-incompatible.title": {
-		"defaultMessage": "模組需要其他 Java 版本"
-	},
-	"console.crash.finding.java-too-new.action": {
-		"defaultMessage": "選擇此 Minecraft 和模組載入器版本所需的 Java 主要版本。"
-	},
-	"console.crash.finding.java-too-new.title": {
-		"defaultMessage": "Java 執行環境版本對此實例過新"
-	},
-	"console.crash.finding.jdk-runtime.action": {
-		"defaultMessage": "為此 Minecraft 版本選擇標準 HotSpot Java 執行環境。"
-	},
-	"console.crash.finding.jdk-runtime.title": {
-		"defaultMessage": "選擇了 JDK 而不是 JRE"
-	},
-	"console.crash.finding.jvm-arguments.action": {
-		"defaultMessage": "移除報告中指出的自訂 JVM 參數，然後重新啟動實例。"
-	},
-	"console.crash.finding.jvm-arguments.title": {
-		"defaultMessage": "JVM 參數無效"
-	},
-	"console.crash.finding.large-resource-pack.action": {
-		"defaultMessage": "停用該資源包，或改用解析度較低的版本。"
-	},
-	"console.crash.finding.large-resource-pack.title": {
-		"defaultMessage": "目前資源包對圖形設定而言過大"
-	},
-	"console.crash.finding.manual-debug-crash.action": {
-		"defaultMessage": "重新啟動，並避免長按手動偵錯崩潰快速鍵。"
-	},
-	"console.crash.finding.manual-debug-crash.title": {
-		"defaultMessage": "觸發了偵錯崩潰快速鍵"
-	},
-	"console.crash.finding.matched-mod": {
-		"defaultMessage": "相符模組：{identity}{modId} - {fileName}"
-	},
-	"console.crash.finding.missing-dependency.action": {
-		"defaultMessage": "安裝所需的相依性版本，或使用與此 Minecraft 版本相符的模組版本。"
-	},
-	"console.crash.finding.missing-dependency.title": {
-		"defaultMessage": "模組相依性缺少或不受支援"
-	},
-	"console.crash.finding.mixin-bootstrap.action": {
-		"defaultMessage": "修復模組載入器安裝，並確認所有模組均適用於已安裝的載入器。"
-	},
-	"console.crash.finding.mixin-bootstrap.title": {
-		"defaultMessage": "缺少 Mixin 啟動程序"
-	},
-	"console.crash.finding.mixin-failure.action": {
-		"defaultMessage": "更新或移除相符的模組，並檢查其 Minecraft 和載入器版本是否相容。"
-	},
-	"console.crash.finding.mixin-failure.title": {
-		"defaultMessage": "模組 Mixin 套用失敗"
-	},
-	"console.crash.finding.mod-config.action": {
-		"defaultMessage": "備份並移除指出的設定檔，讓模組重新產生它。"
-	},
-	"console.crash.finding.mod-config.title": {
-		"defaultMessage": "無法讀取模組設定檔"
-	},
-	"console.crash.finding.mod-filename.action": {
-		"defaultMessage": "使用簡單的拉丁字母檔名重新命名或安裝模組 jar。"
-	},
-	"console.crash.finding.mod-filename.title": {
-		"defaultMessage": "模組檔名包含不支援的字元"
-	},
-	"console.crash.finding.mod-id-limit.action": {
-		"defaultMessage": "移除未使用的模組，或將安裝內容拆分為較小的相容設定檔。"
-	},
-	"console.crash.finding.mod-id-limit.title": {
-		"defaultMessage": "模組過多，超出 ID 限制"
-	},
-	"console.crash.finding.mod-initialization.action": {
-		"defaultMessage": "更新指出的模組，並確認其所需相依性均已安裝。"
-	},
-	"console.crash.finding.mod-initialization.title": {
-		"defaultMessage": "模組初始化失敗"
-	},
-	"console.crash.finding.mod-loader-error.action": {
-		"defaultMessage": "修復載入器安裝，並確認列出的模組檔案與此遊戲版本相符。"
-	},
-	"console.crash.finding.mod-loader-error.title": {
-		"defaultMessage": "模組載入器回報了故障"
-	},
-	"console.crash.finding.mod-loader-failure.action": {
-		"defaultMessage": "修復載入器安裝，並依證據中顯示的故障訊息處理。"
-	},
-	"console.crash.finding.mod-loader-failure.title": {
-		"defaultMessage": "模組載入器在識別模組檔案前失敗"
-	},
-	"console.crash.finding.multiple-forge-versions.action": {
-		"defaultMessage": "修復實例，使其版本設定檔中只包含一個 Forge 安裝。"
-	},
-	"console.crash.finding.multiple-forge-versions.title": {
-		"defaultMessage": "版本設定檔中包含多個 Forge 版本"
-	},
-	"console.crash.finding.nightconfig-bug.action": {
-		"defaultMessage": "備份 config 資料夾，移除損壞設定，讓模組重新產生它。"
-	},
-	"console.crash.finding.nightconfig-bug.title": {
-		"defaultMessage": "NightConfig 無法讀取設定檔"
-	},
-	"console.crash.finding.nvidia-driver.action": {
-		"defaultMessage": "全新安裝最新版 NVIDIA 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
-	},
-	"console.crash.finding.nvidia-driver.title": {
-		"defaultMessage": "NVIDIA 顯示卡驅動程式崩潰"
-	},
-	"console.crash.finding.opengl-unsupported.action": {
-		"defaultMessage": "安裝 GPU 製造商提供的顯示卡驅動程式，並確認 Minecraft 使用預期的 GPU。"
-	},
-	"console.crash.finding.opengl-unsupported.title": {
-		"defaultMessage": "目前顯示卡驅動程式不支援 OpenGL"
-	},
-	"console.crash.finding.openj9.action": {
-		"defaultMessage": "選擇以 HotSpot 為基礎的 Java 執行環境，例如 Eclipse Temurin 或內建 Minecraft 執行環境。"
-	},
-	"console.crash.finding.openj9.title": {
-		"defaultMessage": "所選 OpenJ9 執行環境不相容"
-	},
-	"console.crash.finding.optifine-incompatible.action": {
-		"defaultMessage": "安裝相容的 OptiFine 版本，或移除 OptiFine 和衝突的光影模組。"
-	},
-	"console.crash.finding.optifine-incompatible.title": {
-		"defaultMessage": "OptiFine 與已安裝的載入器或模組衝突"
-	},
-	"console.crash.finding.optifine-world.action": {
-		"defaultMessage": "移除 OptiFine，或安裝與此 Minecraft 和 Forge 版本相容的版本。"
-	},
-	"console.crash.finding.optifine-world.title": {
-		"defaultMessage": "OptiFine 阻止世界載入"
-	},
-	"console.crash.finding.out-of-memory.action": {
-		"defaultMessage": "增加實例記憶體配置，或移除占用大量記憶體的模組和資源包。"
-	},
-	"console.crash.finding.out-of-memory.title": {
-		"defaultMessage": "Minecraft 記憶體不足"
-	},
-	"console.crash.finding.pixel-format.action": {
-		"defaultMessage": "更新或重新安裝顯示卡驅動程式，停用衝突的覆蓋層後重試。"
-	},
-	"console.crash.finding.pixel-format.title": {
-		"defaultMessage": "顯示卡驅動程式無法設定像素格式"
-	},
-	"console.crash.finding.resource-pack.action": {
-		"defaultMessage": "停用目前光影和資源包，再逐一重新啟用。"
-	},
-	"console.crash.finding.resource-pack.title": {
-		"defaultMessage": "光影或資源包觸發圖形錯誤"
-	},
-	"console.crash.finding.shaders-optifine.action": {
-		"defaultMessage": "移除單獨的光影模組，因為 OptiFine 已提供光影支援。"
-	},
-	"console.crash.finding.shaders-optifine.title": {
-		"defaultMessage": "同時安裝了光影模組和 OptiFine"
-	},
-	"console.crash.finding.short-output.action": {
-		"defaultMessage": "重試一次，然後檢查 Java、載入器安裝和啟動器輸出中較早出現的錯誤。"
-	},
-	"console.crash.finding.short-output.title": {
-		"defaultMessage": "遊戲在產生有效日誌前停止"
-	},
-	"console.crash.finding.specific-block.action": {
-		"defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的方塊。"
-	},
-	"console.crash.finding.specific-block.title": {
-		"defaultMessage": "特定方塊導致崩潰"
-	},
-	"console.crash.finding.specific-entity.action": {
-		"defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的實體。"
-	},
-	"console.crash.finding.specific-entity.title": {
-		"defaultMessage": "特定實體導致崩潰"
-	},
-	"console.crash.finding.stack-analysis.action": {
-		"defaultMessage": "更新或暫時移除相符的模組，然後重新測試實例。"
-	},
-	"console.crash.finding.stack-analysis.title": {
-		"defaultMessage": "堆疊追蹤指向已安裝的模組"
-	},
-	"console.crash.finding.suspected-mod.action": {
-		"defaultMessage": "更新或暫時移除報告懷疑且本機相符的模組，然後重試。"
-	},
-	"console.crash.finding.suspected-mod.title": {
-		"defaultMessage": "崩潰報告懷疑一個或多個模組"
-	},
-	"console.crash.local-header": {
-		"defaultMessage": "{findings, plural, other {# 項本機診斷結果}}，來自 {sources, plural, other {# 個相關檔案}}"
-	},
-	"console.crash.problems-detected": {
-		"defaultMessage": "偵測到 {count, plural, other {# 個問題}}"
-	},
-	"console.delete-modal.confirmation": {
-		"defaultMessage": "刪除後無法復原此日誌檔案。確定要繼續嗎？"
-	},
-	"console.delete-modal.irreversible-title": {
-		"defaultMessage": "此操作無法復原"
-	},
-	"console.delete-modal.title": {
-		"defaultMessage": "刪除日誌檔案"
-	},
-	"console.filter.error": {
-		"defaultMessage": "錯誤"
-	},
-	"console.filter.info": {
-		"defaultMessage": "資訊"
-	},
-	"console.filter.warn": {
-		"defaultMessage": "警告"
-	},
-	"console.notification.delete-failed": {
-		"defaultMessage": "刪除日誌檔案失敗"
-	},
-	"console.notification.share-failed": {
-		"defaultMessage": "分享日誌失敗"
-	},
-	"console.notification.unknown-error": {
-		"defaultMessage": "未知錯誤。"
-	},
-	"console.search.placeholder": {
-		"defaultMessage": "搜尋日誌"
-	},
-	"console.share-modal.title": {
-		"defaultMessage": "分享日誌"
-	},
-	"content-type.content.lowercase": {
-		"defaultMessage": "內容"
-	},
-	"content-type.item.lowercase": {
-		"defaultMessage": "{count, plural, other {項目}}"
-	},
-	"content.card.select-project": {
-		"defaultMessage": "選取「{project}」"
-	},
-	"content.confirm-bulk-update.admonition-body": {
-		"defaultMessage": "確定要將這 {count, plural, other {# 個專案}}更新至最新的相容版本嗎？建議你逐一進行更新。"
-	},
-	"content.confirm-bulk-update.admonition-header": {
-		"defaultMessage": "更新警告"
-	},
-	"content.confirm-bulk-update.header": {
-		"defaultMessage": "更新專案"
-	},
-	"content.confirm-bulk-update.update-button": {
-		"defaultMessage": "更新 {count, plural, other {# 個專案}}"
-	},
-	"content.confirm-deletion.admonition-body": {
-		"defaultMessage": "刪除模組可能會對你的世界造成永久性影響，並在重新載入時導致內容遺失或發生非預期的問題。"
-	},
-	"content.confirm-deletion.admonition-header": {
-		"defaultMessage": "刪除警告"
-	},
-	"content.confirm-deletion.delete-button": {
-		"defaultMessage": "刪除 {count, number} 個{itemType}"
-	},
-	"content.confirm-deletion.header": {
-		"defaultMessage": "刪除{itemType}"
-	},
-	"content.confirm-modpack-update.admonition-body": {
-		"defaultMessage": "{action, select, downgrade {降級} other {更新}}可能會導致相容性問題。你額外新增至模組包的模組或內容將保留，但可能與新版本不相容。"
-	},
-	"content.confirm-modpack-update.admonition-header": {
-		"defaultMessage": "{action, select, downgrade {降級} other {更新}}警告"
-	},
-	"content.confirm-modpack-update.confirm-button": {
-		"defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
-	},
-	"content.confirm-modpack-update.header": {
-		"defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
-	},
-	"content.confirm-unlink.admonition-body": {
-		"defaultMessage": "模組與內容將與你額外新增至模組包的內容合併，且將不再接收更新。"
-	},
-	"content.confirm-unlink.admonition-header": {
-		"defaultMessage": "取消連結模組包"
-	},
-	"content.confirm-unlink.header": {
-		"defaultMessage": "取消連結模組包"
-	},
-	"content.confirm-unlink.unlink-button": {
-		"defaultMessage": "取消連結"
-	},
-	"content.dependency-warning.admonition-header": {
-		"defaultMessage": "其他內容需要此內容"
-	},
-	"content.dependency-warning.affected-dependents-label": {
-		"defaultMessage": "受影響{count, plural, other {專案}}"
-	},
-	"content.dependency-warning.bulk-admonition-body": {
-		"defaultMessage": "部分所選的專案已作為相依項安裝。刪除這些專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
-	},
-	"content.dependency-warning.context.instance": {
-		"defaultMessage": "實例"
-	},
-	"content.dependency-warning.context.server": {
-		"defaultMessage": "伺服器"
-	},
-	"content.dependency-warning.delete-anyway-button": {
-		"defaultMessage": "仍要刪除"
-	},
-	"content.dependency-warning.delete-many-anyway-button": {
-		"defaultMessage": "仍要刪除 {count, number} 個{itemType}"
-	},
-	"content.dependency-warning.deleting-label": {
-		"defaultMessage": "刪除"
-	},
-	"content.dependency-warning.disable-dependents-label": {
-		"defaultMessage": "刪除後停用依賴項"
-	},
-	"content.dependency-warning.effect-dependent-content": {
-		"defaultMessage": "依賴項內容可能會無法載入，或自主停用"
-	},
-	"content.dependency-warning.effect-instance": {
-		"defaultMessage": "你的{context}可能會崩潰、無法啟動，或出現異常行為"
-	},
-	"content.dependency-warning.header": {
-		"defaultMessage": "相依項警告"
-	},
-	"content.dependency-warning.single-admonition-body": {
-		"defaultMessage": "{project} 已作為相依項安裝。刪除這個專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
-	},
-	"content.dependency-warning.what-happens-label": {
-		"defaultMessage": "會發生什麼事？"
-	},
-	"content.diff-modal.added-count": {
-		"defaultMessage": "已新增 {count} 個"
-	},
-	"content.diff-modal.diff-type.added": {
-		"defaultMessage": "已新增（相依項）"
-	},
-	"content.diff-modal.diff-type.removed": {
-		"defaultMessage": "已停用"
-	},
-	"content.diff-modal.diff-type.updated": {
-		"defaultMessage": "已更新"
-	},
-	"content.diff-modal.removed-count": {
-		"defaultMessage": "已移除 {count} 個"
-	},
-	"content.diff-modal.unknown-content-body": {
-		"defaultMessage": "你伺服器上的部分內容無法進行分析，且可能會受到這項變更的影響。"
-	},
-	"content.diff-modal.updated-count": {
-		"defaultMessage": "已更新 {count} 個"
-	},
-	"content.filter.disabled": {
-		"defaultMessage": "停用"
-	},
-	"content.filter.enabled": {
-		"defaultMessage": "啟用"
-	},
-	"content.filter.updates": {
-		"defaultMessage": "更新"
-	},
-	"content.filter.warnings": {
-		"defaultMessage": "警告"
-	},
-	"content.page-layout.browse-content": {
-		"defaultMessage": "瀏覽內容"
-	},
-	"content.page-layout.empty.hint": {
-		"defaultMessage": "瀏覽或上傳{contentType}即可開始"
-	},
-	"content.page-layout.empty.no-content-installed": {
-		"defaultMessage": "未安裝內容"
-	},
-	"content.page-layout.failed-to-load": {
-		"defaultMessage": "無法載入內容"
-	},
-	"content.page-layout.no-content-found": {
-		"defaultMessage": "找不到內容。"
-	},
-	"content.page-layout.search-placeholder": {
-		"defaultMessage": "搜尋 {count, number} 個{contentType}..."
-	},
-	"content.page-layout.share.file-names": {
-		"defaultMessage": "檔案名稱"
-	},
-	"content.page-layout.share.label": {
-		"defaultMessage": "分享"
-	},
-	"content.page-layout.share.markdown-links": {
-		"defaultMessage": "Markdown 連結"
-	},
-	"content.page-layout.share.project-links": {
-		"defaultMessage": "專案連結"
-	},
-	"content.page-layout.share.project-names": {
-		"defaultMessage": "專案名稱"
-	},
-	"content.page-layout.sort.alphabetical": {
-		"defaultMessage": "字母順序"
-	},
-	"content.page-layout.sort.date-added-newest": {
-		"defaultMessage": "最新在前"
-	},
-	"content.page-layout.sort.date-added-oldest": {
-		"defaultMessage": "最舊在前"
-	},
-	"content.page-layout.sort.label": {
-		"defaultMessage": "排序依據：{mode}"
-	},
-	"content.page-layout.update-all": {
-		"defaultMessage": "更新全部"
-	},
-	"content.selection-bar.all-already-disabled": {
-		"defaultMessage": "所有已選擇的內容已經停用"
-	},
-	"content.selection-bar.all-already-enabled": {
-		"defaultMessage": "所有已選擇的內容已經啟用"
-	},
-	"content.selection-bar.bulk.deleting": {
-		"defaultMessage": "正在刪除 {progress}/{total} {contentType}..."
-	},
-	"content.selection-bar.bulk.deleting-count": {
-		"defaultMessage": "正在刪除 {count, number} 個{contentType}"
-	},
-	"content.selection-bar.bulk.deleting-waiting": {
-		"defaultMessage": "正在刪除{contentType}..."
-	},
-	"content.selection-bar.bulk.disabling": {
-		"defaultMessage": "正在停用 {progress}/{total} {contentType}..."
-	},
-	"content.selection-bar.bulk.disabling-count": {
-		"defaultMessage": "正在停用 {count, number} 個{contentType}"
-	},
-	"content.selection-bar.bulk.disabling-waiting": {
-		"defaultMessage": "正在停用{contentType}..."
-	},
-	"content.selection-bar.bulk.enabling": {
-		"defaultMessage": "正在啟用 {progress}/{total} {contentType}..."
-	},
-	"content.selection-bar.bulk.enabling-count": {
-		"defaultMessage": "正在啟用 {count, number} 個{contentType}"
-	},
-	"content.selection-bar.bulk.enabling-waiting": {
-		"defaultMessage": "正在啟用{contentType}..."
-	},
-	"content.selection-bar.bulk.updating": {
-		"defaultMessage": "正在更新 {progress}/{total} {contentType}..."
-	},
-	"content.selection-bar.bulk.updating-count": {
-		"defaultMessage": "正在更新 {count, number} 個{contentType}"
-	},
-	"content.selection-bar.bulk.updating-waiting": {
-		"defaultMessage": "正在更新{contentType}..."
-	},
-	"content.selection-bar.selected-count": {
-		"defaultMessage": "已選取 {count, number} 個{contentType}"
-	},
-	"content.selection-bar.selected-count-simple": {
-		"defaultMessage": "已選取 {count, number} 個項目"
-	},
-	"creation-flow.button.create-instance": {
-		"defaultMessage": "建立實例"
-	},
-	"creation-flow.button.create-world": {
-		"defaultMessage": "建立世界"
-	},
-	"creation-flow.button.finish": {
-		"defaultMessage": "完成"
-	},
-	"creation-flow.button.import": {
-		"defaultMessage": "匯入"
-	},
-	"creation-flow.button.import-instances": {
-		"defaultMessage": "匯入 {count, plural, other {# 個實例}}"
-	},
-	"creation-flow.button.setup-server": {
-		"defaultMessage": "設定伺服器"
-	},
-	"creation-flow.modal.custom-setup.build-number.label": {
-		"defaultMessage": "組建編號"
-	},
-	"creation-flow.modal.custom-setup.build-number.placeholder": {
-		"defaultMessage": "選擇組建編號"
-	},
-	"creation-flow.modal.custom-setup.build-number.search-placeholder": {
-		"defaultMessage": "搜尋組建編號..."
-	},
-	"creation-flow.modal.custom-setup.content-loader.label": {
-		"defaultMessage": "內容載入器"
-	},
-	"creation-flow.modal.custom-setup.game-version.load-failed": {
-		"defaultMessage": "遊戲版本載入失敗"
-	},
-	"creation-flow.modal.custom-setup.game-version.no-supported-versions": {
-		"defaultMessage": "沒有遊戲版本支援此載入器"
-	},
-	"creation-flow.modal.custom-setup.game-version.placeholder": {
-		"defaultMessage": "選擇遊戲版本"
-	},
-	"creation-flow.modal.custom-setup.game-version.search-placeholder": {
-		"defaultMessage": "搜尋遊戲版本..."
-	},
-	"creation-flow.modal.custom-setup.game-version-type.alpha": {
-		"defaultMessage": "愚人節版"
-	},
-	"creation-flow.modal.custom-setup.game-version-type.release": {
-		"defaultMessage": "正式版"
-	},
-	"creation-flow.modal.custom-setup.game-version-type.snapshot": {
-		"defaultMessage": "快照版"
-	},
-	"creation-flow.modal.custom-setup.icon.remove": {
-		"defaultMessage": "移除圖示"
-	},
-	"creation-flow.modal.custom-setup.icon.select": {
-		"defaultMessage": "選擇圖示"
-	},
-	"creation-flow.modal.custom-setup.loader-version-type.latest": {
-		"defaultMessage": "最新版"
-	},
-	"creation-flow.modal.custom-setup.loader-version-type.other": {
-		"defaultMessage": "其他"
-	},
-	"creation-flow.modal.custom-setup.loader-version-type.stable": {
-		"defaultMessage": "穩定版"
-	},
-	"creation-flow.modal.custom-setup.loader-version.label": {
-		"defaultMessage": "載入器版本"
-	},
-	"creation-flow.modal.custom-setup.loader-version.placeholder": {
-		"defaultMessage": "選擇載入器版本"
-	},
-	"creation-flow.modal.custom-setup.loader-version.search-placeholder": {
-		"defaultMessage": "搜尋載入器版本..."
-	},
-	"creation-flow.modal.custom-setup.loader.label": {
-		"defaultMessage": "載入器"
-	},
-	"creation-flow.modal.custom-setup.loader.no-such-versions-available": {
-		"defaultMessage": "無此版本"
-	},
-	"creation-flow.modal.custom-setup.loader.unsupported-tooltip": {
-		"defaultMessage": "此載入器不支援所選遊戲版本"
-	},
-	"creation-flow.modal.custom-setup.name.label": {
-		"defaultMessage": "名稱"
-	},
-	"creation-flow.modal.custom-setup.name.placeholder": {
-		"defaultMessage": "輸入實例名稱"
-	},
-	"creation-flow.modal.custom-setup.options.no-versions-available": {
-		"defaultMessage": "沒有可用的版本"
-	},
-	"creation-flow.modal.custom-setup.will-install-loader-version": {
-		"defaultMessage": "將會安裝：{loader} {version}"
-	},
-	"creation-flow.modal.setup-type.instance.description": {
-		"defaultMessage": "實例是指具有特定載入器、版本及模組的 Minecraft 設定。"
-	},
-	"creation-flow.modal.setup-type.option.custom-setup.description": {
-		"defaultMessage": "從頭開始，先選擇載入器與遊戲版本。"
-	},
-	"creation-flow.modal.setup-type.option.custom-setup.title": {
-		"defaultMessage": "自訂設定"
-	},
-	"creation-flow.modal.setup-type.option.import-instance.description": {
-		"defaultMessage": "從 Prism、CurseForge 或類似啟動器匯入實例。"
-	},
-	"creation-flow.modal.setup-type.option.import-instance.title": {
-		"defaultMessage": "匯入實例"
-	},
-	"creation-flow.modal.setup-type.option.modpack-base.description": {
-		"defaultMessage": "在 Modrinth 上瀏覽模組包，或從檔案匯入。"
-	},
-	"creation-flow.modal.setup-type.option.modpack-base.title": {
-		"defaultMessage": "安裝模組包"
-	},
-	"creation-flow.modal.setup-type.option.vanilla-minecraft.description": {
-		"defaultMessage": "不含任何模組或插件的經典 Minecraft。"
-	},
-	"creation-flow.modal.setup-type.option.vanilla-minecraft.title": {
-		"defaultMessage": "原版 Minecraft"
-	},
-	"creation-flow.modal.setup-type.title.installation": {
-		"defaultMessage": "選擇安裝類型"
-	},
-	"creation-flow.modal.setup-type.title.instance": {
-		"defaultMessage": "選擇實例類型"
-	},
-	"creation-flow.modal.setup-type.title.world": {
-		"defaultMessage": "選擇世界類型"
-	},
-	"creation-flow.title.choose-modpack": {
-		"defaultMessage": "選擇模組包"
-	},
-	"creation-flow.title.create-instance": {
-		"defaultMessage": "建立實例"
-	},
-	"creation-flow.title.create-world": {
-		"defaultMessage": "建立世界"
-	},
-	"creation-flow.title.import-instance": {
-		"defaultMessage": "匯入實例"
-	},
-	"creation-flow.title.reset-server": {
-		"defaultMessage": "重設伺服器"
-	},
-	"creation-flow.title.set-up-server": {
-		"defaultMessage": "設定伺服器"
-	},
-	"external-project-license-status.no": {
-		"defaultMessage": "否"
-	},
-	"external-project-license-status.permanent-no": {
-		"defaultMessage": "永久禁止"
-	},
-	"external-project-license-status.unidentified": {
-		"defaultMessage": "未識別"
-	},
-	"external-project-license-status.with-attribution": {
-		"defaultMessage": "附帶引用標註"
-	},
-	"external-project-license-status.with-attribution-and-source": {
-		"defaultMessage": "附帶引用標註與來源"
-	},
-	"external-project-license-status.yes": {
-		"defaultMessage": "是"
-	},
-	"files.conflict-modal.header": {
-		"defaultMessage": "解壓縮摘要"
-	},
-	"files.conflict-modal.overwrite-button": {
-		"defaultMessage": "覆寫"
-	},
-	"files.conflict-modal.overwrite-file-label": {
-		"defaultMessage": "將覆寫 <file-path>{path}</file-path>"
-	},
-	"files.conflict-modal.overwrite-many-warning": {
-		"defaultMessage": "若你繼續執行解壓縮，將有超過 100 個檔案被覆寫；以下列出部分檔案。"
-	},
-	"files.conflict-modal.overwrite-warning": {
-		"defaultMessage": "下列 {count} 個檔案已存在於你的伺服器上，若你繼續執行解壓縮，這些檔案將被覆寫。"
-	},
-	"files.conflict-modal.overwritten-count": {
-		"defaultMessage": "將覆寫 {count} 個檔案"
-	},
-	"files.conflict-modal.warning-header": {
-		"defaultMessage": "檔案將被覆寫"
-	},
-	"files.create-modal.create-button": {
-		"defaultMessage": "建立 {type}"
-	},
-	"files.create-modal.header": {
-		"defaultMessage": "建立一個 {type}"
-	},
-	"files.create-modal.placeholder-directory": {
-		"defaultMessage": "例如：my-folder"
-	},
-	"files.create-modal.placeholder-file": {
-		"defaultMessage": "例如：config.yml"
-	},
-	"files.delete-modal.deleting-name": {
-		"defaultMessage": "正在刪除「{name}」"
-	},
-	"files.delete-modal.header": {
-		"defaultMessage": "刪除檔案"
-	},
-	"files.delete-modal.warning.file": {
-		"defaultMessage": "此檔案將永久刪除。此操作無法撤銷。"
-	},
-	"files.delete-modal.warning.folder": {
-		"defaultMessage": "此資料夾及其所有內容將永久刪除。此操作無法撤銷。"
-	},
-	"files.editor.failed-to-open-text": {
-		"defaultMessage": "無法載入檔案內容。"
-	},
-	"files.editor.failed-to-open-title": {
-		"defaultMessage": "無法開啟檔案"
-	},
-	"files.editor.failed-to-share-text": {
-		"defaultMessage": "無法上傳至 mclo.gs。"
-	},
-	"files.editor.failed-to-share-title": {
-		"defaultMessage": "無法分享檔案"
-	},
-	"files.editor.file-saved-text": {
-		"defaultMessage": "你的檔案已儲存。"
-	},
-	"files.editor.file-saved-title": {
-		"defaultMessage": "已儲存檔案"
-	},
-	"files.editor.find-close": {
-		"defaultMessage": "關閉"
-	},
-	"files.editor.find-in-file": {
-		"defaultMessage": "尋找"
-	},
-	"files.editor.find-match-count": {
-		"defaultMessage": "{current}/{total}"
-	},
-	"files.editor.find-next-match": {
-		"defaultMessage": "下一個相符項"
-	},
-	"files.editor.find-no-results": {
-		"defaultMessage": "沒有結果"
-	},
-	"files.editor.find-previous-match": {
-		"defaultMessage": "上一個相符項"
-	},
-	"files.editor.find-toggle-replace": {
-		"defaultMessage": "切換取代功能"
-	},
-	"files.editor.log-url-copied-text": {
-		"defaultMessage": "你的記錄檔網址已複製到剪貼簿。"
-	},
-	"files.editor.log-url-copied-title": {
-		"defaultMessage": "記錄檔網址已複製"
-	},
-	"files.editor.replace": {
-		"defaultMessage": "取代"
-	},
-	"files.editor.replace-all": {
-		"defaultMessage": "取代全部"
-	},
-	"files.editor.replace-in-file": {
-		"defaultMessage": "取代"
-	},
-	"files.editor.save-failed-text": {
-		"defaultMessage": "無法儲存檔案。"
-	},
-	"files.editor.save-failed-title": {
-		"defaultMessage": "儲存失敗"
-	},
-	"files.error.go-to-home": {
-		"defaultMessage": "前往家資料夾"
-	},
-	"files.error.try-again": {
-		"defaultMessage": "再試一次"
-	},
-	"files.image_viewer.image_too_large": {
-		"defaultMessage": "圖片過大無法預覽 (最大 {maxDimension}x{maxDimension} 像素)"
-	},
-	"files.image_viewer.invalid_image": {
-		"defaultMessage": "圖片檔案無效或內容為空。"
-	},
-	"files.image_viewer.load_failed": {
-		"defaultMessage": "無法載入圖片"
-	},
-	"files.image_viewer.reset_zoom": {
-		"defaultMessage": "重設縮放"
-	},
-	"files.image_viewer.viewed_image_alt": {
-		"defaultMessage": "已檢視圖片"
-	},
-	"files.image_viewer.zoom_in": {
-		"defaultMessage": "放大"
-	},
-	"files.image_viewer.zoom_out": {
-		"defaultMessage": "縮小"
-	},
-	"files.item-type.file": {
-		"defaultMessage": "檔案"
-	},
-	"files.item-type.files": {
-		"defaultMessage": "檔案"
-	},
-	"files.item-type.folder": {
-		"defaultMessage": "資料夾"
-	},
-	"files.item-type.folders": {
-		"defaultMessage": "資料夾"
-	},
-	"files.layout.dry-run-failed-text": {
-		"defaultMessage": "執行模擬測試時發生錯誤"
-	},
-	"files.layout.dry-run-failed-title": {
-		"defaultMessage": "模擬測試失敗"
-	},
-	"files.layout.empty-folder-description": {
-		"defaultMessage": "沒有任何檔案或資料夾"
-	},
-	"files.layout.empty-folder-title": {
-		"defaultMessage": "此資料夾是空的"
-	},
-	"files.layout.error-message": {
-		"defaultMessage": "該資料夾可能不存在"
-	},
-	"files.layout.error-title": {
-		"defaultMessage": "無法載入檔案"
-	},
-	"files.layout.extraction-started-title": {
-		"defaultMessage": "解壓縮已開始"
-	},
-	"files.layout.selected-count": {
-		"defaultMessage": "已選擇 {count} 個"
-	},
-	"files.layout.unsaved-changes": {
-		"defaultMessage": "您有未儲存的變更"
-	},
-	"files.move-modal.current-location": {
-		"defaultMessage": "目前位置"
-	},
-	"files.move-modal.destination-path": {
-		"defaultMessage": "目標路徑"
-	},
-	"files.move-modal.destination-placeholder": {
-		"defaultMessage": "例如：/my-folder"
-	},
-	"files.move-modal.header": {
-		"defaultMessage": "移動{type}"
-	},
-	"files.navbar.back-to-home": {
-		"defaultMessage": "回到首頁"
-	},
-	"files.navbar.breadcrumb-navigation": {
-		"defaultMessage": "麵包屑導覽"
-	},
-	"files.navbar.create-new": {
-		"defaultMessage": "建立新的..."
-	},
-	"files.navbar.file-navigation": {
-		"defaultMessage": "檔案導覽"
-	},
-	"files.navbar.find-in-file": {
-		"defaultMessage": "在檔案中尋找"
-	},
-	"files.navbar.home": {
-		"defaultMessage": "首頁"
-	},
-	"files.navbar.install-curseforge-pack": {
-		"defaultMessage": "安裝 CurseForge 整合包"
-	},
-	"files.navbar.new-file": {
-		"defaultMessage": "新增檔案"
-	},
-	"files.navbar.new-folder": {
-		"defaultMessage": "新增資料夾"
-	},
-	"files.navbar.search-files": {
-		"defaultMessage": "搜尋檔案"
-	},
-	"files.navbar.upload-from-zip": {
-		"defaultMessage": "從 .zip 檔案上傳"
-	},
-	"files.navbar.upload-from-zip-url": {
-		"defaultMessage": "從 .zip 網址上傳"
-	},
-	"files.rename-modal.header": {
-		"defaultMessage": "重新命名 {name}"
-	},
-	"files.rename-modal.new-name-label": {
-		"defaultMessage": "新名稱"
-	},
-	"files.row.item-count": {
-		"defaultMessage": "{count, plural, other {# 個項目}}"
-	},
-	"files.table-header.created": {
-		"defaultMessage": "建立時間"
-	},
-	"files.table-header.modified": {
-		"defaultMessage": "修改時間"
-	},
-	"files.table-header.name": {
-		"defaultMessage": "名稱"
-	},
-	"files.table-header.size": {
-		"defaultMessage": "大小"
-	},
-	"files.unsaved-changes-modal.body": {
-		"defaultMessage": "您有未儲存的變更，如果離開將會遺失。離開前要儲存嗎？"
-	},
-	"files.unsaved-changes-modal.discard": {
-		"defaultMessage": "捨棄"
-	},
-	"files.unsaved-changes-modal.header": {
-		"defaultMessage": "未儲存的變更"
-	},
-	"files.validation.name-invalid-directory": {
-		"defaultMessage": "名稱只能包含英數字、破折號、底線或空格"
-	},
-	"files.validation.name-invalid-file": {
-		"defaultMessage": "名稱只能包含英數字、破折號、底線、點或空格"
-	},
-	"files.validation.name-label": {
-		"defaultMessage": "名稱"
-	},
-	"files.validation.name-required": {
-		"defaultMessage": "名稱為必填項目"
-	},
-	"files.zip-url-modal.cf-header": {
-		"defaultMessage": "安裝 CurseForge 整合包"
-	},
-	"files.zip-url-modal.cf-not-found-text": {
-		"defaultMessage": "在該網址找不到 CurseForge 整合包"
-	},
-	"files.zip-url-modal.cf-not-found-title": {
-		"defaultMessage": "找不到 CurseForge 整合包"
-	},
-	"files.zip-url-modal.enter-link": {
-		"defaultMessage": "輸入連結"
-	},
-	"files.zip-url-modal.error-cf-url": {
-		"defaultMessage": "網址必須是 CurseForge 整合包版本網址"
-	},
-	"files.zip-url-modal.error-url-invalid": {
-		"defaultMessage": "網址必須有效"
-	},
-	"files.zip-url-modal.error-url-required": {
-		"defaultMessage": "網址為必填項目"
-	},
-	"files.zip-url-modal.install-button": {
-		"defaultMessage": "安裝"
-	},
-	"files.zip-url-modal.install-failed-title": {
-		"defaultMessage": "安裝失敗"
-	},
-	"files.zip-url-modal.step-copy-description": {
-		"defaultMessage": "複製版本頁面網址並貼到下方"
-	},
-	"files.zip-url-modal.step-copy-title": {
-		"defaultMessage": "複製網址"
-	},
-	"files.zip-url-modal.step-find-description": {
-		"defaultMessage": "瀏覽 CurseForge 並找到您想要的整合包"
-	},
-	"files.zip-url-modal.step-find-title": {
-		"defaultMessage": "尋找整合包"
-	},
-	"files.zip-url-modal.step-select-description": {
-		"defaultMessage": "前往「檔案」分頁並選擇要安裝的版本"
-	},
-	"files.zip-url-modal.step-select-title": {
-		"defaultMessage": "選擇版本"
-	},
-	"files.zip-url-modal.unknown-error": {
-		"defaultMessage": "發生未知錯誤"
-	},
-	"files.zip-url-modal.zip-description": {
-		"defaultMessage": "複製並貼上 .zip 檔案的直接下載網址"
-	},
-	"files.zip-url-modal.zip-header": {
-		"defaultMessage": "正在從網址上傳 .zip 內容"
-	},
-	"form.label.address-line": {
-		"defaultMessage": "地址行 1"
-	},
-	"form.label.address-line-2": {
-		"defaultMessage": "地址行 2（可選）"
-	},
-	"form.label.amount": {
-		"defaultMessage": "金額"
-	},
-	"form.label.bank-name": {
-		"defaultMessage": "銀行名稱"
-	},
-	"form.label.business-name": {
-		"defaultMessage": "企業名稱"
-	},
-	"form.label.city": {
-		"defaultMessage": "城市"
-	},
-	"form.label.country": {
-		"defaultMessage": "國家或地區"
-	},
-	"form.label.date-of-birth": {
-		"defaultMessage": "出生日期"
-	},
-	"form.label.email": {
-		"defaultMessage": "電子郵件"
-	},
-	"form.label.first-name": {
-		"defaultMessage": "名字"
-	},
-	"form.label.last-name": {
-		"defaultMessage": "姓氏"
-	},
-	"form.label.postal-code": {
-		"defaultMessage": "郵遞區號"
-	},
-	"form.label.state-province": {
-		"defaultMessage": "縣市／省／州"
-	},
-	"form.placeholder.address": {
-		"defaultMessage": "輸入地址"
-	},
-	"form.placeholder.address-2": {
-		"defaultMessage": "公寓、套房等"
-	},
-	"form.placeholder.amount": {
-		"defaultMessage": "輸入金額"
-	},
-	"form.placeholder.bank-name": {
-		"defaultMessage": "輸入銀行名稱"
-	},
-	"form.placeholder.bank-name-dropdown": {
-		"defaultMessage": "選擇銀行名稱"
-	},
-	"form.placeholder.business-name": {
-		"defaultMessage": "輸入企業名稱"
-	},
-	"form.placeholder.city": {
-		"defaultMessage": "輸入城市"
-	},
-	"form.placeholder.country": {
-		"defaultMessage": "選擇國家或地區"
-	},
-	"form.placeholder.email": {
-		"defaultMessage": "輸入電子郵件地址"
-	},
-	"form.placeholder.first-name": {
-		"defaultMessage": "輸入名字"
-	},
-	"form.placeholder.last-name": {
-		"defaultMessage": "輸入姓氏"
-	},
-	"form.placeholder.postal-code": {
-		"defaultMessage": "輸入郵遞區號"
-	},
-	"form.placeholder.state": {
-		"defaultMessage": "輸入縣市／省／州"
-	},
-	"format.bytes.0": {
-		"defaultMessage": "{count, plural, other {# 位元組}}"
-	},
-	"format.bytes.1": {
-		"defaultMessage": "{count, number} KiB"
-	},
-	"format.bytes.2": {
-		"defaultMessage": "{count, number} MiB"
-	},
-	"format.bytes.3": {
-		"defaultMessage": "{count, number} GiB"
-	},
-	"format.bytes.4": {
-		"defaultMessage": "{count, number} TiB"
-	},
-	"header.category.category": {
-		"defaultMessage": "類別"
-	},
-	"header.category.feature": {
-		"defaultMessage": "功能"
-	},
-	"header.category.minecraft-server-community": {
-		"defaultMessage": "社群"
-	},
-	"header.category.minecraft-server-features": {
-		"defaultMessage": "特色"
-	},
-	"header.category.minecraft-server-gameplay": {
-		"defaultMessage": "遊戲玩法"
-	},
-	"header.category.minecraft-server-meta": {
-		"defaultMessage": "設定與機制"
-	},
-	"header.category.performance-impact": {
-		"defaultMessage": "效能影響"
-	},
-	"header.category.resolutions": {
-		"defaultMessage": "解析度"
-	},
-	"icon-select.edit": {
-		"defaultMessage": "編輯圖示"
-	},
-	"icon-select.remove": {
-		"defaultMessage": "移除圖示"
-	},
-	"icon-select.replace": {
-		"defaultMessage": "取代圖示"
-	},
-	"icon-select.select": {
-		"defaultMessage": "選擇圖示"
-	},
-	"input.search-version.placeholder": {
-		"defaultMessage": "搜尋版本..."
-	},
-	"input.search.placeholder": {
-		"defaultMessage": "搜尋..."
-	},
-	"input.select-version.placeholder": {
-		"defaultMessage": "選擇版本"
-	},
-	"input.view.gallery": {
-		"defaultMessage": "圖庫檢視"
-	},
-	"input.view.grid": {
-		"defaultMessage": "格狀檢視"
-	},
-	"input.view.list": {
-		"defaultMessage": "清單檢視"
-	},
-	"installation-settings.aria.select-game-version": {
-		"defaultMessage": "選擇遊戲版本"
-	},
-	"installation-settings.aria.select-loader-version": {
-		"defaultMessage": "選擇 {loader} 版本"
-	},
-	"installation-settings.aria.select-platform": {
-		"defaultMessage": "選擇平臺"
-	},
-	"installation-settings.confirm-version-change": {
-		"defaultMessage": "確定"
-	},
-	"installation-settings.confirm-version-change-description": {
-		"defaultMessage": "變更為 {gameVersion} 將會修改你伺服器上的下列內容。"
-	},
-	"installation-settings.confirm-version-change-header": {
-		"defaultMessage": "檢視內容變更"
-	},
-	"installation-settings.edit-installation.title": {
-		"defaultMessage": "編輯安裝"
-	},
-	"installation-settings.edit.warning-instance": {
-		"defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你仍想修改，請務必謹慎，因為這可能會導致問題。"
-	},
-	"installation-settings.edit.warning-server": {
-		"defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你想進行變更，請重設你的伺服器。"
-	},
-	"installation-settings.incompatible-content.auto-fix-button": {
-		"defaultMessage": "自動修復"
-	},
-	"installation-settings.incompatible-content.change-loader-button": {
-		"defaultMessage": "變更載入器"
-	},
-	"installation-settings.incompatible-content.disable-conflicts-button": {
-		"defaultMessage": "停用衝突項目"
-	},
-	"installation-settings.incompatible-content.game-version-warning-body": {
-		"defaultMessage": "變更遊戲版本時，我們可以停用不相容的已安裝內容，或是嘗試解決相容性問題。"
-	},
-	"installation-settings.incompatible-content.game-version-warning-title": {
-		"defaultMessage": "不相容警告"
-	},
-	"installation-settings.incompatible-content.header": {
-		"defaultMessage": "安裝了不相容的內容"
-	},
-	"installation-settings.incompatible-content.loader-change-body": {
-		"defaultMessage": "變更載入器時，所有已安裝的內容都將被停用。我們建議改為重設你的伺服器。"
-	},
-	"installation-settings.incompatible-content.loader-change-title": {
-		"defaultMessage": "變更載入器具有破壞性"
-	},
-	"installation-settings.linked-instance.title": {
-		"defaultMessage": "已連接{projectType}"
-	},
-	"installation-settings.linked.modpack": {
-		"defaultMessage": "模組包"
-	},
-	"installation-settings.linked.server-project": {
-		"defaultMessage": "伺服器專案"
-	},
-	"installation-settings.loader-version": {
-		"defaultMessage": "{loader} 版本"
-	},
-	"installation-settings.platform-lock-tooltip": {
-		"defaultMessage": "你需要重設伺服器才能切換載入器。"
-	},
-	"installation-settings.reinstall-modpack.description": {
-		"defaultMessage": "重新安裝模組包會將{type}內容重設為原始狀態，你新增的所有模組或內容都將被移除。"
-	},
-	"installation-settings.reinstall-modpack.title": {
-		"defaultMessage": "重新安裝模組包"
-	},
-	"installation-settings.reinstalling-modpack": {
-		"defaultMessage": "正在重新安裝模組包"
-	},
-	"installation-settings.removed-incompatible": {
-		"defaultMessage": "已移除（不相容）"
-	},
-	"installation-settings.repair.instance-description": {
-		"defaultMessage": "重新安裝 Minecraft 的必要元件並檢查檔案是否損毀。這或許能修復你的遊戲因啟動器出錯而打不開的問題。"
-	},
-	"installation-settings.repair.instance-title": {
-		"defaultMessage": "修復實例"
-	},
-	"installation-settings.repair.server-description": {
-		"defaultMessage": "在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的必要元件。這或許能修復你伺服器無法正常啟動的問題。"
-	},
-	"installation-settings.repair.server-title": {
-		"defaultMessage": "修復伺服器"
-	},
-	"installation-settings.saving": {
-		"defaultMessage": "儲存中..."
-	},
-	"installation-settings.search-game-version": {
-		"defaultMessage": "搜尋遊戲版本..."
-	},
-	"installation-settings.type.instance": {
-		"defaultMessage": "實例"
-	},
-	"installation-settings.type.instance-possessive": {
-		"defaultMessage": "實例"
-	},
-	"installation-settings.type.server": {
-		"defaultMessage": "伺服器"
-	},
-	"installation-settings.type.server-possessive": {
-		"defaultMessage": "伺服器"
-	},
-	"installation-settings.unlink": {
-		"defaultMessage": "取消連結"
-	},
-	"installation-settings.unlink.description": {
-		"defaultMessage": "取消連結將會永久中斷這個{type}與{projectType}的連結。這讓你可以變更載入器與 Minecraft 版本，但你將無法收到未來的更新。"
-	},
-	"installation-settings.verifying": {
-		"defaultMessage": "驗證中..."
-	},
-	"instance.confirm-reinstall.admonition-body": {
-		"defaultMessage": "重新安裝將會把所有已安裝或修改過的內容，重設回模組包原始的狀態。這將會移除所有你在原始安裝上額外添加的模組或內容。"
-	},
-	"instance.confirm-reinstall.admonition-header": {
-		"defaultMessage": "重新安裝警告"
-	},
-	"instance.confirm-reinstall.header": {
-		"defaultMessage": "重新安裝模組包"
-	},
-	"instance.confirm-reinstall.reinstall-button": {
-		"defaultMessage": "重新安裝模組包"
-	},
-	"instance.confirm-repair.body.instance": {
-		"defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復遊戲因啟動器出錯而無法啟動的問題。"
-	},
-	"instance.confirm-repair.body.server": {
-		"defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復伺服器無法正常啟動的問題。"
-	},
-	"instance.confirm-repair.header": {
-		"defaultMessage": "修復{type}"
-	},
-	"instance.confirm-repair.instance-label": {
-		"defaultMessage": "實例"
-	},
-	"instance.confirm-repair.repair-button": {
-		"defaultMessage": "修復"
-	},
-	"instance.confirm-repair.server-label": {
-		"defaultMessage": "伺服器"
-	},
-	"instance.worlds.game_mode.adventure": {
-		"defaultMessage": "冒險模式"
-	},
-	"instance.worlds.game_mode.creative": {
-		"defaultMessage": "創造模式"
-	},
-	"instance.worlds.game_mode.spectator": {
-		"defaultMessage": "旁觀者模式"
-	},
-	"instance.worlds.game_mode.survival": {
-		"defaultMessage": "生存模式"
-	},
-	"instance.worlds.game_mode.unknown": {
-		"defaultMessage": "未知的遊戲模式"
-	},
-	"instances.content-install.compatible-count": {
-		"defaultMessage": "{count} 個相容{count, plural, other {實例}}"
-	},
-	"instances.content-install.existing-tab": {
-		"defaultMessage": "已有實例"
-	},
-	"instances.content-install.game-version-placeholder": {
-		"defaultMessage": "選擇遊戲版本"
-	},
-	"instances.content-install.header": {
-		"defaultMessage": "安裝專案"
-	},
-	"instances.content-install.incompatible-tooltip": {
-		"defaultMessage": "這個專案支援的載入器或遊戲版本與這個實例所使用的不同。"
-	},
-	"instances.content-install.install-button": {
-		"defaultMessage": "安裝"
-	},
-	"instances.content-install.installed-badge": {
-		"defaultMessage": "已安裝"
-	},
-	"instances.content-install.instance-type": {
-		"defaultMessage": "實例類型"
-	},
-	"instances.content-install.loader-label": {
-		"defaultMessage": "載入器"
-	},
-	"instances.content-install.name-label": {
-		"defaultMessage": "名稱"
-	},
-	"instances.content-install.name-placeholder": {
-		"defaultMessage": "輸入實例名稱"
-	},
-	"instances.content-install.new-tab": {
-		"defaultMessage": "新的實例"
-	},
-	"instances.content-install.no-instances": {
-		"defaultMessage": "找不到相容的實例"
-	},
-	"instances.content-install.remove-icon": {
-		"defaultMessage": "移除圖示"
-	},
-	"instances.content-install.search-placeholder": {
-		"defaultMessage": "搜尋實例"
-	},
-	"instances.content-install.select-icon": {
-		"defaultMessage": "選擇圖示"
-	},
-	"instances.modpack-content-modal.empty-description": {
-		"defaultMessage": "這個模組包不包含任何額外內容。"
-	},
-	"instances.modpack-content-modal.empty-title": {
-		"defaultMessage": "找不到內容"
-	},
-	"instances.modpack-content-modal.header": {
-		"defaultMessage": "模組包內容"
-	},
-	"instances.modpack-content-modal.loading": {
-		"defaultMessage": "正在載入內容..."
-	},
-	"instances.modpack-content-modal.no-results": {
-		"defaultMessage": "沒有專案符合你的搜尋字詞。"
-	},
-	"instances.modpack-content-modal.search-placeholder": {
-		"defaultMessage": "搜尋 {count, number} {count, plural, other {個專案}}"
-	},
-	"instances.updater-modal.badge.current": {
-		"defaultMessage": "目前"
-	},
-	"instances.updater-modal.badge.incompatible": {
-		"defaultMessage": "不相容"
-	},
-	"instances.updater-modal.downgrade-to": {
-		"defaultMessage": "降級到 {version}"
-	},
-	"instances.updater-modal.header": {
-		"defaultMessage": "更新版本"
-	},
-	"instances.updater-modal.header-modpack": {
-		"defaultMessage": "切換模組包版本"
-	},
-	"instances.updater-modal.header-switch": {
-		"defaultMessage": "切換版本"
-	},
-	"instances.updater-modal.hide-incompatible": {
-		"defaultMessage": "隱藏不相容項目"
-	},
-	"instances.updater-modal.incompatibility-warning": {
-		"defaultMessage": "這個版本與這個實例不相容。相依項將不會自動安裝。"
-	},
-	"instances.updater-modal.incompatibility-warning-header": {
-		"defaultMessage": "選擇版本"
-	},
-	"instances.updater-modal.incompatible-update.description": {
-		"defaultMessage": "{version} 與此實例不相容。它可能無法啟動或運行異常。"
-	},
-	"instances.updater-modal.incompatible-update.header": {
-		"defaultMessage": "更新到不相容版本？"
-	},
-	"instances.updater-modal.incompatible-update.proceed": {
-		"defaultMessage": "仍要更新"
-	},
-	"instances.updater-modal.install-anyway": {
-		"defaultMessage": "仍要安裝"
-	},
-	"instances.updater-modal.loading-changelog": {
-		"defaultMessage": "正在載入更新日誌..."
-	},
-	"instances.updater-modal.loading-versions": {
-		"defaultMessage": "正在載入版本..."
-	},
-	"instances.updater-modal.no-changelog": {
-		"defaultMessage": "這個版本沒有提供更新日誌。"
-	},
-	"instances.updater-modal.no-versions": {
-		"defaultMessage": "找不到版本"
-	},
-	"instances.updater-modal.search-placeholder": {
-		"defaultMessage": "搜尋版本..."
-	},
-	"instances.updater-modal.select-version": {
-		"defaultMessage": "選擇版本以查看更新日誌"
-	},
-	"instances.updater-modal.show-incompatible": {
-		"defaultMessage": "顯示不相容項目"
-	},
-	"instances.updater-modal.switch-to": {
-		"defaultMessage": "切換到 {version}"
-	},
-	"instances.updater-modal.update-to": {
-		"defaultMessage": "更新到 {version}"
-	},
-	"instances.updater-modal.warning-app": {
-		"defaultMessage": "更新可能會導致實例損壞。請先查看版本更新日誌並備份。"
-	},
-	"instances.updater-modal.warning-web": {
-		"defaultMessage": "更新可能會導致世界損壞。請先查看版本更新日誌並備份。"
-	},
-	"label.actions": {
-		"defaultMessage": "動作"
-	},
-	"label.available": {
-		"defaultMessage": "可用餘額 {amount}。"
-	},
-	"label.changelog": {
-		"defaultMessage": "更新日誌"
-	},
-	"label.changes-saved": {
-		"defaultMessage": "變更已儲存"
-	},
-	"label.client-depends-warning": {
-		"defaultMessage": "此模組依賴客戶端模組，啟動伺服器時可能會造成問題"
-	},
-	"label.client-only-warning": {
-		"defaultMessage": "此為用戶端模組，啟動伺服器時可能會導致問題"
-	},
-	"label.client-retained-warning": {
-		"defaultMessage": "這是一個作為依賴項安裝的客戶端模組，啟動伺服器時可能會造成問題"
-	},
-	"label.collections": {
-		"defaultMessage": "收藏"
-	},
-	"label.confirm-password": {
-		"defaultMessage": "確認密碼"
-	},
-	"label.content": {
-		"defaultMessage": "內容"
-	},
-	"label.copied-filename": {
-		"defaultMessage": "已複製檔案名稱"
-	},
-	"label.copied-path": {
-		"defaultMessage": "已複製路徑"
-	},
-	"label.create-failed": {
-		"defaultMessage": "建立失敗"
-	},
-	"label.created-ago": {
-		"defaultMessage": "建立時間：{ago}"
-	},
-	"label.dashboard": {
-		"defaultMessage": "資訊主頁"
-	},
-	"label.delete": {
-		"defaultMessage": "刪除"
-	},
-	"label.delete-failed": {
-		"defaultMessage": "刪除失敗"
-	},
-	"label.delete-immediately": {
-		"defaultMessage": "立即刪除"
-	},
-	"label.description": {
-		"defaultMessage": "描述"
-	},
-	"label.details": {
-		"defaultMessage": "詳細資訊"
-	},
-	"label.done": {
-		"defaultMessage": "完成"
-	},
-	"label.download-failed": {
-		"defaultMessage": "下載失敗"
-	},
-	"label.email": {
-		"defaultMessage": "電子郵件地址"
-	},
-	"label.email-username": {
-		"defaultMessage": "電子郵件地址或使用者名稱"
-	},
-	"label.error": {
-		"defaultMessage": "錯誤"
-	},
-	"label.extract-failed": {
-		"defaultMessage": "解壓縮失敗"
-	},
-	"label.filter-by": {
-		"defaultMessage": "篩選依據"
-	},
-	"label.filters": {
-		"defaultMessage": "篩選器"
-	},
-	"label.followed-projects": {
-		"defaultMessage": "追蹤的專案"
-	},
-	"label.game-version": {
-		"defaultMessage": "遊戲版本"
-	},
-	"label.hide-installed-content": {
-		"defaultMessage": "隱藏已安裝的內容"
-	},
-	"label.hide-selected-content": {
-		"defaultMessage": "隱藏已選取的內容"
-	},
-	"label.installation-info": {
-		"defaultMessage": "安裝資訊"
-	},
-	"label.installed": {
-		"defaultMessage": "已安裝"
-	},
-	"label.installed-modpack": {
-		"defaultMessage": "已安裝模組包"
-	},
-	"label.installing": {
-		"defaultMessage": "安裝中..."
-	},
-	"label.installing-content": {
-		"defaultMessage": "正在安裝內容"
-	},
-	"label.loading": {
-		"defaultMessage": "載入中..."
-	},
-	"label.moderation": {
-		"defaultMessage": "管理"
-	},
-	"label.modpack": {
-		"defaultMessage": "模組包"
-	},
-	"label.move-failed": {
-		"defaultMessage": "移動失敗"
-	},
-	"label.no": {
-		"defaultMessage": "否"
-	},
-	"label.no-items": {
-		"defaultMessage": "沒有項目"
-	},
-	"label.notifications": {
-		"defaultMessage": "通知"
-	},
-	"label.or": {
-		"defaultMessage": "或"
-	},
-	"label.password": {
-		"defaultMessage": "密碼"
-	},
-	"label.plan-custom": {
-		"defaultMessage": "自訂"
-	},
-	"label.plan-large": {
-		"defaultMessage": "大型"
-	},
-	"label.plan-medium": {
-		"defaultMessage": "中型"
-	},
-	"label.plan-small": {
-		"defaultMessage": "小型"
-	},
-	"label.plan-unknown": {
-		"defaultMessage": "未知"
-	},
-	"label.platform": {
-		"defaultMessage": "平臺"
-	},
-	"label.played": {
-		"defaultMessage": "上次遊玩時間：{ago}"
-	},
-	"label.project": {
-		"defaultMessage": "專案"
-	},
-	"label.public": {
-		"defaultMessage": "公開"
-	},
-	"label.rejected": {
-		"defaultMessage": "已拒絕"
-	},
-	"label.rename-failed": {
-		"defaultMessage": "重新命名失敗"
-	},
-	"label.rewards-program-terms-agreement": {
-		"defaultMessage": "我同意《<terms-link>獎勵計畫條款</terms-link>》"
-	},
-	"label.saved": {
-		"defaultMessage": "已儲存"
-	},
-	"label.scopes": {
-		"defaultMessage": "權限範圍"
-	},
-	"label.search": {
-		"defaultMessage": "搜尋"
-	},
-	"label.select-all": {
-		"defaultMessage": "選擇全部"
-	},
-	"label.selected": {
-		"defaultMessage": "已選取"
-	},
-	"label.selection-actions": {
-		"defaultMessage": "選擇動作"
-	},
-	"label.server": {
-		"defaultMessage": "伺服器"
-	},
-	"label.servers": {
-		"defaultMessage": "伺服器"
-	},
-	"label.settings": {
-		"defaultMessage": "設定"
-	},
-	"label.singleplayer": {
-		"defaultMessage": "單人遊戲"
-	},
-	"label.sort-by": {
-		"defaultMessage": "排序依據："
-	},
-	"label.success": {
-		"defaultMessage": "成功"
-	},
-	"label.title": {
-		"defaultMessage": "標題"
-	},
-	"label.unknown": {
-		"defaultMessage": "未知"
-	},
-	"label.unlisted": {
-		"defaultMessage": "不公開"
-	},
-	"label.update-available": {
-		"defaultMessage": "有可用的更新"
-	},
-	"label.updating": {
-		"defaultMessage": "更新中..."
-	},
-	"label.upload-failed": {
-		"defaultMessage": "上傳失敗"
-	},
-	"label.username": {
-		"defaultMessage": "使用者名稱"
-	},
-	"label.validating": {
-		"defaultMessage": "驗證中"
-	},
-	"label.version": {
-		"defaultMessage": "版本"
-	},
-	"label.view": {
-		"defaultMessage": "檢視方式"
-	},
-	"label.visibility": {
-		"defaultMessage": "瀏覽權限"
-	},
-	"label.visit-your-profile": {
-		"defaultMessage": "瀏覽個人檔案"
-	},
-	"label.yes": {
-		"defaultMessage": "是"
-	},
-	"locale.cs-CZ": {
-		"defaultMessage": "捷克文"
-	},
-	"locale.da-DK": {
-		"defaultMessage": "丹麥文"
-	},
-	"locale.de-CH": {
-		"defaultMessage": "德文（瑞士）"
-	},
-	"locale.de-DE": {
-		"defaultMessage": "德文（德國）"
-	},
-	"locale.en-US": {
-		"defaultMessage": "英文（美國）"
-	},
-	"locale.es-419": {
-		"defaultMessage": "西班牙文（拉丁美洲）"
-	},
-	"locale.es-ES": {
-		"defaultMessage": "西班牙文（西班牙）"
-	},
-	"locale.fi-FI": {
-		"defaultMessage": "芬蘭文"
-	},
-	"locale.fil-PH": {
-		"defaultMessage": "菲律賓文"
-	},
-	"locale.fr-FR": {
-		"defaultMessage": "法文"
-	},
-	"locale.he-IL": {
-		"defaultMessage": "希伯來文"
-	},
-	"locale.hu-HU": {
-		"defaultMessage": "匈牙利文"
-	},
-	"locale.id-ID": {
-		"defaultMessage": "印尼文"
-	},
-	"locale.it-IT": {
-		"defaultMessage": "義大利文（義大利）"
-	},
-	"locale.ja-JP": {
-		"defaultMessage": "日文"
-	},
-	"locale.ko-KR": {
-		"defaultMessage": "韓文"
-	},
-	"locale.ms-MY": {
-		"defaultMessage": "馬來文"
-	},
-	"locale.nl-NL": {
-		"defaultMessage": "荷蘭文"
-	},
-	"locale.no-NO": {
-		"defaultMessage": "書面挪威文"
-	},
-	"locale.pl-PL": {
-		"defaultMessage": "波蘭文"
-	},
-	"locale.pt-BR": {
-		"defaultMessage": "葡萄牙文（巴西）"
-	},
-	"locale.pt-PT": {
-		"defaultMessage": "葡萄牙文（葡萄牙）"
-	},
-	"locale.ro-RO": {
-		"defaultMessage": "羅馬尼亞文"
-	},
-	"locale.ru-RU": {
-		"defaultMessage": "俄文"
-	},
-	"locale.sr-CS": {
-		"defaultMessage": "塞爾維亞文（拉丁）"
-	},
-	"locale.sv-SE": {
-		"defaultMessage": "瑞典文"
-	},
-	"locale.th-TH": {
-		"defaultMessage": "泰文"
-	},
-	"locale.tr-TR": {
-		"defaultMessage": "土耳其文"
-	},
-	"locale.uk-UA": {
-		"defaultMessage": "烏克蘭文"
-	},
-	"locale.vi-VN": {
-		"defaultMessage": "越南文"
-	},
-	"locale.zh-CN": {
-		"defaultMessage": "簡體中文"
-	},
-	"locale.zh-TW": {
-		"defaultMessage": "正體中文"
-	},
-	"markdown-editor.default-image-alt-text": {
-		"defaultMessage": "請將此內容替換為描述"
-	},
-	"markdown-editor.error-label": {
-		"defaultMessage": "錯誤"
-	},
-	"markdown-editor.image-modal.description-field.description": {
-		"defaultMessage": "請盡可能詳細描述這張圖片，如同對一位看不見這張圖片的人說明一般。"
-	},
-	"markdown-editor.image-modal.description-field.placeholder": {
-		"defaultMessage": "描述這張圖片..."
-	},
-	"markdown-editor.image-modal.description-field.title": {
-		"defaultMessage": "描述（替代文字）"
-	},
-	"markdown-editor.image-modal.header": {
-		"defaultMessage": "插入圖片"
-	},
-	"markdown-editor.image-modal.upload-mode.label": {
-		"defaultMessage": "圖片來源"
-	},
-	"markdown-editor.image-modal.upload-mode.link": {
-		"defaultMessage": "連結"
-	},
-	"markdown-editor.image-modal.upload-mode.upload": {
-		"defaultMessage": "上傳"
-	},
-	"markdown-editor.image-modal.upload.prompt": {
-		"defaultMessage": "拖曳檔案以上傳或點擊選擇檔案"
-	},
-	"markdown-editor.image-modal.url-field.placeholder": {
-		"defaultMessage": "輸入圖片網址..."
-	},
-	"markdown-editor.insert-button": {
-		"defaultMessage": "插入"
-	},
-	"markdown-editor.link-modal.header": {
-		"defaultMessage": "插入連結"
-	},
-	"markdown-editor.link-modal.label-field.placeholder": {
-		"defaultMessage": "輸入標籤..."
-	},
-	"markdown-editor.link-modal.label-field.title": {
-		"defaultMessage": "標籤"
-	},
-	"markdown-editor.link-modal.url-field.placeholder": {
-		"defaultMessage": "輸入連結網址..."
-	},
-	"markdown-editor.markdown-formatting-support": {
-		"defaultMessage": "這個編輯器支援 <markdown-link>Markdown 格式</markdown-link>。"
-	},
-	"markdown-editor.max-length.label": {
-		"defaultMessage": "長度限制："
-	},
-	"markdown-editor.max-length.unlimited": {
-		"defaultMessage": "無限制"
-	},
-	"markdown-editor.max-length.value": {
-		"defaultMessage": "{currentLength}/{maxLength}"
-	},
-	"markdown-editor.placeholder": {
-		"defaultMessage": "寫點什麼..."
-	},
-	"markdown-editor.preview-label": {
-		"defaultMessage": "預覽"
-	},
-	"markdown-editor.preview-toggle.label": {
-		"defaultMessage": "預覽"
-	},
-	"markdown-editor.toolbar.bold": {
-		"defaultMessage": "粗體"
-	},
-	"markdown-editor.toolbar.bulleted-list": {
-		"defaultMessage": "項目符號清單"
-	},
-	"markdown-editor.toolbar.code": {
-		"defaultMessage": "程式碼"
-	},
-	"markdown-editor.toolbar.heading-1": {
-		"defaultMessage": "標題 1"
-	},
-	"markdown-editor.toolbar.heading-2": {
-		"defaultMessage": "標題 2"
-	},
-	"markdown-editor.toolbar.heading-3": {
-		"defaultMessage": "標題 3"
-	},
-	"markdown-editor.toolbar.image": {
-		"defaultMessage": "圖片"
-	},
-	"markdown-editor.toolbar.italic": {
-		"defaultMessage": "斜體"
-	},
-	"markdown-editor.toolbar.link": {
-		"defaultMessage": "連結"
-	},
-	"markdown-editor.toolbar.ordered-list": {
-		"defaultMessage": "排序清單"
-	},
-	"markdown-editor.toolbar.quote": {
-		"defaultMessage": "引用"
-	},
-	"markdown-editor.toolbar.spoiler": {
-		"defaultMessage": "暴雷內容"
-	},
-	"markdown-editor.toolbar.strikethrough": {
-		"defaultMessage": "刪除線"
-	},
-	"markdown-editor.toolbar.video": {
-		"defaultMessage": "影片"
-	},
-	"markdown-editor.upload-error.no-file": {
-		"defaultMessage": "未提供檔案"
-	},
-	"markdown-editor.upload-error.no-handler": {
-		"defaultMessage": "未提供圖片上傳處理常式"
-	},
-	"markdown-editor.url-label": {
-		"defaultMessage": "網址"
-	},
-	"markdown-editor.url-validation-error.blocked-domain": {
-		"defaultMessage": "無效的網址。不允許這個網域。"
-	},
-	"markdown-editor.url-validation-error.malformed": {
-		"defaultMessage": "無效的網址。請確保網址格式正確。"
-	},
-	"markdown-editor.url-validation-error.unsupported-protocol": {
-		"defaultMessage": "不支援的協定。請使用 http 或 https。"
-	},
-	"markdown-editor.video-embed.title": {
-		"defaultMessage": "YouTube 影片播放器"
-	},
-	"markdown-editor.video-modal.header": {
-		"defaultMessage": "插入 YouTube 影片"
-	},
-	"markdown-editor.video-modal.url-field.description": {
-		"defaultMessage": "請輸入有效的 YouTube 影片連結。"
-	},
-	"markdown-editor.video-modal.url-field.placeholder": {
-		"defaultMessage": "輸入 YouTube 影片網址"
-	},
-	"markdown-editor.video-modal.url-field.title": {
-		"defaultMessage": "YouTube 影片網址"
-	},
-	"modal.open-in-app.benefit.install": {
-		"defaultMessage": "自動安裝所需內容"
-	},
-	"modal.open-in-app.benefit.launch": {
-		"defaultMessage": "直接啟動遊戲並加入伺服器"
-	},
-	"modal.open-in-app.benefit.update": {
-		"defaultMessage": "當伺服器變動時，維持檔案為最新狀態"
-	},
-	"modal.open-in-app.get-app": {
-		"defaultMessage": "取得 Modrinth App"
-	},
-	"modal.open-in-app.opening-automatically": {
-		"defaultMessage": "Modrinth App 將自動開啟..."
-	},
-	"modal.open-in-app.title": {
-		"defaultMessage": "正在開啟 Modrinth App"
-	},
-	"modal.open-in-app.why-use": {
-		"defaultMessage": "為何使用 Modrinth App"
-	},
-	"notification.error.title": {
-		"defaultMessage": "發生錯誤"
-	},
-	"omorphia.component.badge.label.accepted": {
-		"defaultMessage": "已接受"
-	},
-	"omorphia.component.badge.label.approved": {
-		"defaultMessage": "已核准"
-	},
-	"omorphia.component.badge.label.archived": {
-		"defaultMessage": "已封存"
-	},
-	"omorphia.component.badge.label.closed": {
-		"defaultMessage": "已關閉"
-	},
-	"omorphia.component.badge.label.creator": {
-		"defaultMessage": "創作者"
-	},
-	"omorphia.component.badge.label.draft": {
-		"defaultMessage": "草稿"
-	},
-	"omorphia.component.badge.label.failed": {
-		"defaultMessage": "失敗"
-	},
-	"omorphia.component.badge.label.listed": {
-		"defaultMessage": "公開"
-	},
-	"omorphia.component.badge.label.moderator": {
-		"defaultMessage": "管理員"
-	},
-	"omorphia.component.badge.label.modrinth-team": {
-		"defaultMessage": "Modrinth 團隊"
-	},
-	"omorphia.component.badge.label.pending": {
-		"defaultMessage": "待處理"
-	},
-	"omorphia.component.badge.label.private": {
-		"defaultMessage": "私人"
-	},
-	"omorphia.component.badge.label.processed": {
-		"defaultMessage": "已處理"
-	},
-	"omorphia.component.badge.label.rejected": {
-		"defaultMessage": "已拒絕"
-	},
-	"omorphia.component.badge.label.returned": {
-		"defaultMessage": "已退回"
-	},
-	"omorphia.component.badge.label.safe": {
-		"defaultMessage": "通過"
-	},
-	"omorphia.component.badge.label.scheduled": {
-		"defaultMessage": "已排定"
-	},
-	"omorphia.component.badge.label.under-review": {
-		"defaultMessage": "審查中"
-	},
-	"omorphia.component.badge.label.unlisted": {
-		"defaultMessage": "不公開"
-	},
-	"omorphia.component.badge.label.unsafe": {
-		"defaultMessage": "不通過"
-	},
-	"omorphia.component.badge.label.withheld": {
-		"defaultMessage": "由工作人員設為不公開"
-	},
-	"omorphia.component.copy.action.copy": {
-		"defaultMessage": "將程式碼複製到剪貼簿"
-	},
-	"omorphia.component.environment-indicator.label.client": {
-		"defaultMessage": "用戶端"
-	},
-	"omorphia.component.environment-indicator.label.client-and-server": {
-		"defaultMessage": "用戶端與伺服器端"
-	},
-	"omorphia.component.environment-indicator.label.client-or-server": {
-		"defaultMessage": "用戶端或伺服器端"
-	},
-	"omorphia.component.environment-indicator.label.server": {
-		"defaultMessage": "伺服器端"
-	},
-	"omorphia.component.environment-indicator.label.type": {
-		"defaultMessage": "{type}"
-	},
-	"omorphia.component.environment-indicator.label.unsupported": {
-		"defaultMessage": "不支援"
-	},
-	"payment-method.amazon_pay": {
-		"defaultMessage": "Amazon Pay"
-	},
-	"payment-method.amex": {
-		"defaultMessage": "美國運通"
-	},
-	"payment-method.card_display": {
-		"defaultMessage": "{card_brand}（末四碼 {last_four}）"
-	},
-	"payment-method.cashapp": {
-		"defaultMessage": "Cash App"
-	},
-	"payment-method.charity": {
-		"defaultMessage": "慈善機構"
-	},
-	"payment-method.charity-plural": {
-		"defaultMessage": "慈善機構"
-	},
-	"payment-method.diners": {
-		"defaultMessage": "大來卡"
-	},
-	"payment-method.discover": {
-		"defaultMessage": "Discover"
-	},
-	"payment-method.eftpos": {
-		"defaultMessage": "EFTPOS"
-	},
-	"payment-method.gift-card": {
-		"defaultMessage": "禮品卡"
-	},
-	"payment-method.gift-card-plural": {
-		"defaultMessage": "禮品卡"
-	},
-	"payment-method.jcb": {
-		"defaultMessage": "JCB"
-	},
-	"payment-method.mastercard": {
-		"defaultMessage": "萬事達卡"
-	},
-	"payment-method.paypal": {
-		"defaultMessage": "PayPal"
-	},
-	"payment-method.paypal_international": {
-		"defaultMessage": "PayPal 國際"
-	},
-	"payment-method.unionpay": {
-		"defaultMessage": "銀聯"
-	},
-	"payment-method.unknown": {
-		"defaultMessage": "未知的付款方式"
-	},
-	"payment-method.venmo": {
-		"defaultMessage": "Venmo"
-	},
-	"payment-method.virtual-visa": {
-		"defaultMessage": "虛擬 Visa 卡"
-	},
-	"payment-method.virtual-visa-plural": {
-		"defaultMessage": "虛擬 Visa 卡"
-	},
-	"payment-method.visa": {
-		"defaultMessage": "Visa"
-	},
-	"project-card.date.published.tooltip": {
-		"defaultMessage": "發布時間：{date}"
-	},
-	"project-card.date.updated.tooltip": {
-		"defaultMessage": "更新時間：{date}"
-	},
-	"project-card.environment.client": {
-		"defaultMessage": "用戶端"
-	},
-	"project-card.environment.client-and-server": {
-		"defaultMessage": "用戶端與伺服器端"
-	},
-	"project-card.environment.client-or-server": {
-		"defaultMessage": "用戶端或伺服器端"
-	},
-	"project-card.environment.server": {
-		"defaultMessage": "伺服器"
-	},
-	"project-type.all": {
-		"defaultMessage": "全部"
-	},
-	"project-type.datapack.capital": {
-		"defaultMessage": "{count, plural, other {資料包}}"
-	},
-	"project-type.datapack.category": {
-		"defaultMessage": "資料包"
-	},
-	"project-type.datapack.lowercase": {
-		"defaultMessage": "{count, plural, other {資料包}}"
-	},
-	"project-type.mod.capital": {
-		"defaultMessage": "{count, plural, other {模組}}"
-	},
-	"project-type.mod.category": {
-		"defaultMessage": "模組"
-	},
-	"project-type.mod.lowercase": {
-		"defaultMessage": "{count, plural, other {模組}}"
-	},
-	"project-type.modpack.capital": {
-		"defaultMessage": "{count, plural, other {模組包}}"
-	},
-	"project-type.modpack.category": {
-		"defaultMessage": "模組包"
-	},
-	"project-type.modpack.lowercase": {
-		"defaultMessage": "{count, plural, other {模組包}}"
-	},
-	"project-type.plugin.capital": {
-		"defaultMessage": "{count, plural, other {插件}}"
-	},
-	"project-type.plugin.category": {
-		"defaultMessage": "插件"
-	},
-	"project-type.plugin.lowercase": {
-		"defaultMessage": "{count, plural, other {插件}}"
-	},
-	"project-type.project.capital": {
-		"defaultMessage": "{count, plural, other {專案}}"
-	},
-	"project-type.project.category": {
-		"defaultMessage": "專案"
-	},
-	"project-type.project.lowercase": {
-		"defaultMessage": "{count, plural, other {專案}}"
-	},
-	"project-type.resourcepack.capital": {
-		"defaultMessage": "{count, plural, other {資源包}}"
-	},
-	"project-type.resourcepack.category": {
-		"defaultMessage": "資源包"
-	},
-	"project-type.resourcepack.lowercase": {
-		"defaultMessage": "{count, plural, other {資源包}}"
-	},
-	"project-type.server.capital": {
-		"defaultMessage": "{count, plural, one {伺服器} other {伺服器}}"
-	},
-	"project-type.server.category": {
-		"defaultMessage": "伺服器"
-	},
-	"project-type.server.lowercase": {
-		"defaultMessage": "{count, plural, other {伺服器}}"
-	},
-	"project-type.shader.capital": {
-		"defaultMessage": "{count, plural, other {光影包}}"
-	},
-	"project-type.shader.category": {
-		"defaultMessage": "光影包"
-	},
-	"project-type.shader.lowercase": {
-		"defaultMessage": "{count, plural, other {光影包}}"
-	},
-	"project.about.compatibility.environments": {
-		"defaultMessage": "支援環境"
-	},
-	"project.about.compatibility.environments.client-and-server": {
-		"defaultMessage": "用戶端與伺服器端"
-	},
-	"project.about.compatibility.environments.client-side": {
-		"defaultMessage": "用戶端"
-	},
-	"project.about.compatibility.environments.dedicated-servers-only": {
-		"defaultMessage": "僅限專用伺服器"
-	},
-	"project.about.compatibility.environments.server-side": {
-		"defaultMessage": "伺服器端"
-	},
-	"project.about.compatibility.environments.singleplayer": {
-		"defaultMessage": "單人遊戲"
-	},
-	"project.about.compatibility.environments.singleplayer-only": {
-		"defaultMessage": "僅限單人遊戲"
-	},
-	"project.about.compatibility.game.minecraftJava": {
-		"defaultMessage": "Minecraft Java 版"
-	},
-	"project.about.compatibility.platforms": {
-		"defaultMessage": "平臺"
-	},
-	"project.about.compatibility.platforms-plural": {
-		"defaultMessage": "{count, plural, other {平臺}}"
-	},
-	"project.about.compatibility.title": {
-		"defaultMessage": "相容性"
-	},
-	"project.about.creators.organization": {
-		"defaultMessage": "組織"
-	},
-	"project.about.creators.owner": {
-		"defaultMessage": "專案擁有者"
-	},
-	"project.about.creators.title": {
-		"defaultMessage": "創作者"
-	},
-	"project.about.details.created": {
-		"defaultMessage": "建立時間：{date}"
-	},
-	"project.about.details.licensed": {
-		"defaultMessage": "授權條款：{license}"
-	},
-	"project.about.details.published": {
-		"defaultMessage": "發布時間：{date}"
-	},
-	"project.about.details.submitted": {
-		"defaultMessage": "提交時間：{date}"
-	},
-	"project.about.details.updated": {
-		"defaultMessage": "更新時間：{date}"
-	},
-	"project.about.links.discord": {
-		"defaultMessage": "加入 Discord 伺服器"
-	},
-	"project.about.links.donate.bmac": {
-		"defaultMessage": "Buy Me a Coffee"
-	},
-	"project.about.links.donate.generic": {
-		"defaultMessage": "贊助"
-	},
-	"project.about.links.donate.github": {
-		"defaultMessage": "GitHub Sponsors 贊助"
-	},
-	"project.about.links.donate.kofi": {
-		"defaultMessage": "Ko-fi 贊助"
-	},
-	"project.about.links.donate.patreon": {
-		"defaultMessage": "Patreon 贊助"
-	},
-	"project.about.links.donate.paypal": {
-		"defaultMessage": "PayPal 贊助"
-	},
-	"project.about.links.issues": {
-		"defaultMessage": "回報問題"
-	},
-	"project.about.links.site": {
-		"defaultMessage": "前往網站"
-	},
-	"project.about.links.source": {
-		"defaultMessage": "檢視原始碼"
-	},
-	"project.about.links.store": {
-		"defaultMessage": "前往商店頁面"
-	},
-	"project.about.links.title": {
-		"defaultMessage": "相關連結"
-	},
-	"project.about.links.wiki": {
-		"defaultMessage": "前往 wiki"
-	},
-	"project.about.server.address.tooltip": {
-		"defaultMessage": "複製 Java 伺服器位址"
-	},
-	"project.about.server.copied": {
-		"defaultMessage": "已複製！"
-	},
-	"project.about.server.copiedText": {
-		"defaultMessage": "已將伺服器位址複製到剪貼簿"
-	},
-	"project.about.server.downloadModpack": {
-		"defaultMessage": "下載模組包"
-	},
-	"project.about.server.languages": {
-		"defaultMessage": "語言"
-	},
-	"project.about.server.recommendedVersion": {
-		"defaultMessage": "（推薦）"
-	},
-	"project.about.server.region": {
-		"defaultMessage": "地區"
-	},
-	"project.about.server.requiredContent": {
-		"defaultMessage": "必需內容"
-	},
-	"project.about.server.title": {
-		"defaultMessage": "伺服器詳細資訊"
-	},
-	"project.about.tags.title": {
-		"defaultMessage": "標籤"
-	},
-	"project.download-count-tooltip": {
-		"defaultMessage": "{count, number} 次{count, plural, other {下載}}"
-	},
-	"project.follower-count-tooltip": {
-		"defaultMessage": "{count, number} 位{count, plural, other {追蹤者}}"
-	},
-	"project.online-player-count": {
-		"defaultMessage": "{count, number} 人在線上"
-	},
-	"project.online-player-count.tooltip": {
-		"defaultMessage": "{count} 位{countPlural, plural, other {玩家}}在線上"
-	},
-	"project.recent-plays": {
-		"defaultMessage": "{count} 次{countPlural, plural, other {近期遊玩}}"
-	},
-	"project.recent-plays.tooltip": {
-		"defaultMessage": "過去 2 週內來自 Modrinth 的 {count} 次{countPlural, plural, other {最近遊玩次數}}"
-	},
-	"project.server.customModpackTooltip": {
-		"defaultMessage": "這個專案使用了自訂模組包"
-	},
-	"project.server.language.af": {
-		"defaultMessage": "南非文"
-	},
-	"project.server.language.am": {
-		"defaultMessage": "阿姆哈拉文"
-	},
-	"project.server.language.ar": {
-		"defaultMessage": "阿拉伯文"
-	},
-	"project.server.language.az": {
-		"defaultMessage": "亞塞拜然文"
-	},
-	"project.server.language.be": {
-		"defaultMessage": "白俄羅斯文"
-	},
-	"project.server.language.bg": {
-		"defaultMessage": "保加利亞文"
-	},
-	"project.server.language.bn": {
-		"defaultMessage": "孟加拉文"
-	},
-	"project.server.language.bs": {
-		"defaultMessage": "波士尼亞文"
-	},
-	"project.server.language.ca": {
-		"defaultMessage": "加泰隆尼亞文"
-	},
-	"project.server.language.cs": {
-		"defaultMessage": "捷克文"
-	},
-	"project.server.language.da": {
-		"defaultMessage": "丹麥文"
-	},
-	"project.server.language.de": {
-		"defaultMessage": "德文"
-	},
-	"project.server.language.el": {
-		"defaultMessage": "希臘文"
-	},
-	"project.server.language.en": {
-		"defaultMessage": "英文"
-	},
-	"project.server.language.eo": {
-		"defaultMessage": "世界語"
-	},
-	"project.server.language.es": {
-		"defaultMessage": "西班牙文"
-	},
-	"project.server.language.et": {
-		"defaultMessage": "愛沙尼亞文"
-	},
-	"project.server.language.eu": {
-		"defaultMessage": "巴斯克文"
-	},
-	"project.server.language.fa": {
-		"defaultMessage": "波斯文"
-	},
-	"project.server.language.fi": {
-		"defaultMessage": "芬蘭文"
-	},
-	"project.server.language.fr": {
-		"defaultMessage": "法文"
-	},
-	"project.server.language.ga": {
-		"defaultMessage": "愛爾蘭文"
-	},
-	"project.server.language.gl": {
-		"defaultMessage": "加利西亞文"
-	},
-	"project.server.language.he": {
-		"defaultMessage": "希伯來文"
-	},
-	"project.server.language.hi": {
-		"defaultMessage": "印地文"
-	},
-	"project.server.language.hr": {
-		"defaultMessage": "克羅埃西亞文"
-	},
-	"project.server.language.hu": {
-		"defaultMessage": "匈牙利文"
-	},
-	"project.server.language.hy": {
-		"defaultMessage": "亞美尼亞文"
-	},
-	"project.server.language.id": {
-		"defaultMessage": "印尼文"
-	},
-	"project.server.language.is": {
-		"defaultMessage": "冰島文"
-	},
-	"project.server.language.it": {
-		"defaultMessage": "義大利文"
-	},
-	"project.server.language.ja": {
-		"defaultMessage": "日文"
-	},
-	"project.server.language.ka": {
-		"defaultMessage": "喬治亞文"
-	},
-	"project.server.language.kk": {
-		"defaultMessage": "哈薩克文"
-	},
-	"project.server.language.km": {
-		"defaultMessage": "高棉文"
-	},
-	"project.server.language.kn": {
-		"defaultMessage": "坎那達文"
-	},
-	"project.server.language.ko": {
-		"defaultMessage": "韓文"
-	},
-	"project.server.language.lo": {
-		"defaultMessage": "寮文"
-	},
-	"project.server.language.lt": {
-		"defaultMessage": "立陶宛文"
-	},
-	"project.server.language.lv": {
-		"defaultMessage": "拉脫維亞文"
-	},
-	"project.server.language.mk": {
-		"defaultMessage": "馬其頓文"
-	},
-	"project.server.language.ml": {
-		"defaultMessage": "馬來亞拉姆文"
-	},
-	"project.server.language.mn": {
-		"defaultMessage": "蒙古文"
-	},
-	"project.server.language.mr": {
-		"defaultMessage": "馬拉提文"
-	},
-	"project.server.language.ms": {
-		"defaultMessage": "馬來文"
-	},
-	"project.server.language.my": {
-		"defaultMessage": "緬甸文"
-	},
-	"project.server.language.ne": {
-		"defaultMessage": "尼泊爾文"
-	},
-	"project.server.language.nl": {
-		"defaultMessage": "荷蘭文"
-	},
-	"project.server.language.no": {
-		"defaultMessage": "挪威文"
-	},
-	"project.server.language.pa": {
-		"defaultMessage": "旁遮普文"
-	},
-	"project.server.language.pl": {
-		"defaultMessage": "波蘭文"
-	},
-	"project.server.language.pt": {
-		"defaultMessage": "葡萄牙文"
-	},
-	"project.server.language.ro": {
-		"defaultMessage": "羅馬尼亞文"
-	},
-	"project.server.language.ru": {
-		"defaultMessage": "俄文"
-	},
-	"project.server.language.si": {
-		"defaultMessage": "僧伽羅文"
-	},
-	"project.server.language.sk": {
-		"defaultMessage": "斯洛伐克文"
-	},
-	"project.server.language.sl": {
-		"defaultMessage": "斯洛維尼亞文"
-	},
-	"project.server.language.sq": {
-		"defaultMessage": "阿爾巴尼亞文"
-	},
-	"project.server.language.sr": {
-		"defaultMessage": "塞爾維亞文"
-	},
-	"project.server.language.sv": {
-		"defaultMessage": "瑞典文"
-	},
-	"project.server.language.sw": {
-		"defaultMessage": "斯瓦希里文"
-	},
-	"project.server.language.ta": {
-		"defaultMessage": "泰米爾文"
-	},
-	"project.server.language.te": {
-		"defaultMessage": "泰盧固文"
-	},
-	"project.server.language.th": {
-		"defaultMessage": "泰文"
-	},
-	"project.server.language.tl": {
-		"defaultMessage": "菲律賓文"
-	},
-	"project.server.language.tr": {
-		"defaultMessage": "土耳其文"
-	},
-	"project.server.language.uk": {
-		"defaultMessage": "烏克蘭文"
-	},
-	"project.server.language.ur": {
-		"defaultMessage": "烏爾都文"
-	},
-	"project.server.language.uz": {
-		"defaultMessage": "烏茲別克文"
-	},
-	"project.server.language.vi": {
-		"defaultMessage": "越南文"
-	},
-	"project.server.language.yo": {
-		"defaultMessage": "約魯巴文"
-	},
-	"project.server.language.zh": {
-		"defaultMessage": "中文"
-	},
-	"project.server.language.zu": {
-		"defaultMessage": "祖魯文"
-	},
-	"project.server.ping.ms": {
-		"defaultMessage": "{ping, number} 毫秒"
-	},
-	"project.server.region.asia": {
-		"defaultMessage": "亞洲"
-	},
-	"project.server.region.australia": {
-		"defaultMessage": "澳洲"
-	},
-	"project.server.region.europe": {
-		"defaultMessage": "歐洲"
-	},
-	"project.server.region.middle_east": {
-		"defaultMessage": "中東"
-	},
-	"project.server.region.russia": {
-		"defaultMessage": "俄羅斯"
-	},
-	"project.server.region.south_america": {
-		"defaultMessage": "南美洲"
-	},
-	"project.server.region.tooltip": {
-		"defaultMessage": "伺服器位於{regionName}"
-	},
-	"project.server.region.us_east": {
-		"defaultMessage": "美國東部"
-	},
-	"project.server.region.us_west": {
-		"defaultMessage": "美國西部"
-	},
-	"project.server.status.offline": {
-		"defaultMessage": "離線"
-	},
-	"project.server.status.offline.tooltip": {
-		"defaultMessage": "伺服器已離線"
-	},
-	"project.server.status.online": {
-		"defaultMessage": "線上"
-	},
-	"project.settings.analytics.title": {
-		"defaultMessage": "數據分析"
-	},
-	"project.settings.content.title": {
-		"defaultMessage": "內容"
-	},
-	"project.settings.description.title": {
-		"defaultMessage": "描述"
-	},
-	"project.settings.environment.title": {
-		"defaultMessage": "環境"
-	},
-	"project.settings.gallery.title": {
-		"defaultMessage": "圖庫"
-	},
-	"project.settings.general.title": {
-		"defaultMessage": "一般"
-	},
-	"project.settings.license.title": {
-		"defaultMessage": "授權條款"
-	},
-	"project.settings.links.title": {
-		"defaultMessage": "連結"
-	},
-	"project.settings.members.title": {
-		"defaultMessage": "成員"
-	},
-	"project.settings.notice.no-permission.description": {
-		"defaultMessage": "你沒有編輯這個設定的權限。"
-	},
-	"project.settings.notice.no-permission.title": {
-		"defaultMessage": "沒有權限"
-	},
-	"project.settings.server.title": {
-		"defaultMessage": "伺服器"
-	},
-	"project.settings.tags.title": {
-		"defaultMessage": "標籤"
-	},
-	"project.settings.upload.title": {
-		"defaultMessage": "上傳"
-	},
-	"project.settings.versions.permissions": {
-		"defaultMessage": "權限"
-	},
-	"project.settings.versions.title": {
-		"defaultMessage": "版本"
-	},
-	"project.settings.view.title": {
-		"defaultMessage": "檢視"
-	},
-	"project.versions.channel.alpha.symbol": {
-		"defaultMessage": "A"
-	},
-	"project.versions.channel.beta.symbol": {
-		"defaultMessage": "B"
-	},
-	"project.versions.channel.release.symbol": {
-		"defaultMessage": "R"
-	},
-	"project.versions.version.withheld": {
-		"defaultMessage": "保留"
-	},
-	"project.versions.version.withheld.tooltip": {
-		"defaultMessage": "版本由於缺少授權資訊而被保留"
-	},
-	"project.versions.withheld-versions-warning.resolve-button": {
-		"defaultMessage": "解決"
-	},
-	"project.visibility.archived": {
-		"defaultMessage": "已封存"
-	},
-	"project.visibility.draft": {
-		"defaultMessage": "草稿"
-	},
-	"project.visibility.private": {
-		"defaultMessage": "私人"
-	},
-	"project.visibility.public": {
-		"defaultMessage": "公開"
-	},
-	"project.visibility.rejected": {
-		"defaultMessage": "已拒絕"
-	},
-	"project.visibility.scheduled": {
-		"defaultMessage": "已排定"
-	},
-	"project.visibility.under-review": {
-		"defaultMessage": "審查中"
-	},
-	"project.visibility.unknown": {
-		"defaultMessage": "未知"
-	},
-	"project.visibility.unlisted": {
-		"defaultMessage": "不公開"
-	},
-	"project.visibility.unlisted-by-staff": {
-		"defaultMessage": "由工作人員設為不公開"
-	},
-	"report.item-type.content": {
-		"defaultMessage": "內容"
-	},
-	"report.item-type.project": {
-		"defaultMessage": "專案"
-	},
-	"report.item-type.user": {
-		"defaultMessage": "使用者"
-	},
-	"report.item-type.version": {
-		"defaultMessage": "版本"
-	},
-	"search.filter.locked.default": {
-		"defaultMessage": "篩選器已鎖定"
-	},
-	"search.filter.locked.default.description": {
-		"defaultMessage": "解鎖這個篩選器可能導致安裝不相容的內容。"
-	},
-	"search.filter.locked.default.sync": {
-		"defaultMessage": "同步篩選器"
-	},
-	"search.filter.locked.default.title": {
-		"defaultMessage": "{type} 已鎖定"
-	},
-	"search.filter.locked.default.unlock": {
-		"defaultMessage": "解鎖篩選器"
-	},
-	"search.filter.option.exclusion.add.tooltip": {
-		"defaultMessage": "排除"
-	},
-	"search.filter.option.search.clear.aria_label": {
-		"defaultMessage": "清除搜尋"
-	},
-	"search.filter.option.search.placeholder": {
-		"defaultMessage": "搜尋..."
-	},
-	"search.filter.option.show_fewer": {
-		"defaultMessage": "只顯示部分內容"
-	},
-	"search.filter.option.show_more": {
-		"defaultMessage": "顯示更多內容"
-	},
-	"search.filter_type.environment": {
-		"defaultMessage": "環境"
-	},
-	"search.filter_type.environment.client": {
-		"defaultMessage": "用戶端"
-	},
-	"search.filter_type.environment.server": {
-		"defaultMessage": "伺服器端"
-	},
-	"search.filter_type.game_version": {
-		"defaultMessage": "遊戲版本"
-	},
-	"search.filter_type.game_version.all_versions": {
-		"defaultMessage": "顯示所有版本"
-	},
-	"search.filter_type.license": {
-		"defaultMessage": "授權條款"
-	},
-	"search.filter_type.license.open_source": {
-		"defaultMessage": "開放原始碼"
-	},
-	"search.filter_type.mod_loader": {
-		"defaultMessage": "載入器"
-	},
-	"search.filter_type.modpack_loader": {
-		"defaultMessage": "載入器"
-	},
-	"search.filter_type.plugin_loader": {
-		"defaultMessage": "載入器"
-	},
-	"search.filter_type.plugin_platform": {
-		"defaultMessage": "平臺"
-	},
-	"search.filter_type.project_id": {
-		"defaultMessage": "專案 ID"
-	},
-	"search.filter_type.server_content_type": {
-		"defaultMessage": "類型"
-	},
-	"search.filter_type.server_language": {
-		"defaultMessage": "語言"
-	},
-	"search.filter_type.server_region": {
-		"defaultMessage": "地區"
-	},
-	"search.filter_type.server_status": {
-		"defaultMessage": "狀態"
-	},
-	"search.filter_type.shader_loader": {
-		"defaultMessage": "載入器"
-	},
-	"search.server_content_type.modpack": {
-		"defaultMessage": "模組支援"
-	},
-	"search.server_content_type.vanilla": {
-		"defaultMessage": "原版"
-	},
-	"servers.notice.dismiss": {
-		"defaultMessage": "撤銷"
-	},
-	"servers.notice.dismissable": {
-		"defaultMessage": "可撤銷"
-	},
-	"servers.notice.heading.attention": {
-		"defaultMessage": "注意"
-	},
-	"servers.notice.heading.info": {
-		"defaultMessage": "資訊"
-	},
-	"servers.notice.level.critical.name": {
-		"defaultMessage": "重要"
-	},
-	"servers.notice.level.info.name": {
-		"defaultMessage": "資訊"
-	},
-	"servers.notice.level.survey.name": {
-		"defaultMessage": "問卷"
-	},
-	"servers.notice.level.warn.name": {
-		"defaultMessage": "警告"
-	},
-	"servers.notice.undismissable": {
-		"defaultMessage": "不可撤銷"
-	},
-	"servers.region.australia": {
-		"defaultMessage": "澳洲"
-	},
-	"servers.region.central-europe": {
-		"defaultMessage": "中歐"
-	},
-	"servers.region.north-america-central": {
-		"defaultMessage": "北美中部"
-	},
-	"servers.region.north-america-east": {
-		"defaultMessage": "北美東部"
-	},
-	"servers.region.north-america-west": {
-		"defaultMessage": "北美西部"
-	},
-	"servers.region.southeast-asia": {
-		"defaultMessage": "東南亞"
-	},
-	"servers.region.western-europe": {
-		"defaultMessage": "西歐"
-	},
-	"servers.setup.upload-warning": {
-		"defaultMessage": "上傳時請勿關閉此頁面。"
-	},
-	"servers.setup.uploading-modpack.header": {
-		"defaultMessage": "正在上傳模組包"
-	},
-	"settings.account.title": {
-		"defaultMessage": "帳號和安全性"
-	},
-	"settings.appearance.title": {
-		"defaultMessage": "外觀"
-	},
-	"settings.applications.title": {
-		"defaultMessage": "你的應用程式"
-	},
-	"settings.authorized-apps.title": {
-		"defaultMessage": "已授權的應用程式"
-	},
-	"settings.display.theme.dark": {
-		"defaultMessage": "深色"
-	},
-	"settings.display.theme.description": {
-		"defaultMessage": "依照偏好，設定這部裝置的 Modrinth 主題顏色。"
-	},
-	"settings.display.theme.light": {
-		"defaultMessage": "淺色"
-	},
-	"settings.display.theme.oled": {
-		"defaultMessage": "OLED"
-	},
-	"settings.display.theme.preferred-dark-theme": {
-		"defaultMessage": "偏好深色主題"
-	},
-	"settings.display.theme.preferred-light-theme": {
-		"defaultMessage": "偏好淺色主題"
-	},
-	"settings.display.theme.retro": {
-		"defaultMessage": "復古"
-	},
-	"settings.display.theme.system": {
-		"defaultMessage": "與系統同步"
-	},
-	"settings.display.theme.title": {
-		"defaultMessage": "色彩主題"
-	},
-	"settings.feature-flags.title": {
-		"defaultMessage": "功能旗標"
-	},
-	"settings.language.categories.default": {
-		"defaultMessage": "標準語言"
-	},
-	"settings.language.categories.search-result": {
-		"defaultMessage": "搜尋結果"
-	},
-	"settings.language.description": {
-		"defaultMessage": "選擇你偏好的{platform}語言。翻譯由 <crowdin-link>Crowdin</crowdin-link> 上的志願者所貢獻。"
-	},
-	"settings.language.languages.search-field.placeholder": {
-		"defaultMessage": "搜尋語言..."
-	},
-	"settings.language.languages.search-results-announcement": {
-		"defaultMessage": "{matches, plural, =0 {未搜尋到相關語言} other {有 # 個語言符合搜尋字詞}}。"
-	},
-	"settings.language.languages.search.no-results": {
-		"defaultMessage": "沒有語言符合你的搜尋字詞。"
-	},
-	"settings.language.platform.app": {
-		"defaultMessage": "應用程式"
-	},
-	"settings.language.platform.site": {
-		"defaultMessage": "網站"
-	},
-	"settings.language.title": {
-		"defaultMessage": "語言"
-	},
-	"settings.language.warning": {
-		"defaultMessage": "變更{platform}的語言後，若部分內容尚未提供翻譯，則會以英文顯示。{platform}目前尚未完全翻譯，因此，在某些語言下，部分內容仍可能以英文顯示。"
-	},
-	"settings.pats.title": {
-		"defaultMessage": "個人存取權杖"
-	},
-	"settings.profile.title": {
-		"defaultMessage": "公開個人檔案"
-	},
-	"settings.sessions.title": {
-		"defaultMessage": "工作階段"
-	},
-	"tag.category.128x": {
-		"defaultMessage": "128x"
-	},
-	"tag.category.16x": {
-		"defaultMessage": "16x"
-	},
-	"tag.category.256x": {
-		"defaultMessage": "256x"
-	},
-	"tag.category.32x": {
-		"defaultMessage": "32x"
-	},
-	"tag.category.48x": {
-		"defaultMessage": "48x"
-	},
-	"tag.category.512x+": {
-		"defaultMessage": "512× 以上"
-	},
-	"tag.category.64x": {
-		"defaultMessage": "64x"
-	},
-	"tag.category.8x-": {
-		"defaultMessage": "8× 以下"
-	},
-	"tag.category.adventure": {
-		"defaultMessage": "冒險"
-	},
-	"tag.category.adventure-mode": {
-		"defaultMessage": "冒險模式"
-	},
-	"tag.category.anarchy": {
-		"defaultMessage": "無政府"
-	},
-	"tag.category.atmosphere": {
-		"defaultMessage": "大氣效果"
-	},
-	"tag.category.audio": {
-		"defaultMessage": "音效"
-	},
-	"tag.category.battle-royale": {
-		"defaultMessage": "大逃殺"
-	},
-	"tag.category.bedwars": {
-		"defaultMessage": "床戰"
-	},
-	"tag.category.blocks": {
-		"defaultMessage": "方塊"
-	},
-	"tag.category.bloom": {
-		"defaultMessage": "泛光"
-	},
-	"tag.category.bosses": {
-		"defaultMessage": "Boss"
-	},
-	"tag.category.cartoon": {
-		"defaultMessage": "卡通"
-	},
-	"tag.category.challenging": {
-		"defaultMessage": "挑戰"
-	},
-	"tag.category.classes": {
-		"defaultMessage": "職業"
-	},
-	"tag.category.colored-lighting": {
-		"defaultMessage": "彩色光照"
-	},
-	"tag.category.combat": {
-		"defaultMessage": "戰鬥"
-	},
-	"tag.category.competitive": {
-		"defaultMessage": "競技"
-	},
-	"tag.category.core-shaders": {
-		"defaultMessage": "核心著色器"
-	},
-	"tag.category.creative-mode": {
-		"defaultMessage": "創造模式"
-	},
-	"tag.category.creator-community": {
-		"defaultMessage": "創作者社群"
-	},
-	"tag.category.crossplay": {
-		"defaultMessage": "跨平臺"
-	},
-	"tag.category.cursed": {
-		"defaultMessage": "邪門"
-	},
-	"tag.category.custom-content": {
-		"defaultMessage": "自訂內容"
-	},
-	"tag.category.decoration": {
-		"defaultMessage": "裝飾"
-	},
-	"tag.category.dungeons": {
-		"defaultMessage": "副本"
-	},
-	"tag.category.economy": {
-		"defaultMessage": "經濟"
-	},
-	"tag.category.entities": {
-		"defaultMessage": "實體"
-	},
-	"tag.category.environment": {
-		"defaultMessage": "環境"
-	},
-	"tag.category.equipment": {
-		"defaultMessage": "裝備"
-	},
-	"tag.category.factions": {
-		"defaultMessage": "派系"
-	},
-	"tag.category.fantasy": {
-		"defaultMessage": "奇幻"
-	},
-	"tag.category.foliage": {
-		"defaultMessage": "植被"
-	},
-	"tag.category.fonts": {
-		"defaultMessage": "字型"
-	},
-	"tag.category.food": {
-		"defaultMessage": "食物"
-	},
-	"tag.category.game-mechanics": {
-		"defaultMessage": "遊戲機制"
-	},
-	"tag.category.gens": {
-		"defaultMessage": "生成器"
-	},
-	"tag.category.gui": {
-		"defaultMessage": "GUI"
-	},
-	"tag.category.hardcore-mode": {
-		"defaultMessage": "極限模式"
-	},
-	"tag.category.high": {
-		"defaultMessage": "高"
-	},
-	"tag.category.items": {
-		"defaultMessage": "物品"
-	},
-	"tag.category.keep-inventory": {
-		"defaultMessage": "保留物品欄"
-	},
-	"tag.category.kitchen-sink": {
-		"defaultMessage": "大雜燴"
-	},
-	"tag.category.kitpvp": {
-		"defaultMessage": "Kit PvP"
-	},
-	"tag.category.library": {
-		"defaultMessage": "程式庫"
-	},
-	"tag.category.lifesteal": {
-		"defaultMessage": "生命竊取"
-	},
-	"tag.category.lightweight": {
-		"defaultMessage": "輕量"
-	},
-	"tag.category.locale": {
-		"defaultMessage": "在地化"
-	},
-	"tag.category.low": {
-		"defaultMessage": "低"
-	},
-	"tag.category.magic": {
-		"defaultMessage": "魔法"
-	},
-	"tag.category.management": {
-		"defaultMessage": "管理"
-	},
-	"tag.category.media": {
-		"defaultMessage": "媒體"
-	},
-	"tag.category.medium": {
-		"defaultMessage": "中"
-	},
-	"tag.category.microgames": {
-		"defaultMessage": "微型遊戲"
-	},
-	"tag.category.minigame": {
-		"defaultMessage": "小遊戲"
-	},
-	"tag.category.minigames": {
-		"defaultMessage": "小遊戲"
-	},
-	"tag.category.mmo": {
-		"defaultMessage": "MMO"
-	},
-	"tag.category.mobs": {
-		"defaultMessage": "生物"
-	},
-	"tag.category.modded": {
-		"defaultMessage": "模組支援"
-	},
-	"tag.category.models": {
-		"defaultMessage": "模型"
-	},
-	"tag.category.multiplayer": {
-		"defaultMessage": "多人遊戲"
-	},
-	"tag.category.network": {
-		"defaultMessage": "群組伺服器"
-	},
-	"tag.category.offline-mode": {
-		"defaultMessage": "離線模式"
-	},
-	"tag.category.oneblock": {
-		"defaultMessage": "一格方塊"
-	},
-	"tag.category.op": {
-		"defaultMessage": "OP"
-	},
-	"tag.category.optimization": {
-		"defaultMessage": "最佳化"
-	},
-	"tag.category.parkour": {
-		"defaultMessage": "跑酷"
-	},
-	"tag.category.path-tracing": {
-		"defaultMessage": "光線追蹤"
-	},
-	"tag.category.pbr": {
-		"defaultMessage": "PBR"
-	},
-	"tag.category.personal-worlds": {
-		"defaultMessage": "個人世界"
-	},
-	"tag.category.plots": {
-		"defaultMessage": "地塊"
-	},
-	"tag.category.pokemon": {
-		"defaultMessage": "寶可夢"
-	},
-	"tag.category.potato": {
-		"defaultMessage": "馬鈴薯"
-	},
-	"tag.category.prison": {
-		"defaultMessage": "監獄"
-	},
-	"tag.category.pve": {
-		"defaultMessage": "PvE"
-	},
-	"tag.category.pvp": {
-		"defaultMessage": "PvP"
-	},
-	"tag.category.questing": {
-		"defaultMessage": "任務"
-	},
-	"tag.category.quests": {
-		"defaultMessage": "任務"
-	},
-	"tag.category.racing": {
-		"defaultMessage": "競速"
-	},
-	"tag.category.realistic": {
-		"defaultMessage": "寫實"
-	},
-	"tag.category.recording-smp": {
-		"defaultMessage": "錄影 SMP"
-	},
-	"tag.category.reflections": {
-		"defaultMessage": "折射"
-	},
-	"tag.category.roleplay": {
-		"defaultMessage": "角色扮演"
-	},
-	"tag.category.rpg": {
-		"defaultMessage": "RPG"
-	},
-	"tag.category.screenshot": {
-		"defaultMessage": "擷圖用"
-	},
-	"tag.category.semi-realistic": {
-		"defaultMessage": "半寫實"
-	},
-	"tag.category.shadows": {
-		"defaultMessage": "陰影"
-	},
-	"tag.category.simplistic": {
-		"defaultMessage": "簡約"
-	},
-	"tag.category.skyblock": {
-		"defaultMessage": "空島生存"
-	},
-	"tag.category.smp": {
-		"defaultMessage": "SMP"
-	},
-	"tag.category.social": {
-		"defaultMessage": "社交"
-	},
-	"tag.category.storage": {
-		"defaultMessage": "儲物管理"
-	},
-	"tag.category.survival-mode": {
-		"defaultMessage": "生存模式"
-	},
-	"tag.category.teams": {
-		"defaultMessage": "團隊"
-	},
-	"tag.category.technical": {
-		"defaultMessage": "技術性"
-	},
-	"tag.category.technology": {
-		"defaultMessage": "科技"
-	},
-	"tag.category.themed": {
-		"defaultMessage": "特定主題"
-	},
-	"tag.category.towns": {
-		"defaultMessage": "城鎮"
-	},
-	"tag.category.transportation": {
-		"defaultMessage": "交通"
-	},
-	"tag.category.tweaks": {
-		"defaultMessage": "微調"
-	},
-	"tag.category.utility": {
-		"defaultMessage": "工具"
-	},
-	"tag.category.vanilla-like": {
-		"defaultMessage": "類原版"
-	},
-	"tag.category.whitelisted": {
-		"defaultMessage": "白名單"
-	},
-	"tag.category.world-resets": {
-		"defaultMessage": "世界重設"
-	},
-	"tag.category.worldgen": {
-		"defaultMessage": "世界生成"
-	},
-	"tag.loader.babric": {
-		"defaultMessage": "Babric"
-	},
-	"tag.loader.bta-babric": {
-		"defaultMessage": "BTA（Babric）"
-	},
-	"tag.loader.bukkit": {
-		"defaultMessage": "Bukkit"
-	},
-	"tag.loader.bungeecord": {
-		"defaultMessage": "BungeeCord"
-	},
-	"tag.loader.canvas": {
-		"defaultMessage": "Canvas"
-	},
-	"tag.loader.datapack": {
-		"defaultMessage": "資料包"
-	},
-	"tag.loader.fabric": {
-		"defaultMessage": "Fabric"
-	},
-	"tag.loader.folia": {
-		"defaultMessage": "Folia"
-	},
-	"tag.loader.forge": {
-		"defaultMessage": "Forge"
-	},
-	"tag.loader.geyser": {
-		"defaultMessage": "Geyser 擴充"
-	},
-	"tag.loader.iris": {
-		"defaultMessage": "Iris"
-	},
-	"tag.loader.java-agent": {
-		"defaultMessage": "Java 代理"
-	},
-	"tag.loader.legacy-fabric": {
-		"defaultMessage": "Legacy Fabric"
-	},
-	"tag.loader.liteloader": {
-		"defaultMessage": "LiteLoader"
-	},
-	"tag.loader.minecraft": {
-		"defaultMessage": "資源包"
-	},
-	"tag.loader.modloader": {
-		"defaultMessage": "Risugami's ModLoader"
-	},
-	"tag.loader.mrpack": {
-		"defaultMessage": "模組包"
-	},
-	"tag.loader.neoforge": {
-		"defaultMessage": "NeoForge"
-	},
-	"tag.loader.nilloader": {
-		"defaultMessage": "NilLoader"
-	},
-	"tag.loader.optifine": {
-		"defaultMessage": "OptiFine"
-	},
-	"tag.loader.ornithe": {
-		"defaultMessage": "Ornithe"
-	},
-	"tag.loader.paper": {
-		"defaultMessage": "Paper"
-	},
-	"tag.loader.purpur": {
-		"defaultMessage": "Purpur"
-	},
-	"tag.loader.quilt": {
-		"defaultMessage": "Quilt"
-	},
-	"tag.loader.rift": {
-		"defaultMessage": "Rift"
-	},
-	"tag.loader.spigot": {
-		"defaultMessage": "Spigot"
-	},
-	"tag.loader.sponge": {
-		"defaultMessage": "Sponge"
-	},
-	"tag.loader.vanilla": {
-		"defaultMessage": "原版著色器"
-	},
-	"tag.loader.velocity": {
-		"defaultMessage": "Velocity"
-	},
-	"tag.loader.waterfall": {
-		"defaultMessage": "Waterfall"
-	},
-	"time-frame-picker.apply": {
-		"defaultMessage": "套用"
-	},
-	"time-frame-picker.cancel": {
-		"defaultMessage": "取消"
-	},
-	"time-frame-picker.clear-range": {
-		"defaultMessage": "清除"
-	},
-	"time-frame-picker.custom-range": {
-		"defaultMessage": "自訂日期範圍..."
-	},
-	"time-frame-picker.decrease-amount": {
-		"defaultMessage": "減少時間範圍時長"
-	},
-	"time-frame-picker.empty-range": {
-		"defaultMessage": "未選取日期範圍。"
-	},
-	"time-frame-picker.end-date": {
-		"defaultMessage": "結束日期"
-	},
-	"time-frame-picker.increase-amount": {
-		"defaultMessage": "增加時間範圍時長"
-	},
-	"time-frame-picker.last-timeframe": {
-		"defaultMessage": "在過去 {amount} {unit, select, hours {{amount, plural, other {小時}}} days {{amount, plural, other {天}}} weeks {{amount, plural, other {週}}} months {{amount, plural, other {月}}} other {天}}"
-	},
-	"time-frame-picker.last-timeframe-prefix": {
-		"defaultMessage": "在過去"
-	},
-	"time-frame-picker.option.all-time": {
-		"defaultMessage": "所有時間"
-	},
-	"time-frame-picker.option.last-14-days": {
-		"defaultMessage": "過去 14 天"
-	},
-	"time-frame-picker.option.last-180-days": {
-		"defaultMessage": "過去 180 天"
-	},
-	"time-frame-picker.option.last-30-days": {
-		"defaultMessage": "過去 30 天"
-	},
-	"time-frame-picker.option.last-7-days": {
-		"defaultMessage": "過去 7 天"
-	},
-	"time-frame-picker.option.last-90-days": {
-		"defaultMessage": "過去 90 天"
-	},
-	"time-frame-picker.option.today": {
-		"defaultMessage": "今天"
-	},
-	"time-frame-picker.option.year-to-date": {
-		"defaultMessage": "今年迄今"
-	},
-	"time-frame-picker.option.yesterday": {
-		"defaultMessage": "昨天"
-	},
-	"time-frame-picker.select-timeframe": {
-		"defaultMessage": "選取時間範圍"
-	},
-	"time-frame-picker.selected-range": {
-		"defaultMessage": "選取範圍"
-	},
-	"time-frame-picker.selecting-range": {
-		"defaultMessage": "選取中"
-	},
-	"time-frame-picker.start-date": {
-		"defaultMessage": "開始日期"
-	},
-	"time-frame-picker.timeframe-amount": {
-		"defaultMessage": "時間範圍時長"
-	},
-	"time-frame-picker.timeframe-unit": {
-		"defaultMessage": "時間範圍單位"
-	},
-	"time-frame-picker.unit.days": {
-		"defaultMessage": "天"
-	},
-	"time-frame-picker.unit.hours": {
-		"defaultMessage": "小時"
-	},
-	"time-frame-picker.unit.months": {
-		"defaultMessage": "月"
-	},
-	"time-frame-picker.unit.weeks": {
-		"defaultMessage": "週"
-	},
-	"ui.component.unsaved-changes-popup.body": {
-		"defaultMessage": "你的變更尚未儲存。"
-	},
-	"ui.confirm-leave-modal.body": {
-		"defaultMessage": "您有未儲存的變更，如果離開此頁面將會遺失"
-	},
-	"ui.confirm-leave-modal.header": {
-		"defaultMessage": "您有未儲存的變更"
-	},
-	"ui.confirm-leave-modal.leave": {
-		"defaultMessage": "離開頁面"
-	},
-	"ui.confirm-leave-modal.stay": {
-		"defaultMessage": "留在頁面"
-	},
-	"ui.confirm-leave-modal.title": {
-		"defaultMessage": "離開頁面？"
-	},
-	"ui.stacked-admonitions.alert-count": {
-		"defaultMessage": "{count, plural, other {# 個警示}}"
-	},
-	"ui.stacked-admonitions.dismiss-all": {
-		"defaultMessage": "忽略全部"
-	},
-	"version.content.name": {
-		"defaultMessage": "名稱"
-	},
-	"version.content.version": {
-		"defaultMessage": "版本"
-	},
-	"version.file-type.dev-jar": {
-		"defaultMessage": "開發用 jar"
-	},
-	"version.file-type.javadoc-jar": {
-		"defaultMessage": "Javadoc jar"
-	},
-	"version.file-type.optional-resource-pack": {
-		"defaultMessage": "可選資源包"
-	},
-	"version.file-type.primary": {
-		"defaultMessage": "主要"
-	},
-	"version.file-type.required-resource-pack": {
-		"defaultMessage": "所需資源包"
-	},
-	"version.file-type.signature": {
-		"defaultMessage": "簽署文件"
-	},
-	"version.file-type.sources-jar": {
-		"defaultMessage": "原始碼 jar"
-	},
-	"version.file-type.unknown": {
-		"defaultMessage": "其他"
-	},
-	"version.section.changes": {
-		"defaultMessage": "變更"
-	},
-	"version.section.compatibility": {
-		"defaultMessage": "相容性"
-	},
-	"version.section.content": {
-		"defaultMessage": "內容"
-	},
-	"version.section.content.search-placeholder": {
-		"defaultMessage": "搜尋內容..."
-	},
-	"version.section.dependencies.any-compatible-version": {
-		"defaultMessage": "任何相容的版本"
-	},
-	"version.section.dependencies.any-version": {
-		"defaultMessage": "任何版本"
-	},
-	"version.section.dependencies.unavailable-version": {
-		"defaultMessage": "不可用版本"
-	},
-	"version.section.dependencies.unavailable-version.description": {
-		"defaultMessage": "這個版本可能已被刪除，或正在由管理員審查。"
-	},
-	"version.section.dependencies.unavailable-version.description.required": {
-		"defaultMessage": "所需版本可能已被刪除，或正在由管理員審查。"
-	},
-	"version.section.files": {
-		"defaultMessage": "檔案"
-	},
-	"version.section.included-content": {
-		"defaultMessage": "包含的內容"
-	},
-	"version.section.known-incompatibilities": {
-		"defaultMessage": "已知不相容"
-	},
-	"version.section.no-changes": {
-		"defaultMessage": "未提供變更日誌。"
-	},
-	"version.section.no-modpack-mod-loader": {
-		"defaultMessage": "無模組載入器"
-	},
-	"version.section.optional-dependencies": {
-		"defaultMessage": "可選相依項"
-	},
-	"version.section.required-content": {
-		"defaultMessage": "所需內容"
-	},
-	"version.section.supplementary-resources": {
-		"defaultMessage": "補充資源"
-	},
-	"version.supplementary-resources.file": {
-		"defaultMessage": "檔案"
-	},
-	"version.supplementary-resources.size": {
-		"defaultMessage": "檔案大小"
-	},
-	"version.supplementary-resources.type": {
-		"defaultMessage": "類型"
-	},
-	"files.row.parent-folder": {
-		"message": "Parent folder"
-	},
-	"omorphia.component.loading-indicator.label": {
-		"message": "Loading"
-	},
-	"drop.confirm.title": {
-		"message": "你想以什麼類型匯入？"
-	},
-	"drop.confirm.cancel": {
-		"message": "取消"
-	},
-	"drop.confirm.help": {
-		"message": "我可以拖入什麼？"
-	},
-	"drop.confirm.as-mod": {
-		"message": "模組"
-	},
-	"drop.confirm.as-mod-desc": {
-		"message": "將模組 JAR 安裝到 Minecraft 實例"
-	},
-	"drop.confirm.as-instance": {
-		"message": "實例"
-	},
-	"drop.confirm.as-instance-desc": {
-		"message": "從其他啟動器匯入 Minecraft 實例"
-	},
-	"drop.confirm.as-modpack": {
-		"message": "整合包"
-	},
-	"drop.confirm.as-modpack-desc": {
-		"message": "從整合包建立新實例"
-	},
-	"drop.confirm.as-resource-pack": {
-		"message": "資源包"
-	},
-	"drop.confirm.as-resource-pack-desc": {
-		"message": "將資源包安裝到實例"
-	},
-	"drop.confirm.as-shader-pack": {
-		"message": "光影包"
-	},
-	"drop.confirm.as-shader-pack-desc": {
-		"message": "將光影包安裝到實例"
-	},
-	"drop.confirm.as-world": {
-		"message": "存檔"
-	},
-	"drop.confirm.as-world-desc": {
-		"message": "將存檔匯入到實例中"
-	},
-	"drop.confirm.as-schematic": {
-		"message": "投影"
-	},
-	"drop.confirm.as-schematic-desc": {
-		"message": "匯入 Litematic 投影檔案"
-	},
-	"drop.confirm.as-dot-minecraft": {
-		"message": ".minecraft"
-	},
-	"drop.confirm.as-dot-minecraft-desc": {
-		"message": "掃描 .minecraft 資料夾以建立實例"
-	},
-	"drop.confirm.as-launcher": {
-		"message": "啟動器"
-	},
-	"drop.confirm.as-hmcl-launcher": {
-		"message": "HMCL 啟動器"
-	},
-	"drop.generic_install.title": {
-		"message": "安裝 {type}"
-	},
-	"drop.generic_install.search": {
-		"message": "搜尋實例..."
-	},
-	"drop.generic_install.install": {
-		"message": "安裝"
-	},
-	"drop.generic_install.cancel": {
-		"message": "取消"
-	},
-	"drop.generic_install.create_new": {
-		"message": "建立新實例..."
-	},
-	"drop.generic_install.no_instances": {
-		"message": "找不到實例"
-	},
-	"drop.launcher_import.title": {
-		"message": "從 {launcherName} 匯入實例"
-	},
-	"drop.launcher_import.subtitle": {
-		"message": "在 {basePath} 中掃描到 {count} 個實例"
-	},
-	"drop.launcher_import.select_all": {
-		"message": "全選"
-	},
-	"drop.launcher_import.deselect_all": {
-		"message": "取消全選"
-	},
-	"drop.launcher_import.selected": {
-		"message": "已選 {n} 個"
-	},
-	"drop.launcher_import.cancel": {
-		"message": "取消"
-	},
-	"drop.launcher_import.import": {
-		"message": "匯入（{n}）"
-	},
-	"drop.launcher_import.no_instances": {
-		"message": "找不到實例"
-	},
-	"drop.symlink_method.title": {
-		"message": "選擇匯入方式"
-	},
-	"drop.symlink_method.subtitle": {
-		"message": "正在匯入 {n} 個實例"
-	},
-	"drop.symlink_method.copy_title": {
-		"message": "複製檔案"
-	},
-	"drop.symlink_method.copy_desc": {
-		"message": "複製到 Axolotl 目錄"
-	},
-	"drop.symlink_method.symlink_title": {
-		"message": "符號連結"
-	},
-	"drop.symlink_method.symlink_desc": {
-		"message": "引用原始位置"
-	},
-	"drop.symlink_method.requires_admin": {
-		"message": "建立連結時將要求一次系統管理員授權（UAC）"
-	},
-	"drop.symlink_method.unsupported_warning": {
-		"message": "此系統不支援符號連結"
-	},
-	"drop.symlink_method.cancel": {
-		"message": "取消"
-	},
-	"drop.symlink_method.confirm": {
-		"message": "確認"
-	},
-	"project.versions.filter.toggle-tooltip": {
-		"message": "Toggle filter for {filter}"
-	},
-	"project.versions.platform.modloader.short": {
-		"message": "ModLoader"
-	},
-	"skin.preview.drag-to-rotate": {
-		"message": "Drag to rotate"
-	},
-	"browse.sort.relevance": {
-		"message": "Relevance"
-	},
-	"browse.sort.downloads": {
-		"message": "Downloads"
-	},
-	"browse.sort.followers": {
-		"message": "Followers"
-	},
-	"browse.sort.date-published": {
-		"message": "Date published"
-	},
-	"browse.sort.date-updated": {
-		"message": "Date updated"
-	},
-	"browse.sort.verified-plays": {
-		"message": "Verified plays"
-	},
-	"browse.sort.players": {
-		"message": "Players"
-	},
-	"content.card.pending-manual-download": {
-		"message": "Manual download required"
-	},
-	"content.card.rollback-tooltip": {
-		"defaultMessage": "回滾到 {fileName}"
-	},
-	"app.symlink-warning.write.header": {
-		"message": "Shared instance"
-	},
-	"app.symlink-warning.write.body": {
-		"message": "This instance is linked to "
-	},
-	"instances.updater-modal.search-compat": {
-		"message": "尋找相容版本"
-	},
-	"files.delete-modal.bulk-header": {
-		"message": "Delete multiple items"
-	},
-	"files.delete-modal.deleting-multiple": {
-		"message": "Deleting {count} items"
-	},
-	"files.delete-modal.bulk-warning": {
-		"message": "The selected items will be permanently deleted. This action cannot be undone."
-	},
-	"files.delete-modal.symlink-warning-header": {
-		"message": "Shared instance"
-	},
-	"files.delete-modal.symlink-warning-body": {
-		"message": "You are modifying files in a shared instance linked to "
-	},
-	"button.open-in-browser": {
-		"message": "Open in browser"
-	},
-	"label.server-only": {
-		"message": "Server only"
-	},
-	"button.switch-to-version": {
-		"message": "Switch to version"
-	},
-	"project-type.schematic.category": {
-		"message": "投影"
-	},
-	"project-type.schematic.capital": {
-		"message": "{count, plural, one {投影} other {投影}}"
-	},
-	"project-type.schematic.lowercase": {
-		"message": "{count, plural, one {投影} other {投影}}"
-	},
-	"search.filter_type.advanced.exclude_mod": {
-		"message": "Exclude mods"
-	},
-	"search.filter_type.advanced.exclude_plugin": {
-		"message": "Exclude plugins"
-	},
-	"search.filter_type.advanced.exclude_datapack": {
-		"message": "Exclude data packs"
-	},
-	"search.filter_type.advanced": {
-		"message": "Advanced"
-	},
-	"header.category.cf-extra": {
-		"message": "More CurseForge categories"
-	},
-	"project.environment.tag.not-applicable": {
-		"defaultMessage": "不適用"
-	},
-	"project.environment.tag.unknown": {
-		"defaultMessage": "未知"
-	},
-	"browse.selected-projects-floating-bar.hide-projects": {
-		"defaultMessage": "隐藏已选项目"
-	},
-	"browse.selected-projects-floating-bar.show-projects": {
-		"defaultMessage": "显示{count, plural, other {#个已选项目}}"
-	},
-	"console.notification.share-truncated": {
-		"defaultMessage": "日志过大，已自动截取最后 9MB 上传。"
-	},
-	"console.log.toggle-wrap": {
-		"defaultMessage": "切换换行"
-	},
-	"console.log.wrap-label": {
-		"defaultMessage": "换行"
-	},
-	"console.empty.instance-title": {
-		"defaultMessage": "暂无日志"
-	},
-	"console.empty.instance-description": {
-		"defaultMessage": "点击右上角「开始游戏」即可接收实时日志"
-	},
-	"console.empty.server-title": {
-		"defaultMessage": "欢迎使用 Modrinth 服务器！"
-	},
-	"console.empty.server-description": {
-		"defaultMessage": "点击启动按钮即可启动服务器！"
-	},
-	"content.card.dependency-badge": {
-		"defaultMessage": "前置"
-	},
-	"content.card.duplicate-mod": {
-		"defaultMessage": "此模组已安装 {count, number} 次。"
-	},
-	"content.card.group.hardcore": {
-		"defaultMessage": "硬核模式"
-	},
-	"content.card.group.not-played-yet": {
-		"defaultMessage": "尚未游玩"
-	},
-	"content.card.orphaned-dependency-badge": {
-		"defaultMessage": "孤立前置"
-	},
-	"content.filter.duplicates": {
-		"defaultMessage": "重复"
-	},
-	"content.metadata-filter.author": {
-		"defaultMessage": "作者"
-	},
-	"content.metadata-filter.clear": {
-		"defaultMessage": "清除"
-	},
-	"content.metadata-filter.environment": {
-		"defaultMessage": "环境"
-	},
-	"content.metadata-filter.environment.client": {
-		"defaultMessage": "客户端"
-	},
-	"content.metadata-filter.environment.client-and-server": {
-		"defaultMessage": "客户端和服务端"
-	},
-	"content.metadata-filter.environment.server": {
-		"defaultMessage": "服务端"
-	},
-	"content.metadata-filter.environment.singleplayer": {
-		"defaultMessage": "单人游戏"
-	},
-	"content.metadata-filter.external": {
-		"defaultMessage": "外部文件"
-	},
-	"content.metadata-filter.external.external": {
-		"defaultMessage": "外部文件"
-	},
-	"content.metadata-filter.external.linked": {
-		"defaultMessage": "在线项目"
-	},
-	"content.metadata-filter.loader": {
-		"defaultMessage": "加载器"
-	},
-	"content.metadata-filter.loader.fabric": {
-		"defaultMessage": "Fabric"
-	},
-	"content.metadata-filter.loader.forge": {
-		"defaultMessage": "Forge"
-	},
-	"content.metadata-filter.loader.neoforge": {
-		"defaultMessage": "NeoForge"
-	},
-	"content.metadata-filter.loader.other": {
-		"defaultMessage": "其他"
-	},
-	"content.metadata-filter.loader.quilt": {
-		"defaultMessage": "Quilt"
-	},
-	"content.metadata-filter.long-press-reset": {
-		"defaultMessage": "长按重置筛选"
-	},
-	"content.metadata-filter.open-source": {
-		"defaultMessage": "开源"
-	},
-	"content.metadata-filter.open-source.closed": {
-		"defaultMessage": "非开源"
-	},
-	"content.metadata-filter.open-source.open": {
-		"defaultMessage": "开源"
-	},
-	"content.metadata-filter.search": {
-		"defaultMessage": "搜索..."
-	},
-	"content.metadata-filter.select-all": {
-		"defaultMessage": "全选"
-	},
-	"content.metadata-filter.source": {
-		"defaultMessage": "来源"
-	},
-	"content.metadata-filter.source.curseforge": {
-		"defaultMessage": "CurseForge"
-	},
-	"content.metadata-filter.source.imported-modpack": {
-		"defaultMessage": "导入整合包"
-	},
-	"content.metadata-filter.source.local": {
-		"defaultMessage": "本地"
-	},
-	"content.metadata-filter.source.modrinth-modpack": {
-		"defaultMessage": "Modrinth 整合包"
-	},
-	"content.metadata-filter.source.server-project": {
-		"defaultMessage": "服务器项目"
-	},
-	"content.metadata-filter.source.shared-instance": {
-		"defaultMessage": "共享实例"
-	},
-	"content.metadata-filter.state": {
-		"defaultMessage": "状态"
-	},
-	"content.metadata-filter.state.disabled": {
-		"defaultMessage": "已禁用"
-	},
-	"content.metadata-filter.state.enabled": {
-		"defaultMessage": "已启用"
-	},
-	"content.metadata-filter.toggle": {
-		"defaultMessage": "筛选"
-	},
-	"content.metadata-filter.toggle-active": {
-		"defaultMessage": "筛选（已启用 {count, number} 项）"
-	},
-	"content.metadata-filter.unknown": {
-		"defaultMessage": "未知"
-	},
-	"content.metadata-filter.update.available": {
-		"defaultMessage": "可更新"
-	},
-	"content.metadata-filter.update.up-to-date": {
-		"defaultMessage": "已是最新"
-	},
-	"content.metadata-filter.updates": {
-		"defaultMessage": "更新"
-	},
-	"content.page-layout.sort.file-name-ascending": {
-		"defaultMessage": "文件名 A-Z"
-	},
-	"content.page-layout.sort.file-name-descending": {
-		"defaultMessage": "文件名 Z-A"
-	},
-	"content.page-layout.sort.project-name-ascending": {
-		"defaultMessage": "项目名称 A-Z"
-	},
-	"content.page-layout.sort.project-name-descending": {
-		"defaultMessage": "项目名称 Z-A"
-	},
-	"content.page-layout.pin-view": {
-		"defaultMessage": "固定当前视图"
-	},
-	"content.page-layout.reset-view": {
-		"defaultMessage": "重置视图"
-	},
-	"content.page-layout.unpin-view": {
-		"defaultMessage": "取消固定当前视图"
-	},
-	"content.page-layout.view-options": {
-		"defaultMessage": "视图选项"
-	},
-	"creation-flow.modal.custom-setup.adjunct.hint": {
-		"defaultMessage": "下载前会自动选择兼容版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.checking-compatibility": {
-		"defaultMessage": "正在检查兼容性……"
-	},
-	"creation-flow.modal.custom-setup.adjunct.compatibility-load-failed": {
-		"defaultMessage": "无法验证 {loader} 的兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.label": {
-		"defaultMessage": "附加加载器"
-	},
-	"creation-flow.modal.custom-setup.adjunct.optifabric-load-failed": {
-		"defaultMessage": "无法验证 OptiFabric 兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.optifabric-unsupported": {
-		"defaultMessage": "OptiFine 需要 OptiFabric，但当前游戏版本没有兼容版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.primary-unsupported": {
-		"defaultMessage": "所选主加载器不支持当前游戏版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.select-game-version": {
-		"defaultMessage": "请先选择游戏版本以检查兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.unsupported": {
-		"defaultMessage": "{loader} 没有支持当前游戏版本的兼容版本。"
-	},
-	"creation-flow.modal.custom-setup.loader.compatibility-load-failed": {
-		"defaultMessage": "无法验证加载器兼容性"
-	},
-	"creation-flow.modal.import-instance.import-prompt": {
-		"defaultMessage": "拖拽启动器文件夹、整合包文件或 .minecraft 文件夹即可一键导入实例"
-	},
-	"creation-flow.modal.import-instance.select-file": {
-		"defaultMessage": "选择要导入的文件"
-	},
-	"files.editor.share-truncated-warning": {
-		"defaultMessage": "日志文件过大，已自动截取最后 9MB 上传。"
-	},
-	"files.navbar.share-log": {
-		"defaultMessage": "分享日志"
-	},
-	"installation-settings.loader-version.error": {
-		"defaultMessage": "加载加载器版本数据失败"
-	},
-	"installation-settings.loader-version.unsupported": {
-		"defaultMessage": "此加载器不支持所选游戏版本"
-	},
-	"multiselect.selection-actions.label": {
-		"defaultMessage": "已选 {count, number} 项"
-	},
-	"project.about.links.mcmod": {
-		"defaultMessage": "MC Mod"
-	},
-	"project.versions.table.downloads": {
-		"defaultMessage": "下载量"
-	},
-	"project.versions.table.environment": {
-		"defaultMessage": "运行环境"
-	},
-	"project.versions.table.game-version": {
-		"defaultMessage": "游戏版本"
-	},
-	"project.versions.table.platform": {
-		"defaultMessage": "平台"
-	},
-	"project.versions.table.published": {
-		"defaultMessage": "发布时间"
-	},
-	"project.versions.table.version": {
-		"defaultMessage": "版本"
-	},
-	"project.versions.filter.projectChannels": {
-		"defaultMessage": "更新通道"
-	},
-	"project.versions.filter.gameVersions": {
-		"defaultMessage": "游戏版本"
-	},
-	"drop.confirm.not-this": {
-		"message": "作為其他內容匯入"
-	},
-	"app.drop.batch.scan.title": {
-		"message": "正在識別 {count, plural, one {# 個檔案} other {# 個檔案}}…"
-	},
-	"app.drop.batch.scan.subtitle": {
-		"message": "已識別 {done} / {total}"
-	},
-	"app.drop.batch.scan.cancel": {
-		"message": "取消"
-	},
-	"app.drop.batch.scan.pending": {
-		"message": "等待"
-	},
-	"app.drop.batch.scan.scanning": {
-		"message": "掃描中"
-	},
-	"app.drop.batch.scan.done": {
-		"message": "已識別"
-	},
-	"app.drop.batch.scan.skipped": {
-		"message": "已跳過"
-	},
-	"app.drop.batch.scan.error": {
-		"message": "失敗"
-	},
-	"drop.symlink_method.reset_changes": {
-		"message": "重置更改"
-	},
-	"drop.symlink_method.next": {
-		"message": "下一步"
-	},
-	"drop.symlink_method.instance_nav_label": {
-		"message": "切換到 {name}"
-	},
-	"drop.symlink_method.detecting": {
-		"message": "檢測中..."
-	},
-	"drop.symlink_method.game_version": {
-		"message": "遊戲版本"
-	},
-	"drop.symlink_method.import_path": {
-		"message": "版本路徑"
-	},
-	"drop.symlink_method.import_path_tooltip": {
-		"message": "匯入路徑"
-	},
-	"drop.symlink_method.instance": {
-		"message": "例項"
-	},
-	"drop.symlink_method.loader": {
-		"message": "載入器"
-	},
-	"drop.symlink_method.loader_type_unknown_tooltip": {
-		"message": "此版本安裝有Mod，但未識別到載入器。"
-	},
-	"drop.symlink_method.loader_version": {
-		"message": "載入器版本"
-	},
-	"drop.symlink_method.loader_version_unknown_tooltip": {
-		"message": "未檢測到載入器版本，將使用自定義版本。"
-	},
-	"drop.symlink_method.latest": {
-		"message": "最新"
-	},
-	"drop.symlink_method.method": {
-		"message": "匯入方式"
-	},
-	"drop.symlink_method.missing": {
-		"message": "缺失"
-	},
-	"drop.symlink_method.missing_path": {
-		"message": "沒有可用的匯入路徑"
-	},
-	"drop.symlink_method.not_available": {
-		"message": "不可用"
-	},
-	"drop.symlink_method.plan_failed": {
-		"message": "未能估算進度"
-	},
-	"drop.symlink_method.unrecognized": {
-		"message": "未識別"
-	},
-	"drop.symlink_method.custom": {
-		"message": "自定義"
-	},
-	"drop.symlink_method.custom_tooltip": {
-		"message": "通常您不應該自定義它，除非您確認它識別錯誤。"
-	},
-	"drop.symlink_method.runtime_root": {
-		"message": "根目錄"
-	},
-	"drop.symlink_method.runtime_root_tooltip": {
-		"message": "Runtime 根目錄"
-	},
-	"drop.symlink_method.search_game_version": {
-		"message": "搜尋遊戲版本"
-	},
-	"drop.symlink_method.search_loader_version": {
-		"message": "搜尋載入器版本"
-	},
-	"drop.symlink_method.select_game_version": {
-		"message": "選擇遊戲版本"
-	},
-	"drop.symlink_method.select_instance": {
-		"message": "選擇例項"
-	},
-	"drop.symlink_method.select_loader_version": {
-		"message": "選擇載入器版本"
-	},
-	"drop.symlink_method.stats": {
-		"message": "估計"
-	},
-	"drop.symlink_method.stats_cache": {
-		"message": "快取"
-	},
-	"drop.symlink_method.stats_cache_tooltip": {
-		"message": "Axolotl 快取"
-	},
-	"drop.symlink_method.stats_local": {
-		"message": "複用"
-	},
-	"drop.symlink_method.stats_local_tooltip": {
-		"message": "本地複用"
-	},
-	"drop.symlink_method.stats_migrate": {
-		"message": "遷移"
-	},
-	"drop.symlink_method.stats_migrate_tooltip": {
-		"message": "需要遷移"
-	},
-	"drop.symlink_method.stats_files": {
-		"message": "{files} 個檔案"
-	},
-	"drop.symlink_method.stats_network": {
-		"message": "下載"
-	},
-	"drop.symlink_method.stats_network_tooltip": {
-		"message": "需要下載"
-	},
-	"creation-flow.modal.import-instance.select-folder.description": {
-		"defaultMessage": "导入启动器文件夹或 .minecraft 文件夹"
-	},
-	"creation-flow.modal.import-instance.select-folder": {
-		"defaultMessage": "选择要导入的文件夹"
-	},
-	"creation-flow.modal.import-instance.select-file.description": {
-		"defaultMessage": "导入整合包文件或启动器(HMCL、PCL)"
-	},
-	"drop.confirm.as-data-pack": {
-		"defaultMessage": "数据包"
-	},
-	"drop.confirm.as-data-pack-desc": {
-		"defaultMessage": "将数据包安装到存档"
-	},
-	"app.translation-settings.provider.deepl": "DeepL 翻译",
-	"app.settings.updates.miawa": "柠泽镜像"
+  "action.no-permission": {
+    "defaultMessage": "你沒有權限。"
+  },
+  "badge.alpha": {
+    "defaultMessage": "Alpha 版"
+  },
+  "badge.beta": {
+    "defaultMessage": "Beta 版"
+  },
+  "badge.beta-release": {
+    "defaultMessage": "Beta 版發布"
+  },
+  "badge.new": {
+    "defaultMessage": "新功能"
+  },
+  "badge.release": {
+    "defaultMessage": "正式版"
+  },
+  "browse.filter-results": {
+    "defaultMessage": "篩選結果..."
+  },
+  "browse.no-results": {
+    "defaultMessage": "找不到符合你查詢的結果！"
+  },
+  "browse.offline": {
+    "defaultMessage": "你目前處於離線狀態，請連線至網路以瀏覽 Modrinth！"
+  },
+  "browse.search.placeholder": {
+    "defaultMessage": "搜尋{projectType}..."
+  },
+  "browse.selected-projects-floating-bar.aria-label": {
+    "defaultMessage": "已選取專案"
+  },
+  "browse.selected-projects-floating-bar.install": {
+    "defaultMessage": "安裝 {count, plural, other {# 個專案}}"
+  },
+  "browse.selected-projects-floating-bar.selected-count": {
+    "defaultMessage": "{count, plural, other {已選取 # 個專案}}"
+  },
+  "browse.selected-projects-leave-modal.admonition-body": {
+    "defaultMessage": "你已選取 {count, plural, other {# 個專案}}來安裝。立即安裝專案，或返回而不安裝。"
+  },
+  "browse.selected-projects-leave-modal.admonition-header": {
+    "defaultMessage": "你選取的專案尚未安裝"
+  },
+  "browse.selected-projects-leave-modal.discard": {
+    "defaultMessage": "捨棄"
+  },
+  "browse.selected-projects-leave-modal.header": {
+    "defaultMessage": "你選取的專案尚未安裝"
+  },
+  "browse.view-prefix": {
+    "defaultMessage": "檢視模式："
+  },
+  "button.accept": {
+    "defaultMessage": "接受"
+  },
+  "button.add-server-to-instance": {
+    "defaultMessage": "將伺服器新增至實例"
+  },
+  "button.affiliate-links": {
+    "defaultMessage": "聯盟連結"
+  },
+  "button.analytics": {
+    "defaultMessage": "數據分析"
+  },
+  "button.back": {
+    "defaultMessage": "返回"
+  },
+  "button.cancel": {
+    "defaultMessage": "取消"
+  },
+  "button.change-version": {
+    "defaultMessage": "變更版本"
+  },
+  "button.clear": {
+    "defaultMessage": "清除"
+  },
+  "button.close": {
+    "defaultMessage": "關閉"
+  },
+  "button.continue": {
+    "defaultMessage": "繼續"
+  },
+  "button.copy-filename": {
+    "defaultMessage": "複製檔案名稱"
+  },
+  "button.copy-full-path": {
+    "defaultMessage": "複製完整路徑"
+  },
+  "button.copy-id": {
+    "defaultMessage": "複製 ID"
+  },
+  "button.copy-link": {
+    "defaultMessage": "複製連結"
+  },
+  "button.copy-permalink": {
+    "defaultMessage": "複製永久連結"
+  },
+  "button.create-a-project": {
+    "defaultMessage": "建立專案"
+  },
+  "button.decline": {
+    "defaultMessage": "拒絕"
+  },
+  "button.disable": {
+    "defaultMessage": "停用"
+  },
+  "button.download": {
+    "defaultMessage": "下載"
+  },
+  "button.downloading": {
+    "defaultMessage": "下載中"
+  },
+  "button.edit": {
+    "defaultMessage": "編輯"
+  },
+  "button.enable": {
+    "defaultMessage": "啟用"
+  },
+  "button.extract": {
+    "defaultMessage": "解壓縮"
+  },
+  "button.follow": {
+    "defaultMessage": "追蹤"
+  },
+  "button.hide-snapshots": {
+    "defaultMessage": "隱藏快照版本"
+  },
+  "button.install": {
+    "defaultMessage": "安裝"
+  },
+  "button.max": {
+    "defaultMessage": "最大值"
+  },
+  "button.more-options": {
+    "defaultMessage": "更多選項"
+  },
+  "button.move": {
+    "defaultMessage": "移動"
+  },
+  "button.next": {
+    "defaultMessage": "下一步"
+  },
+  "button.open-folder": {
+    "defaultMessage": "開啟資料夾"
+  },
+  "button.open-in-folder": {
+    "defaultMessage": "在資料夾中開啟"
+  },
+  "button.open-in-modrinth": {
+    "defaultMessage": "在 Modrinth 中開啟"
+  },
+  "button.play": {
+    "defaultMessage": "遊玩"
+  },
+  "button.refresh": {
+    "defaultMessage": "重新整理"
+  },
+  "button.reinstall-modpack": {
+    "defaultMessage": "重新安裝模組包"
+  },
+  "button.remove": {
+    "defaultMessage": "刪除通行金鑰"
+  },
+  "button.remove-image": {
+    "defaultMessage": "移除圖片"
+  },
+  "button.rename": {
+    "defaultMessage": "重新命名"
+  },
+  "button.repair": {
+    "defaultMessage": "修復"
+  },
+  "button.repairing": {
+    "defaultMessage": "修復中..."
+  },
+  "button.report": {
+    "defaultMessage": "檢舉"
+  },
+  "button.reset": {
+    "defaultMessage": "重設"
+  },
+  "button.reset-server": {
+    "defaultMessage": "重設伺服器"
+  },
+  "button.retry": {
+    "defaultMessage": "重試"
+  },
+  "button.save": {
+    "defaultMessage": "儲存"
+  },
+  "button.save-changes": {
+    "defaultMessage": "儲存變更"
+  },
+  "button.saving": {
+    "defaultMessage": "儲存中"
+  },
+  "button.show-all-versions": {
+    "defaultMessage": "顯示所有版本"
+  },
+  "button.show-file": {
+    "defaultMessage": "顯示檔案"
+  },
+  "button.sign-in": {
+    "defaultMessage": "登入"
+  },
+  "button.sign-out": {
+    "defaultMessage": "登出"
+  },
+  "button.sign-up": {
+    "defaultMessage": "註冊"
+  },
+  "button.stop": {
+    "defaultMessage": "停止"
+  },
+  "button.switch-version": {
+    "defaultMessage": "切換版本"
+  },
+  "button.unfollow": {
+    "defaultMessage": "取消追蹤"
+  },
+  "button.unlink-modpack": {
+    "defaultMessage": "取消連結模組包"
+  },
+  "button.update": {
+    "defaultMessage": "更新"
+  },
+  "button.upload-image": {
+    "defaultMessage": "上傳圖片"
+  },
+  "collections.label.private": {
+    "defaultMessage": "私人"
+  },
+  "console.action.collapse": {
+    "defaultMessage": "收合"
+  },
+  "console.action.expand": {
+    "defaultMessage": "展開"
+  },
+  "console.action.share": {
+    "defaultMessage": "分享"
+  },
+  "console.command.disabled-placeholder": {
+    "defaultMessage": "指令輸入已停用"
+  },
+  "console.command.server-not-running-placeholder": {
+    "defaultMessage": "伺服器未執行"
+  },
+  "console.crash.export-context": {
+    "defaultMessage": "匯出崩潰內容"
+  },
+  "console.crash.finding.amd-driver.action": {
+    "defaultMessage": "全新安裝最新版 AMD 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
+  },
+  "console.crash.finding.amd-driver.title": {
+    "defaultMessage": "AMD 顯示卡驅動程式崩潰"
+  },
+  "console.crash.finding.content-verification.action": {
+    "defaultMessage": "從可信來源重新安裝證據中指出的檔案。"
+  },
+  "console.crash.finding.content-verification.title": {
+    "defaultMessage": "jar 簽章驗證失敗"
+  },
+  "console.crash.finding.definite-mod-fabric.action": {
+    "defaultMessage": "更新或暫時移除 Fabric 載入器證據中指出的模組。"
+  },
+  "console.crash.finding.definite-mod-fabric.title": {
+    "defaultMessage": "Fabric 發現特定模組故障"
+  },
+  "console.crash.finding.definite-mod.action": {
+    "defaultMessage": "更新、修復或暫時移除證據和相符 jar 中指出的模組。"
+  },
+  "console.crash.finding.definite-mod.title": {
+    "defaultMessage": "特定模組導致崩潰"
+  },
+  "console.crash.finding.duplicate-mod.action": {
+    "defaultMessage": "在 mods 資料夾中，每個模組只保留一個相容版本。"
+  },
+  "console.crash.finding.duplicate-mod.title": {
+    "defaultMessage": "安裝了重複模組"
+  },
+  "console.crash.finding.extracted-mod.action": {
+    "defaultMessage": "從 mods 資料夾移除解壓縮後的目錄，並安裝原始 jar 檔案。"
+  },
+  "console.crash.finding.extracted-mod.title": {
+    "defaultMessage": "發現已解壓縮的模組"
+  },
+  "console.crash.finding.fabric-solution.action": {
+    "defaultMessage": "依證據中列出的相依性變更處理後再啟動。"
+  },
+  "console.crash.finding.fabric-solution.title": {
+    "defaultMessage": "Fabric 發現不相容模組或缺少相依性"
+  },
+  "console.crash.finding.fallback-action": {
+    "defaultMessage": "檢視下方證據和本機實例中相符的模組。"
+  },
+  "console.crash.finding.fallback-title": {
+    "defaultMessage": "未知診斷：{finding}"
+  },
+  "console.crash.finding.forge-error.action": {
+    "defaultMessage": "檢視 Forge 故障證據，並在撤銷近期變更後測試指出的模組。"
+  },
+  "console.crash.finding.forge-error.title": {
+    "defaultMessage": "Forge 回報了遊戲錯誤"
+  },
+  "console.crash.finding.forge-incomplete.action": {
+    "defaultMessage": "修復或重新安裝此實例的 Forge 載入器。"
+  },
+  "console.crash.finding.forge-incomplete.title": {
+    "defaultMessage": "Forge 安裝不完整"
+  },
+  "console.crash.finding.forge-java-incompatible.action": {
+    "defaultMessage": "使用此 Forge 版本所需的 Java 版本，或更新 Forge。"
+  },
+  "console.crash.finding.forge-java-incompatible.title": {
+    "defaultMessage": "此 Forge 版本與所選 Java 執行環境不相容"
+  },
+  "console.crash.finding.incompatible-mods.action": {
+    "defaultMessage": "依證據中的相容性詳情更新、移除或替換衝突模組。"
+  },
+  "console.crash.finding.incompatible-mods.title": {
+    "defaultMessage": "已安裝的模組互不相容"
+  },
+  "console.crash.finding.intel-driver.action": {
+    "defaultMessage": "安裝最新版 Intel 顯示卡驅動程式，或改用其他可用 GPU 執行 Minecraft。"
+  },
+  "console.crash.finding.intel-driver.title": {
+    "defaultMessage": "Intel 顯示卡驅動程式崩潰"
+  },
+  "console.crash.finding.java-11-required.action": {
+    "defaultMessage": "選擇 Java 11，或安裝與所選 Java 版本相容的模組版本。"
+  },
+  "console.crash.finding.java-11-required.title": {
+    "defaultMessage": "模組需要 Java 11"
+  },
+  "console.crash.finding.java-32bit.action": {
+    "defaultMessage": "安裝並選擇 64 位元 Java 執行環境，然後重試啟動。"
+  },
+  "console.crash.finding.java-32bit.title": {
+    "defaultMessage": "32 位元 Java 執行環境無法配置所需記憶體"
+  },
+  "console.crash.finding.java-incompatible.action": {
+    "defaultMessage": "使用相容的 Java 執行環境，或安裝適用於此 Java 版本的模組版本。"
+  },
+  "console.crash.finding.java-incompatible.title": {
+    "defaultMessage": "模組需要其他 Java 版本"
+  },
+  "console.crash.finding.java-too-new.action": {
+    "defaultMessage": "選擇此 Minecraft 和模組載入器版本所需的 Java 主要版本。"
+  },
+  "console.crash.finding.java-too-new.title": {
+    "defaultMessage": "Java 執行環境版本對此實例過新"
+  },
+  "console.crash.finding.jdk-runtime.action": {
+    "defaultMessage": "為此 Minecraft 版本選擇標準 HotSpot Java 執行環境。"
+  },
+  "console.crash.finding.jdk-runtime.title": {
+    "defaultMessage": "選擇了 JDK 而不是 JRE"
+  },
+  "console.crash.finding.jvm-arguments.action": {
+    "defaultMessage": "移除報告中指出的自訂 JVM 參數，然後重新啟動實例。"
+  },
+  "console.crash.finding.jvm-arguments.title": {
+    "defaultMessage": "JVM 參數無效"
+  },
+  "console.crash.finding.large-resource-pack.action": {
+    "defaultMessage": "停用該資源包，或改用解析度較低的版本。"
+  },
+  "console.crash.finding.large-resource-pack.title": {
+    "defaultMessage": "目前資源包對圖形設定而言過大"
+  },
+  "console.crash.finding.manual-debug-crash.action": {
+    "defaultMessage": "重新啟動，並避免長按手動偵錯崩潰快速鍵。"
+  },
+  "console.crash.finding.manual-debug-crash.title": {
+    "defaultMessage": "觸發了偵錯崩潰快速鍵"
+  },
+  "console.crash.finding.matched-mod": {
+    "defaultMessage": "相符模組：{identity}{modId} - {fileName}"
+  },
+  "console.crash.finding.missing-dependency.action": {
+    "defaultMessage": "安裝所需的相依性版本，或使用與此 Minecraft 版本相符的模組版本。"
+  },
+  "console.crash.finding.missing-dependency.title": {
+    "defaultMessage": "模組相依性缺少或不受支援"
+  },
+  "console.crash.finding.mixin-bootstrap.action": {
+    "defaultMessage": "修復模組載入器安裝，並確認所有模組均適用於已安裝的載入器。"
+  },
+  "console.crash.finding.mixin-bootstrap.title": {
+    "defaultMessage": "缺少 Mixin 啟動程序"
+  },
+  "console.crash.finding.mixin-failure.action": {
+    "defaultMessage": "更新或移除相符的模組，並檢查其 Minecraft 和載入器版本是否相容。"
+  },
+  "console.crash.finding.mixin-failure.title": {
+    "defaultMessage": "模組 Mixin 套用失敗"
+  },
+  "console.crash.finding.mod-config.action": {
+    "defaultMessage": "備份並移除指出的設定檔，讓模組重新產生它。"
+  },
+  "console.crash.finding.mod-config.title": {
+    "defaultMessage": "無法讀取模組設定檔"
+  },
+  "console.crash.finding.mod-filename.action": {
+    "defaultMessage": "使用簡單的拉丁字母檔名重新命名或安裝模組 jar。"
+  },
+  "console.crash.finding.mod-filename.title": {
+    "defaultMessage": "模組檔名包含不支援的字元"
+  },
+  "console.crash.finding.mod-id-limit.action": {
+    "defaultMessage": "移除未使用的模組，或將安裝內容拆分為較小的相容設定檔。"
+  },
+  "console.crash.finding.mod-id-limit.title": {
+    "defaultMessage": "模組過多，超出 ID 限制"
+  },
+  "console.crash.finding.mod-initialization.action": {
+    "defaultMessage": "更新指出的模組，並確認其所需相依性均已安裝。"
+  },
+  "console.crash.finding.mod-initialization.title": {
+    "defaultMessage": "模組初始化失敗"
+  },
+  "console.crash.finding.mod-loader-error.action": {
+    "defaultMessage": "修復載入器安裝，並確認列出的模組檔案與此遊戲版本相符。"
+  },
+  "console.crash.finding.mod-loader-error.title": {
+    "defaultMessage": "模組載入器回報了故障"
+  },
+  "console.crash.finding.mod-loader-failure.action": {
+    "defaultMessage": "修復載入器安裝，並依證據中顯示的故障訊息處理。"
+  },
+  "console.crash.finding.mod-loader-failure.title": {
+    "defaultMessage": "模組載入器在識別模組檔案前失敗"
+  },
+  "console.crash.finding.multiple-forge-versions.action": {
+    "defaultMessage": "修復實例，使其版本設定檔中只包含一個 Forge 安裝。"
+  },
+  "console.crash.finding.multiple-forge-versions.title": {
+    "defaultMessage": "版本設定檔中包含多個 Forge 版本"
+  },
+  "console.crash.finding.nightconfig-bug.action": {
+    "defaultMessage": "備份 config 資料夾，移除損壞設定，讓模組重新產生它。"
+  },
+  "console.crash.finding.nightconfig-bug.title": {
+    "defaultMessage": "NightConfig 無法讀取設定檔"
+  },
+  "console.crash.finding.nvidia-driver.action": {
+    "defaultMessage": "全新安裝最新版 NVIDIA 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
+  },
+  "console.crash.finding.nvidia-driver.title": {
+    "defaultMessage": "NVIDIA 顯示卡驅動程式崩潰"
+  },
+  "console.crash.finding.opengl-unsupported.action": {
+    "defaultMessage": "安裝 GPU 製造商提供的顯示卡驅動程式，並確認 Minecraft 使用預期的 GPU。"
+  },
+  "console.crash.finding.opengl-unsupported.title": {
+    "defaultMessage": "目前顯示卡驅動程式不支援 OpenGL"
+  },
+  "console.crash.finding.openj9.action": {
+    "defaultMessage": "選擇以 HotSpot 為基礎的 Java 執行環境，例如 Eclipse Temurin 或內建 Minecraft 執行環境。"
+  },
+  "console.crash.finding.openj9.title": {
+    "defaultMessage": "所選 OpenJ9 執行環境不相容"
+  },
+  "console.crash.finding.optifine-incompatible.action": {
+    "defaultMessage": "安裝相容的 OptiFine 版本，或移除 OptiFine 和衝突的光影模組。"
+  },
+  "console.crash.finding.optifine-incompatible.title": {
+    "defaultMessage": "OptiFine 與已安裝的載入器或模組衝突"
+  },
+  "console.crash.finding.optifine-world.action": {
+    "defaultMessage": "移除 OptiFine，或安裝與此 Minecraft 和 Forge 版本相容的版本。"
+  },
+  "console.crash.finding.optifine-world.title": {
+    "defaultMessage": "OptiFine 阻止世界載入"
+  },
+  "console.crash.finding.out-of-memory.action": {
+    "defaultMessage": "增加實例記憶體配置，或移除占用大量記憶體的模組和資源包。"
+  },
+  "console.crash.finding.out-of-memory.title": {
+    "defaultMessage": "Minecraft 記憶體不足"
+  },
+  "console.crash.finding.pixel-format.action": {
+    "defaultMessage": "更新或重新安裝顯示卡驅動程式，停用衝突的覆蓋層後重試。"
+  },
+  "console.crash.finding.pixel-format.title": {
+    "defaultMessage": "顯示卡驅動程式無法設定像素格式"
+  },
+  "console.crash.finding.resource-pack.action": {
+    "defaultMessage": "停用目前光影和資源包，再逐一重新啟用。"
+  },
+  "console.crash.finding.resource-pack.title": {
+    "defaultMessage": "光影或資源包觸發圖形錯誤"
+  },
+  "console.crash.finding.shaders-optifine.action": {
+    "defaultMessage": "移除單獨的光影模組，因為 OptiFine 已提供光影支援。"
+  },
+  "console.crash.finding.shaders-optifine.title": {
+    "defaultMessage": "同時安裝了光影模組和 OptiFine"
+  },
+  "console.crash.finding.short-output.action": {
+    "defaultMessage": "重試一次，然後檢查 Java、載入器安裝和啟動器輸出中較早出現的錯誤。"
+  },
+  "console.crash.finding.short-output.title": {
+    "defaultMessage": "遊戲在產生有效日誌前停止"
+  },
+  "console.crash.finding.specific-block.action": {
+    "defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的方塊。"
+  },
+  "console.crash.finding.specific-block.title": {
+    "defaultMessage": "特定方塊導致崩潰"
+  },
+  "console.crash.finding.specific-entity.action": {
+    "defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的實體。"
+  },
+  "console.crash.finding.specific-entity.title": {
+    "defaultMessage": "特定實體導致崩潰"
+  },
+  "console.crash.finding.stack-analysis.action": {
+    "defaultMessage": "更新或暫時移除相符的模組，然後重新測試實例。"
+  },
+  "console.crash.finding.stack-analysis.title": {
+    "defaultMessage": "堆疊追蹤指向已安裝的模組"
+  },
+  "console.crash.finding.suspected-mod.action": {
+    "defaultMessage": "更新或暫時移除報告懷疑且本機相符的模組，然後重試。"
+  },
+  "console.crash.finding.suspected-mod.title": {
+    "defaultMessage": "崩潰報告懷疑一個或多個模組"
+  },
+  "console.crash.local-header": {
+    "defaultMessage": "{findings, plural, other {# 項本機診斷結果}}，來自 {sources, plural, other {# 個相關檔案}}"
+  },
+  "console.crash.problems-detected": {
+    "defaultMessage": "偵測到 {count, plural, other {# 個問題}}"
+  },
+  "console.delete-modal.confirmation": {
+    "defaultMessage": "刪除後無法復原此日誌檔案。確定要繼續嗎？"
+  },
+  "console.delete-modal.irreversible-title": {
+    "defaultMessage": "此操作無法復原"
+  },
+  "console.delete-modal.title": {
+    "defaultMessage": "刪除日誌檔案"
+  },
+  "console.filter.error": {
+    "defaultMessage": "錯誤"
+  },
+  "console.filter.info": {
+    "defaultMessage": "資訊"
+  },
+  "console.filter.warn": {
+    "defaultMessage": "警告"
+  },
+  "console.notification.delete-failed": {
+    "defaultMessage": "刪除日誌檔案失敗"
+  },
+  "console.notification.share-failed": {
+    "defaultMessage": "分享日誌失敗"
+  },
+  "console.notification.unknown-error": {
+    "defaultMessage": "未知錯誤。"
+  },
+  "console.search.placeholder": {
+    "defaultMessage": "搜尋日誌"
+  },
+  "console.share-modal.title": {
+    "defaultMessage": "分享日誌"
+  },
+  "content-type.content.lowercase": {
+    "defaultMessage": "內容"
+  },
+  "content-type.item.lowercase": {
+    "defaultMessage": "{count, plural, other {項目}}"
+  },
+  "content.card.select-project": {
+    "defaultMessage": "選取「{project}」"
+  },
+  "content.confirm-bulk-update.admonition-body": {
+    "defaultMessage": "確定要將這 {count, plural, other {# 個專案}}更新至最新的相容版本嗎？建議你逐一進行更新。"
+  },
+  "content.confirm-bulk-update.admonition-header": {
+    "defaultMessage": "更新警告"
+  },
+  "content.confirm-bulk-update.header": {
+    "defaultMessage": "更新專案"
+  },
+  "content.confirm-bulk-update.update-button": {
+    "defaultMessage": "更新 {count, plural, other {# 個專案}}"
+  },
+  "content.confirm-deletion.admonition-body": {
+    "defaultMessage": "刪除模組可能會對你的世界造成永久性影響，並在重新載入時導致內容遺失或發生非預期的問題。"
+  },
+  "content.confirm-deletion.admonition-header": {
+    "defaultMessage": "刪除警告"
+  },
+  "content.confirm-deletion.delete-button": {
+    "defaultMessage": "刪除 {count, number} 個{itemType}"
+  },
+  "content.confirm-deletion.header": {
+    "defaultMessage": "刪除{itemType}"
+  },
+  "content.confirm-modpack-update.admonition-body": {
+    "defaultMessage": "{action, select, downgrade {降級} other {更新}}可能會導致相容性問題。你額外新增至模組包的模組或內容將保留，但可能與新版本不相容。"
+  },
+  "content.confirm-modpack-update.admonition-header": {
+    "defaultMessage": "{action, select, downgrade {降級} other {更新}}警告"
+  },
+  "content.confirm-modpack-update.confirm-button": {
+    "defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
+  },
+  "content.confirm-modpack-update.header": {
+    "defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
+  },
+  "content.confirm-unlink.admonition-body": {
+    "defaultMessage": "模組與內容將與你額外新增至模組包的內容合併，且將不再接收更新。"
+  },
+  "content.confirm-unlink.admonition-header": {
+    "defaultMessage": "取消連結模組包"
+  },
+  "content.confirm-unlink.header": {
+    "defaultMessage": "取消連結模組包"
+  },
+  "content.confirm-unlink.unlink-button": {
+    "defaultMessage": "取消連結"
+  },
+  "content.dependency-warning.admonition-header": {
+    "defaultMessage": "其他內容需要此內容"
+  },
+  "content.dependency-warning.affected-dependents-label": {
+    "defaultMessage": "受影響{count, plural, other {專案}}"
+  },
+  "content.dependency-warning.bulk-admonition-body": {
+    "defaultMessage": "部分所選的專案已作為相依項安裝。刪除這些專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
+  },
+  "content.dependency-warning.context.instance": {
+    "defaultMessage": "實例"
+  },
+  "content.dependency-warning.context.server": {
+    "defaultMessage": "伺服器"
+  },
+  "content.dependency-warning.delete-anyway-button": {
+    "defaultMessage": "仍要刪除"
+  },
+  "content.dependency-warning.delete-many-anyway-button": {
+    "defaultMessage": "仍要刪除 {count, number} 個{itemType}"
+  },
+  "content.dependency-warning.deleting-label": {
+    "defaultMessage": "刪除"
+  },
+  "content.dependency-warning.disable-dependents-label": {
+    "defaultMessage": "刪除後停用依賴項"
+  },
+  "content.dependency-warning.effect-dependent-content": {
+    "defaultMessage": "依賴項內容可能會無法載入，或自主停用"
+  },
+  "content.dependency-warning.effect-instance": {
+    "defaultMessage": "你的{context}可能會崩潰、無法啟動，或出現異常行為"
+  },
+  "content.dependency-warning.header": {
+    "defaultMessage": "相依項警告"
+  },
+  "content.dependency-warning.single-admonition-body": {
+    "defaultMessage": "{project} 已作為相依項安裝。刪除這個專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
+  },
+  "content.dependency-warning.what-happens-label": {
+    "defaultMessage": "會發生什麼事？"
+  },
+  "content.diff-modal.added-count": {
+    "defaultMessage": "已新增 {count} 個"
+  },
+  "content.diff-modal.diff-type.added": {
+    "defaultMessage": "已新增（相依項）"
+  },
+  "content.diff-modal.diff-type.removed": {
+    "defaultMessage": "已停用"
+  },
+  "content.diff-modal.diff-type.updated": {
+    "defaultMessage": "已更新"
+  },
+  "content.diff-modal.removed-count": {
+    "defaultMessage": "已移除 {count} 個"
+  },
+  "content.diff-modal.unknown-content-body": {
+    "defaultMessage": "你伺服器上的部分內容無法進行分析，且可能會受到這項變更的影響。"
+  },
+  "content.diff-modal.updated-count": {
+    "defaultMessage": "已更新 {count} 個"
+  },
+  "content.filter.disabled": {
+    "defaultMessage": "停用"
+  },
+  "content.filter.enabled": {
+    "defaultMessage": "啟用"
+  },
+  "content.filter.updates": {
+    "defaultMessage": "更新"
+  },
+  "content.filter.warnings": {
+    "defaultMessage": "警告"
+  },
+  "content.page-layout.browse-content": {
+    "defaultMessage": "瀏覽內容"
+  },
+  "content.page-layout.empty.hint": {
+    "defaultMessage": "瀏覽或上傳{contentType}即可開始"
+  },
+  "content.page-layout.empty.no-content-installed": {
+    "defaultMessage": "未安裝內容"
+  },
+  "content.page-layout.failed-to-load": {
+    "defaultMessage": "無法載入內容"
+  },
+  "content.page-layout.no-content-found": {
+    "defaultMessage": "找不到內容。"
+  },
+  "content.page-layout.search-placeholder": {
+    "defaultMessage": "搜尋 {count, number} 個{contentType}..."
+  },
+  "content.page-layout.share.file-names": {
+    "defaultMessage": "檔案名稱"
+  },
+  "content.page-layout.share.label": {
+    "defaultMessage": "分享"
+  },
+  "content.page-layout.share.markdown-links": {
+    "defaultMessage": "Markdown 連結"
+  },
+  "content.page-layout.share.project-links": {
+    "defaultMessage": "專案連結"
+  },
+  "content.page-layout.share.project-names": {
+    "defaultMessage": "專案名稱"
+  },
+  "content.page-layout.sort.alphabetical": {
+    "defaultMessage": "字母順序"
+  },
+  "content.page-layout.sort.date-added-newest": {
+    "defaultMessage": "最新在前"
+  },
+  "content.page-layout.sort.date-added-oldest": {
+    "defaultMessage": "最舊在前"
+  },
+  "content.page-layout.sort.label": {
+    "defaultMessage": "排序依據：{mode}"
+  },
+  "content.page-layout.update-all": {
+    "defaultMessage": "更新全部"
+  },
+  "content.selection-bar.all-already-disabled": {
+    "defaultMessage": "所有已選擇的內容已經停用"
+  },
+  "content.selection-bar.all-already-enabled": {
+    "defaultMessage": "所有已選擇的內容已經啟用"
+  },
+  "content.selection-bar.bulk.deleting": {
+    "defaultMessage": "正在刪除 {progress}/{total} {contentType}..."
+  },
+  "content.selection-bar.bulk.deleting-count": {
+    "defaultMessage": "正在刪除 {count, number} 個{contentType}"
+  },
+  "content.selection-bar.bulk.deleting-waiting": {
+    "defaultMessage": "正在刪除{contentType}..."
+  },
+  "content.selection-bar.bulk.disabling": {
+    "defaultMessage": "正在停用 {progress}/{total} {contentType}..."
+  },
+  "content.selection-bar.bulk.disabling-count": {
+    "defaultMessage": "正在停用 {count, number} 個{contentType}"
+  },
+  "content.selection-bar.bulk.disabling-waiting": {
+    "defaultMessage": "正在停用{contentType}..."
+  },
+  "content.selection-bar.bulk.enabling": {
+    "defaultMessage": "正在啟用 {progress}/{total} {contentType}..."
+  },
+  "content.selection-bar.bulk.enabling-count": {
+    "defaultMessage": "正在啟用 {count, number} 個{contentType}"
+  },
+  "content.selection-bar.bulk.enabling-waiting": {
+    "defaultMessage": "正在啟用{contentType}..."
+  },
+  "content.selection-bar.bulk.updating": {
+    "defaultMessage": "正在更新 {progress}/{total} {contentType}..."
+  },
+  "content.selection-bar.bulk.updating-count": {
+    "defaultMessage": "正在更新 {count, number} 個{contentType}"
+  },
+  "content.selection-bar.bulk.updating-waiting": {
+    "defaultMessage": "正在更新{contentType}..."
+  },
+  "content.selection-bar.selected-count": {
+    "defaultMessage": "已選取 {count, number} 個{contentType}"
+  },
+  "content.selection-bar.selected-count-simple": {
+    "defaultMessage": "已選取 {count, number} 個項目"
+  },
+  "creation-flow.button.create-instance": {
+    "defaultMessage": "建立實例"
+  },
+  "creation-flow.button.create-world": {
+    "defaultMessage": "建立世界"
+  },
+  "creation-flow.button.finish": {
+    "defaultMessage": "完成"
+  },
+  "creation-flow.button.import": {
+    "defaultMessage": "匯入"
+  },
+  "creation-flow.button.import-instances": {
+    "defaultMessage": "匯入 {count, plural, other {# 個實例}}"
+  },
+  "creation-flow.button.setup-server": {
+    "defaultMessage": "設定伺服器"
+  },
+  "creation-flow.modal.custom-setup.build-number.label": {
+    "defaultMessage": "組建編號"
+  },
+  "creation-flow.modal.custom-setup.build-number.placeholder": {
+    "defaultMessage": "選擇組建編號"
+  },
+  "creation-flow.modal.custom-setup.build-number.search-placeholder": {
+    "defaultMessage": "搜尋組建編號..."
+  },
+  "creation-flow.modal.custom-setup.content-loader.label": {
+    "defaultMessage": "內容載入器"
+  },
+  "creation-flow.modal.custom-setup.game-version.load-failed": {
+    "defaultMessage": "遊戲版本載入失敗"
+  },
+  "creation-flow.modal.custom-setup.game-version.no-supported-versions": {
+    "defaultMessage": "沒有遊戲版本支援此載入器"
+  },
+  "creation-flow.modal.custom-setup.game-version.placeholder": {
+    "defaultMessage": "選擇遊戲版本"
+  },
+  "creation-flow.modal.custom-setup.game-version.search-placeholder": {
+    "defaultMessage": "搜尋遊戲版本..."
+  },
+  "creation-flow.modal.custom-setup.game-version-type.alpha": {
+    "defaultMessage": "愚人節版"
+  },
+  "creation-flow.modal.custom-setup.game-version-type.release": {
+    "defaultMessage": "正式版"
+  },
+  "creation-flow.modal.custom-setup.game-version-type.snapshot": {
+    "defaultMessage": "快照版"
+  },
+  "creation-flow.modal.custom-setup.icon.remove": {
+    "defaultMessage": "移除圖示"
+  },
+  "creation-flow.modal.custom-setup.icon.select": {
+    "defaultMessage": "選擇圖示"
+  },
+  "creation-flow.modal.custom-setup.loader-version-type.latest": {
+    "defaultMessage": "最新版"
+  },
+  "creation-flow.modal.custom-setup.loader-version-type.other": {
+    "defaultMessage": "其他"
+  },
+  "creation-flow.modal.custom-setup.loader-version-type.stable": {
+    "defaultMessage": "穩定版"
+  },
+  "creation-flow.modal.custom-setup.loader-version.label": {
+    "defaultMessage": "載入器版本"
+  },
+  "creation-flow.modal.custom-setup.loader-version.placeholder": {
+    "defaultMessage": "選擇載入器版本"
+  },
+  "creation-flow.modal.custom-setup.loader-version.search-placeholder": {
+    "defaultMessage": "搜尋載入器版本..."
+  },
+  "creation-flow.modal.custom-setup.loader.label": {
+    "defaultMessage": "載入器"
+  },
+  "creation-flow.modal.custom-setup.loader.no-such-versions-available": {
+    "defaultMessage": "無此版本"
+  },
+  "creation-flow.modal.custom-setup.loader.unsupported-tooltip": {
+    "defaultMessage": "此載入器不支援所選遊戲版本"
+  },
+  "creation-flow.modal.custom-setup.name.label": {
+    "defaultMessage": "名稱"
+  },
+  "creation-flow.modal.custom-setup.name.placeholder": {
+    "defaultMessage": "輸入實例名稱"
+  },
+  "creation-flow.modal.custom-setup.options.no-versions-available": {
+    "defaultMessage": "沒有可用的版本"
+  },
+  "creation-flow.modal.custom-setup.will-install-loader-version": {
+    "defaultMessage": "將會安裝：{loader} {version}"
+  },
+  "creation-flow.modal.setup-type.instance.description": {
+    "defaultMessage": "實例是指具有特定載入器、版本及模組的 Minecraft 設定。"
+  },
+  "creation-flow.modal.setup-type.option.custom-setup.description": {
+    "defaultMessage": "從頭開始，先選擇載入器與遊戲版本。"
+  },
+  "creation-flow.modal.setup-type.option.custom-setup.title": {
+    "defaultMessage": "自訂設定"
+  },
+  "creation-flow.modal.setup-type.option.import-instance.description": {
+    "defaultMessage": "從 Prism、CurseForge 或類似啟動器匯入實例。"
+  },
+  "creation-flow.modal.setup-type.option.import-instance.title": {
+    "defaultMessage": "匯入實例"
+  },
+  "creation-flow.modal.setup-type.option.modpack-base.description": {
+    "defaultMessage": "在 Modrinth 上瀏覽模組包，或從檔案匯入。"
+  },
+  "creation-flow.modal.setup-type.option.modpack-base.title": {
+    "defaultMessage": "安裝模組包"
+  },
+  "creation-flow.modal.setup-type.option.vanilla-minecraft.description": {
+    "defaultMessage": "不含任何模組或插件的經典 Minecraft。"
+  },
+  "creation-flow.modal.setup-type.option.vanilla-minecraft.title": {
+    "defaultMessage": "原版 Minecraft"
+  },
+  "creation-flow.modal.setup-type.title.installation": {
+    "defaultMessage": "選擇安裝類型"
+  },
+  "creation-flow.modal.setup-type.title.instance": {
+    "defaultMessage": "選擇實例類型"
+  },
+  "creation-flow.modal.setup-type.title.world": {
+    "defaultMessage": "選擇世界類型"
+  },
+  "creation-flow.title.choose-modpack": {
+    "defaultMessage": "選擇模組包"
+  },
+  "creation-flow.title.create-instance": {
+    "defaultMessage": "建立實例"
+  },
+  "creation-flow.title.create-world": {
+    "defaultMessage": "建立世界"
+  },
+  "creation-flow.title.import-instance": {
+    "defaultMessage": "匯入實例"
+  },
+  "creation-flow.title.reset-server": {
+    "defaultMessage": "重設伺服器"
+  },
+  "creation-flow.title.set-up-server": {
+    "defaultMessage": "設定伺服器"
+  },
+  "external-project-license-status.no": {
+    "defaultMessage": "否"
+  },
+  "external-project-license-status.permanent-no": {
+    "defaultMessage": "永久禁止"
+  },
+  "external-project-license-status.unidentified": {
+    "defaultMessage": "未識別"
+  },
+  "external-project-license-status.with-attribution": {
+    "defaultMessage": "附帶引用標註"
+  },
+  "external-project-license-status.with-attribution-and-source": {
+    "defaultMessage": "附帶引用標註與來源"
+  },
+  "external-project-license-status.yes": {
+    "defaultMessage": "是"
+  },
+  "files.conflict-modal.header": {
+    "defaultMessage": "解壓縮摘要"
+  },
+  "files.conflict-modal.overwrite-button": {
+    "defaultMessage": "覆寫"
+  },
+  "files.conflict-modal.overwrite-file-label": {
+    "defaultMessage": "將覆寫 <file-path>{path}</file-path>"
+  },
+  "files.conflict-modal.overwrite-many-warning": {
+    "defaultMessage": "若你繼續執行解壓縮，將有超過 100 個檔案被覆寫；以下列出部分檔案。"
+  },
+  "files.conflict-modal.overwrite-warning": {
+    "defaultMessage": "下列 {count} 個檔案已存在於你的伺服器上，若你繼續執行解壓縮，這些檔案將被覆寫。"
+  },
+  "files.conflict-modal.overwritten-count": {
+    "defaultMessage": "將覆寫 {count} 個檔案"
+  },
+  "files.conflict-modal.warning-header": {
+    "defaultMessage": "檔案將被覆寫"
+  },
+  "files.create-modal.create-button": {
+    "defaultMessage": "建立 {type}"
+  },
+  "files.create-modal.header": {
+    "defaultMessage": "建立一個 {type}"
+  },
+  "files.create-modal.placeholder-directory": {
+    "defaultMessage": "例如：my-folder"
+  },
+  "files.create-modal.placeholder-file": {
+    "defaultMessage": "例如：config.yml"
+  },
+  "files.delete-modal.deleting-name": {
+    "defaultMessage": "正在刪除「{name}」"
+  },
+  "files.delete-modal.header": {
+    "defaultMessage": "刪除檔案"
+  },
+  "files.delete-modal.warning.file": {
+    "defaultMessage": "此檔案將永久刪除。此操作無法撤銷。"
+  },
+  "files.delete-modal.warning.folder": {
+    "defaultMessage": "此資料夾及其所有內容將永久刪除。此操作無法撤銷。"
+  },
+  "files.editor.failed-to-open-text": {
+    "defaultMessage": "無法載入檔案內容。"
+  },
+  "files.editor.failed-to-open-title": {
+    "defaultMessage": "無法開啟檔案"
+  },
+  "files.editor.failed-to-share-text": {
+    "defaultMessage": "無法上傳至 mclo.gs。"
+  },
+  "files.editor.failed-to-share-title": {
+    "defaultMessage": "無法分享檔案"
+  },
+  "files.editor.file-saved-text": {
+    "defaultMessage": "你的檔案已儲存。"
+  },
+  "files.editor.file-saved-title": {
+    "defaultMessage": "已儲存檔案"
+  },
+  "files.editor.find-close": {
+    "defaultMessage": "關閉"
+  },
+  "files.editor.find-in-file": {
+    "defaultMessage": "尋找"
+  },
+  "files.editor.find-match-count": {
+    "defaultMessage": "{current}/{total}"
+  },
+  "files.editor.find-next-match": {
+    "defaultMessage": "下一個相符項"
+  },
+  "files.editor.find-no-results": {
+    "defaultMessage": "沒有結果"
+  },
+  "files.editor.find-previous-match": {
+    "defaultMessage": "上一個相符項"
+  },
+  "files.editor.find-toggle-replace": {
+    "defaultMessage": "切換取代功能"
+  },
+  "files.editor.log-url-copied-text": {
+    "defaultMessage": "你的記錄檔網址已複製到剪貼簿。"
+  },
+  "files.editor.log-url-copied-title": {
+    "defaultMessage": "記錄檔網址已複製"
+  },
+  "files.editor.replace": {
+    "defaultMessage": "取代"
+  },
+  "files.editor.replace-all": {
+    "defaultMessage": "取代全部"
+  },
+  "files.editor.replace-in-file": {
+    "defaultMessage": "取代"
+  },
+  "files.editor.save-failed-text": {
+    "defaultMessage": "無法儲存檔案。"
+  },
+  "files.editor.save-failed-title": {
+    "defaultMessage": "儲存失敗"
+  },
+  "files.error.go-to-home": {
+    "defaultMessage": "前往家資料夾"
+  },
+  "files.error.try-again": {
+    "defaultMessage": "再試一次"
+  },
+  "files.image_viewer.image_too_large": {
+    "defaultMessage": "圖片過大無法預覽 (最大 {maxDimension}x{maxDimension} 像素)"
+  },
+  "files.image_viewer.invalid_image": {
+    "defaultMessage": "圖片檔案無效或內容為空。"
+  },
+  "files.image_viewer.load_failed": {
+    "defaultMessage": "無法載入圖片"
+  },
+  "files.image_viewer.reset_zoom": {
+    "defaultMessage": "重設縮放"
+  },
+  "files.image_viewer.viewed_image_alt": {
+    "defaultMessage": "已檢視圖片"
+  },
+  "files.image_viewer.zoom_in": {
+    "defaultMessage": "放大"
+  },
+  "files.image_viewer.zoom_out": {
+    "defaultMessage": "縮小"
+  },
+  "files.item-type.file": {
+    "defaultMessage": "檔案"
+  },
+  "files.item-type.files": {
+    "defaultMessage": "檔案"
+  },
+  "files.item-type.folder": {
+    "defaultMessage": "資料夾"
+  },
+  "files.item-type.folders": {
+    "defaultMessage": "資料夾"
+  },
+  "files.layout.dry-run-failed-text": {
+    "defaultMessage": "執行模擬測試時發生錯誤"
+  },
+  "files.layout.dry-run-failed-title": {
+    "defaultMessage": "模擬測試失敗"
+  },
+  "files.layout.empty-folder-description": {
+    "defaultMessage": "沒有任何檔案或資料夾"
+  },
+  "files.layout.empty-folder-title": {
+    "defaultMessage": "此資料夾是空的"
+  },
+  "files.layout.error-message": {
+    "defaultMessage": "該資料夾可能不存在"
+  },
+  "files.layout.error-title": {
+    "defaultMessage": "無法載入檔案"
+  },
+  "files.layout.extraction-started-title": {
+    "defaultMessage": "解壓縮已開始"
+  },
+  "files.layout.selected-count": {
+    "defaultMessage": "已選擇 {count} 個"
+  },
+  "files.layout.unsaved-changes": {
+    "defaultMessage": "您有未儲存的變更"
+  },
+  "files.move-modal.current-location": {
+    "defaultMessage": "目前位置"
+  },
+  "files.move-modal.destination-path": {
+    "defaultMessage": "目標路徑"
+  },
+  "files.move-modal.destination-placeholder": {
+    "defaultMessage": "例如：/my-folder"
+  },
+  "files.move-modal.header": {
+    "defaultMessage": "移動{type}"
+  },
+  "files.navbar.back-to-home": {
+    "defaultMessage": "回到首頁"
+  },
+  "files.navbar.breadcrumb-navigation": {
+    "defaultMessage": "麵包屑導覽"
+  },
+  "files.navbar.create-new": {
+    "defaultMessage": "建立新的..."
+  },
+  "files.navbar.file-navigation": {
+    "defaultMessage": "檔案導覽"
+  },
+  "files.navbar.find-in-file": {
+    "defaultMessage": "在檔案中尋找"
+  },
+  "files.navbar.home": {
+    "defaultMessage": "首頁"
+  },
+  "files.navbar.install-curseforge-pack": {
+    "defaultMessage": "安裝 CurseForge 整合包"
+  },
+  "files.navbar.new-file": {
+    "defaultMessage": "新增檔案"
+  },
+  "files.navbar.new-folder": {
+    "defaultMessage": "新增資料夾"
+  },
+  "files.navbar.search-files": {
+    "defaultMessage": "搜尋檔案"
+  },
+  "files.navbar.upload-from-zip": {
+    "defaultMessage": "從 .zip 檔案上傳"
+  },
+  "files.navbar.upload-from-zip-url": {
+    "defaultMessage": "從 .zip 網址上傳"
+  },
+  "files.rename-modal.header": {
+    "defaultMessage": "重新命名 {name}"
+  },
+  "files.rename-modal.new-name-label": {
+    "defaultMessage": "新名稱"
+  },
+  "files.row.item-count": {
+    "defaultMessage": "{count, plural, other {# 個項目}}"
+  },
+  "files.table-header.created": {
+    "defaultMessage": "建立時間"
+  },
+  "files.table-header.modified": {
+    "defaultMessage": "修改時間"
+  },
+  "files.table-header.name": {
+    "defaultMessage": "名稱"
+  },
+  "files.table-header.size": {
+    "defaultMessage": "大小"
+  },
+  "files.unsaved-changes-modal.body": {
+    "defaultMessage": "您有未儲存的變更，如果離開將會遺失。離開前要儲存嗎？"
+  },
+  "files.unsaved-changes-modal.discard": {
+    "defaultMessage": "捨棄"
+  },
+  "files.unsaved-changes-modal.header": {
+    "defaultMessage": "未儲存的變更"
+  },
+  "files.validation.name-invalid-directory": {
+    "defaultMessage": "名稱只能包含英數字、破折號、底線或空格"
+  },
+  "files.validation.name-invalid-file": {
+    "defaultMessage": "名稱只能包含英數字、破折號、底線、點或空格"
+  },
+  "files.validation.name-label": {
+    "defaultMessage": "名稱"
+  },
+  "files.validation.name-required": {
+    "defaultMessage": "名稱為必填項目"
+  },
+  "files.zip-url-modal.cf-header": {
+    "defaultMessage": "安裝 CurseForge 整合包"
+  },
+  "files.zip-url-modal.cf-not-found-text": {
+    "defaultMessage": "在該網址找不到 CurseForge 整合包"
+  },
+  "files.zip-url-modal.cf-not-found-title": {
+    "defaultMessage": "找不到 CurseForge 整合包"
+  },
+  "files.zip-url-modal.enter-link": {
+    "defaultMessage": "輸入連結"
+  },
+  "files.zip-url-modal.error-cf-url": {
+    "defaultMessage": "網址必須是 CurseForge 整合包版本網址"
+  },
+  "files.zip-url-modal.error-url-invalid": {
+    "defaultMessage": "網址必須有效"
+  },
+  "files.zip-url-modal.error-url-required": {
+    "defaultMessage": "網址為必填項目"
+  },
+  "files.zip-url-modal.install-button": {
+    "defaultMessage": "安裝"
+  },
+  "files.zip-url-modal.install-failed-title": {
+    "defaultMessage": "安裝失敗"
+  },
+  "files.zip-url-modal.step-copy-description": {
+    "defaultMessage": "複製版本頁面網址並貼到下方"
+  },
+  "files.zip-url-modal.step-copy-title": {
+    "defaultMessage": "複製網址"
+  },
+  "files.zip-url-modal.step-find-description": {
+    "defaultMessage": "瀏覽 CurseForge 並找到您想要的整合包"
+  },
+  "files.zip-url-modal.step-find-title": {
+    "defaultMessage": "尋找整合包"
+  },
+  "files.zip-url-modal.step-select-description": {
+    "defaultMessage": "前往「檔案」分頁並選擇要安裝的版本"
+  },
+  "files.zip-url-modal.step-select-title": {
+    "defaultMessage": "選擇版本"
+  },
+  "files.zip-url-modal.unknown-error": {
+    "defaultMessage": "發生未知錯誤"
+  },
+  "files.zip-url-modal.zip-description": {
+    "defaultMessage": "複製並貼上 .zip 檔案的直接下載網址"
+  },
+  "files.zip-url-modal.zip-header": {
+    "defaultMessage": "正在從網址上傳 .zip 內容"
+  },
+  "form.label.address-line": {
+    "defaultMessage": "地址行 1"
+  },
+  "form.label.address-line-2": {
+    "defaultMessage": "地址行 2（可選）"
+  },
+  "form.label.amount": {
+    "defaultMessage": "金額"
+  },
+  "form.label.bank-name": {
+    "defaultMessage": "銀行名稱"
+  },
+  "form.label.business-name": {
+    "defaultMessage": "企業名稱"
+  },
+  "form.label.city": {
+    "defaultMessage": "城市"
+  },
+  "form.label.country": {
+    "defaultMessage": "國家或地區"
+  },
+  "form.label.date-of-birth": {
+    "defaultMessage": "出生日期"
+  },
+  "form.label.email": {
+    "defaultMessage": "電子郵件"
+  },
+  "form.label.first-name": {
+    "defaultMessage": "名字"
+  },
+  "form.label.last-name": {
+    "defaultMessage": "姓氏"
+  },
+  "form.label.postal-code": {
+    "defaultMessage": "郵遞區號"
+  },
+  "form.label.state-province": {
+    "defaultMessage": "縣市／省／州"
+  },
+  "form.placeholder.address": {
+    "defaultMessage": "輸入地址"
+  },
+  "form.placeholder.address-2": {
+    "defaultMessage": "公寓、套房等"
+  },
+  "form.placeholder.amount": {
+    "defaultMessage": "輸入金額"
+  },
+  "form.placeholder.bank-name": {
+    "defaultMessage": "輸入銀行名稱"
+  },
+  "form.placeholder.bank-name-dropdown": {
+    "defaultMessage": "選擇銀行名稱"
+  },
+  "form.placeholder.business-name": {
+    "defaultMessage": "輸入企業名稱"
+  },
+  "form.placeholder.city": {
+    "defaultMessage": "輸入城市"
+  },
+  "form.placeholder.country": {
+    "defaultMessage": "選擇國家或地區"
+  },
+  "form.placeholder.email": {
+    "defaultMessage": "輸入電子郵件地址"
+  },
+  "form.placeholder.first-name": {
+    "defaultMessage": "輸入名字"
+  },
+  "form.placeholder.last-name": {
+    "defaultMessage": "輸入姓氏"
+  },
+  "form.placeholder.postal-code": {
+    "defaultMessage": "輸入郵遞區號"
+  },
+  "form.placeholder.state": {
+    "defaultMessage": "輸入縣市／省／州"
+  },
+  "format.bytes.0": {
+    "defaultMessage": "{count, plural, other {# 位元組}}"
+  },
+  "format.bytes.1": {
+    "defaultMessage": "{count, number} KiB"
+  },
+  "format.bytes.2": {
+    "defaultMessage": "{count, number} MiB"
+  },
+  "format.bytes.3": {
+    "defaultMessage": "{count, number} GiB"
+  },
+  "format.bytes.4": {
+    "defaultMessage": "{count, number} TiB"
+  },
+  "header.category.category": {
+    "defaultMessage": "類別"
+  },
+  "header.category.feature": {
+    "defaultMessage": "功能"
+  },
+  "header.category.minecraft-server-community": {
+    "defaultMessage": "社群"
+  },
+  "header.category.minecraft-server-features": {
+    "defaultMessage": "特色"
+  },
+  "header.category.minecraft-server-gameplay": {
+    "defaultMessage": "遊戲玩法"
+  },
+  "header.category.minecraft-server-meta": {
+    "defaultMessage": "設定與機制"
+  },
+  "header.category.performance-impact": {
+    "defaultMessage": "效能影響"
+  },
+  "header.category.resolutions": {
+    "defaultMessage": "解析度"
+  },
+  "icon-select.edit": {
+    "defaultMessage": "編輯圖示"
+  },
+  "icon-select.remove": {
+    "defaultMessage": "移除圖示"
+  },
+  "icon-select.replace": {
+    "defaultMessage": "取代圖示"
+  },
+  "icon-select.select": {
+    "defaultMessage": "選擇圖示"
+  },
+  "input.search-version.placeholder": {
+    "defaultMessage": "搜尋版本..."
+  },
+  "input.search.placeholder": {
+    "defaultMessage": "搜尋..."
+  },
+  "input.select-version.placeholder": {
+    "defaultMessage": "選擇版本"
+  },
+  "input.view.gallery": {
+    "defaultMessage": "圖庫檢視"
+  },
+  "input.view.grid": {
+    "defaultMessage": "格狀檢視"
+  },
+  "input.view.list": {
+    "defaultMessage": "清單檢視"
+  },
+  "installation-settings.aria.select-game-version": {
+    "defaultMessage": "選擇遊戲版本"
+  },
+  "installation-settings.aria.select-loader-version": {
+    "defaultMessage": "選擇 {loader} 版本"
+  },
+  "installation-settings.aria.select-platform": {
+    "defaultMessage": "選擇平臺"
+  },
+  "installation-settings.confirm-version-change": {
+    "defaultMessage": "確定"
+  },
+  "installation-settings.confirm-version-change-description": {
+    "defaultMessage": "變更為 {gameVersion} 將會修改你伺服器上的下列內容。"
+  },
+  "installation-settings.confirm-version-change-header": {
+    "defaultMessage": "檢視內容變更"
+  },
+  "installation-settings.edit-installation.title": {
+    "defaultMessage": "編輯安裝"
+  },
+  "installation-settings.edit.warning-instance": {
+    "defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你仍想修改，請務必謹慎，因為這可能會導致問題。"
+  },
+  "installation-settings.edit.warning-server": {
+    "defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你想進行變更，請重設你的伺服器。"
+  },
+  "installation-settings.incompatible-content.auto-fix-button": {
+    "defaultMessage": "自動修復"
+  },
+  "installation-settings.incompatible-content.change-loader-button": {
+    "defaultMessage": "變更載入器"
+  },
+  "installation-settings.incompatible-content.disable-conflicts-button": {
+    "defaultMessage": "停用衝突項目"
+  },
+  "installation-settings.incompatible-content.game-version-warning-body": {
+    "defaultMessage": "變更遊戲版本時，我們可以停用不相容的已安裝內容，或是嘗試解決相容性問題。"
+  },
+  "installation-settings.incompatible-content.game-version-warning-title": {
+    "defaultMessage": "不相容警告"
+  },
+  "installation-settings.incompatible-content.header": {
+    "defaultMessage": "安裝了不相容的內容"
+  },
+  "installation-settings.incompatible-content.loader-change-body": {
+    "defaultMessage": "變更載入器時，所有已安裝的內容都將被停用。我們建議改為重設你的伺服器。"
+  },
+  "installation-settings.incompatible-content.loader-change-title": {
+    "defaultMessage": "變更載入器具有破壞性"
+  },
+  "installation-settings.linked-instance.title": {
+    "defaultMessage": "已連接{projectType}"
+  },
+  "installation-settings.linked.modpack": {
+    "defaultMessage": "模組包"
+  },
+  "installation-settings.linked.server-project": {
+    "defaultMessage": "伺服器專案"
+  },
+  "installation-settings.loader-version": {
+    "defaultMessage": "{loader} 版本"
+  },
+  "installation-settings.platform-lock-tooltip": {
+    "defaultMessage": "你需要重設伺服器才能切換載入器。"
+  },
+  "installation-settings.reinstall-modpack.description": {
+    "defaultMessage": "重新安裝模組包會將{type}內容重設為原始狀態，你新增的所有模組或內容都將被移除。"
+  },
+  "installation-settings.reinstall-modpack.title": {
+    "defaultMessage": "重新安裝模組包"
+  },
+  "installation-settings.reinstalling-modpack": {
+    "defaultMessage": "正在重新安裝模組包"
+  },
+  "installation-settings.removed-incompatible": {
+    "defaultMessage": "已移除（不相容）"
+  },
+  "installation-settings.repair.instance-description": {
+    "defaultMessage": "重新安裝 Minecraft 的必要元件並檢查檔案是否損毀。這或許能修復你的遊戲因啟動器出錯而打不開的問題。"
+  },
+  "installation-settings.repair.instance-title": {
+    "defaultMessage": "修復實例"
+  },
+  "installation-settings.repair.server-description": {
+    "defaultMessage": "在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的必要元件。這或許能修復你伺服器無法正常啟動的問題。"
+  },
+  "installation-settings.repair.server-title": {
+    "defaultMessage": "修復伺服器"
+  },
+  "installation-settings.saving": {
+    "defaultMessage": "儲存中..."
+  },
+  "installation-settings.search-game-version": {
+    "defaultMessage": "搜尋遊戲版本..."
+  },
+  "installation-settings.type.instance": {
+    "defaultMessage": "實例"
+  },
+  "installation-settings.type.instance-possessive": {
+    "defaultMessage": "實例"
+  },
+  "installation-settings.type.server": {
+    "defaultMessage": "伺服器"
+  },
+  "installation-settings.type.server-possessive": {
+    "defaultMessage": "伺服器"
+  },
+  "installation-settings.unlink": {
+    "defaultMessage": "取消連結"
+  },
+  "installation-settings.unlink.description": {
+    "defaultMessage": "取消連結將會永久中斷這個{type}與{projectType}的連結。這讓你可以變更載入器與 Minecraft 版本，但你將無法收到未來的更新。"
+  },
+  "installation-settings.verifying": {
+    "defaultMessage": "驗證中..."
+  },
+  "instance.confirm-reinstall.admonition-body": {
+    "defaultMessage": "重新安裝將會把所有已安裝或修改過的內容，重設回模組包原始的狀態。這將會移除所有你在原始安裝上額外添加的模組或內容。"
+  },
+  "instance.confirm-reinstall.admonition-header": {
+    "defaultMessage": "重新安裝警告"
+  },
+  "instance.confirm-reinstall.header": {
+    "defaultMessage": "重新安裝模組包"
+  },
+  "instance.confirm-reinstall.reinstall-button": {
+    "defaultMessage": "重新安裝模組包"
+  },
+  "instance.confirm-repair.body.instance": {
+    "defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復遊戲因啟動器出錯而無法啟動的問題。"
+  },
+  "instance.confirm-repair.body.server": {
+    "defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復伺服器無法正常啟動的問題。"
+  },
+  "instance.confirm-repair.header": {
+    "defaultMessage": "修復{type}"
+  },
+  "instance.confirm-repair.instance-label": {
+    "defaultMessage": "實例"
+  },
+  "instance.confirm-repair.repair-button": {
+    "defaultMessage": "修復"
+  },
+  "instance.confirm-repair.server-label": {
+    "defaultMessage": "伺服器"
+  },
+  "instance.worlds.game_mode.adventure": {
+    "defaultMessage": "冒險模式"
+  },
+  "instance.worlds.game_mode.creative": {
+    "defaultMessage": "創造模式"
+  },
+  "instance.worlds.game_mode.spectator": {
+    "defaultMessage": "旁觀者模式"
+  },
+  "instance.worlds.game_mode.survival": {
+    "defaultMessage": "生存模式"
+  },
+  "instance.worlds.game_mode.unknown": {
+    "defaultMessage": "未知的遊戲模式"
+  },
+  "instances.content-install.compatible-count": {
+    "defaultMessage": "{count} 個相容{count, plural, other {實例}}"
+  },
+  "instances.content-install.existing-tab": {
+    "defaultMessage": "已有實例"
+  },
+  "instances.content-install.game-version-placeholder": {
+    "defaultMessage": "選擇遊戲版本"
+  },
+  "instances.content-install.header": {
+    "defaultMessage": "安裝專案"
+  },
+  "instances.content-install.incompatible-tooltip": {
+    "defaultMessage": "這個專案支援的載入器或遊戲版本與這個實例所使用的不同。"
+  },
+  "instances.content-install.install-button": {
+    "defaultMessage": "安裝"
+  },
+  "instances.content-install.installed-badge": {
+    "defaultMessage": "已安裝"
+  },
+  "instances.content-install.instance-type": {
+    "defaultMessage": "實例類型"
+  },
+  "instances.content-install.loader-label": {
+    "defaultMessage": "載入器"
+  },
+  "instances.content-install.name-label": {
+    "defaultMessage": "名稱"
+  },
+  "instances.content-install.name-placeholder": {
+    "defaultMessage": "輸入實例名稱"
+  },
+  "instances.content-install.new-tab": {
+    "defaultMessage": "新的實例"
+  },
+  "instances.content-install.no-instances": {
+    "defaultMessage": "找不到相容的實例"
+  },
+  "instances.content-install.remove-icon": {
+    "defaultMessage": "移除圖示"
+  },
+  "instances.content-install.search-placeholder": {
+    "defaultMessage": "搜尋實例"
+  },
+  "instances.content-install.select-icon": {
+    "defaultMessage": "選擇圖示"
+  },
+  "instances.modpack-content-modal.empty-description": {
+    "defaultMessage": "這個模組包不包含任何額外內容。"
+  },
+  "instances.modpack-content-modal.empty-title": {
+    "defaultMessage": "找不到內容"
+  },
+  "instances.modpack-content-modal.header": {
+    "defaultMessage": "模組包內容"
+  },
+  "instances.modpack-content-modal.loading": {
+    "defaultMessage": "正在載入內容..."
+  },
+  "instances.modpack-content-modal.no-results": {
+    "defaultMessage": "沒有專案符合你的搜尋字詞。"
+  },
+  "instances.modpack-content-modal.search-placeholder": {
+    "defaultMessage": "搜尋 {count, number} {count, plural, other {個專案}}"
+  },
+  "instances.updater-modal.badge.current": {
+    "defaultMessage": "目前"
+  },
+  "instances.updater-modal.badge.incompatible": {
+    "defaultMessage": "不相容"
+  },
+  "instances.updater-modal.downgrade-to": {
+    "defaultMessage": "降級到 {version}"
+  },
+  "instances.updater-modal.header": {
+    "defaultMessage": "更新版本"
+  },
+  "instances.updater-modal.header-modpack": {
+    "defaultMessage": "切換模組包版本"
+  },
+  "instances.updater-modal.header-switch": {
+    "defaultMessage": "切換版本"
+  },
+  "instances.updater-modal.hide-incompatible": {
+    "defaultMessage": "隱藏不相容項目"
+  },
+  "instances.updater-modal.incompatibility-warning": {
+    "defaultMessage": "這個版本與這個實例不相容。相依項將不會自動安裝。"
+  },
+  "instances.updater-modal.incompatibility-warning-header": {
+    "defaultMessage": "選擇版本"
+  },
+  "instances.updater-modal.incompatible-update.description": {
+    "defaultMessage": "{version} 與此實例不相容。它可能無法啟動或運行異常。"
+  },
+  "instances.updater-modal.incompatible-update.header": {
+    "defaultMessage": "更新到不相容版本？"
+  },
+  "instances.updater-modal.incompatible-update.proceed": {
+    "defaultMessage": "仍要更新"
+  },
+  "instances.updater-modal.install-anyway": {
+    "defaultMessage": "仍要安裝"
+  },
+  "instances.updater-modal.loading-changelog": {
+    "defaultMessage": "正在載入更新日誌..."
+  },
+  "instances.updater-modal.loading-versions": {
+    "defaultMessage": "正在載入版本..."
+  },
+  "instances.updater-modal.no-changelog": {
+    "defaultMessage": "這個版本沒有提供更新日誌。"
+  },
+  "instances.updater-modal.no-versions": {
+    "defaultMessage": "找不到版本"
+  },
+  "instances.updater-modal.search-placeholder": {
+    "defaultMessage": "搜尋版本..."
+  },
+  "instances.updater-modal.select-version": {
+    "defaultMessage": "選擇版本以查看更新日誌"
+  },
+  "instances.updater-modal.show-incompatible": {
+    "defaultMessage": "顯示不相容項目"
+  },
+  "instances.updater-modal.switch-to": {
+    "defaultMessage": "切換到 {version}"
+  },
+  "instances.updater-modal.update-to": {
+    "defaultMessage": "更新到 {version}"
+  },
+  "instances.updater-modal.warning-app": {
+    "defaultMessage": "更新可能會導致實例損壞。請先查看版本更新日誌並備份。"
+  },
+  "instances.updater-modal.warning-web": {
+    "defaultMessage": "更新可能會導致世界損壞。請先查看版本更新日誌並備份。"
+  },
+  "label.actions": {
+    "defaultMessage": "動作"
+  },
+  "label.available": {
+    "defaultMessage": "可用餘額 {amount}。"
+  },
+  "label.changelog": {
+    "defaultMessage": "更新日誌"
+  },
+  "label.changes-saved": {
+    "defaultMessage": "變更已儲存"
+  },
+  "label.client-depends-warning": {
+    "defaultMessage": "此模組依賴客戶端模組，啟動伺服器時可能會造成問題"
+  },
+  "label.client-only-warning": {
+    "defaultMessage": "此為用戶端模組，啟動伺服器時可能會導致問題"
+  },
+  "label.client-retained-warning": {
+    "defaultMessage": "這是一個作為依賴項安裝的客戶端模組，啟動伺服器時可能會造成問題"
+  },
+  "label.collections": {
+    "defaultMessage": "收藏"
+  },
+  "label.confirm-password": {
+    "defaultMessage": "確認密碼"
+  },
+  "label.content": {
+    "defaultMessage": "內容"
+  },
+  "label.copied-filename": {
+    "defaultMessage": "已複製檔案名稱"
+  },
+  "label.copied-path": {
+    "defaultMessage": "已複製路徑"
+  },
+  "label.create-failed": {
+    "defaultMessage": "建立失敗"
+  },
+  "label.created-ago": {
+    "defaultMessage": "建立時間：{ago}"
+  },
+  "label.dashboard": {
+    "defaultMessage": "資訊主頁"
+  },
+  "label.delete": {
+    "defaultMessage": "刪除"
+  },
+  "label.delete-failed": {
+    "defaultMessage": "刪除失敗"
+  },
+  "label.delete-immediately": {
+    "defaultMessage": "立即刪除"
+  },
+  "label.description": {
+    "defaultMessage": "描述"
+  },
+  "label.details": {
+    "defaultMessage": "詳細資訊"
+  },
+  "label.done": {
+    "defaultMessage": "完成"
+  },
+  "label.download-failed": {
+    "defaultMessage": "下載失敗"
+  },
+  "label.email": {
+    "defaultMessage": "電子郵件地址"
+  },
+  "label.email-username": {
+    "defaultMessage": "電子郵件地址或使用者名稱"
+  },
+  "label.error": {
+    "defaultMessage": "錯誤"
+  },
+  "label.extract-failed": {
+    "defaultMessage": "解壓縮失敗"
+  },
+  "label.filter-by": {
+    "defaultMessage": "篩選依據"
+  },
+  "label.filters": {
+    "defaultMessage": "篩選器"
+  },
+  "label.followed-projects": {
+    "defaultMessage": "追蹤的專案"
+  },
+  "label.game-version": {
+    "defaultMessage": "遊戲版本"
+  },
+  "label.hide-installed-content": {
+    "defaultMessage": "隱藏已安裝的內容"
+  },
+  "label.hide-selected-content": {
+    "defaultMessage": "隱藏已選取的內容"
+  },
+  "label.installation-info": {
+    "defaultMessage": "安裝資訊"
+  },
+  "label.installed": {
+    "defaultMessage": "已安裝"
+  },
+  "label.installed-modpack": {
+    "defaultMessage": "已安裝模組包"
+  },
+  "label.installing": {
+    "defaultMessage": "安裝中..."
+  },
+  "label.installing-content": {
+    "defaultMessage": "正在安裝內容"
+  },
+  "label.loading": {
+    "defaultMessage": "載入中..."
+  },
+  "label.moderation": {
+    "defaultMessage": "管理"
+  },
+  "label.modpack": {
+    "defaultMessage": "模組包"
+  },
+  "label.move-failed": {
+    "defaultMessage": "移動失敗"
+  },
+  "label.no": {
+    "defaultMessage": "否"
+  },
+  "label.no-items": {
+    "defaultMessage": "沒有項目"
+  },
+  "label.notifications": {
+    "defaultMessage": "通知"
+  },
+  "label.or": {
+    "defaultMessage": "或"
+  },
+  "label.password": {
+    "defaultMessage": "密碼"
+  },
+  "label.plan-custom": {
+    "defaultMessage": "自訂"
+  },
+  "label.plan-large": {
+    "defaultMessage": "大型"
+  },
+  "label.plan-medium": {
+    "defaultMessage": "中型"
+  },
+  "label.plan-small": {
+    "defaultMessage": "小型"
+  },
+  "label.plan-unknown": {
+    "defaultMessage": "未知"
+  },
+  "label.platform": {
+    "defaultMessage": "平臺"
+  },
+  "label.played": {
+    "defaultMessage": "上次遊玩時間：{ago}"
+  },
+  "label.project": {
+    "defaultMessage": "專案"
+  },
+  "label.public": {
+    "defaultMessage": "公開"
+  },
+  "label.rejected": {
+    "defaultMessage": "已拒絕"
+  },
+  "label.rename-failed": {
+    "defaultMessage": "重新命名失敗"
+  },
+  "label.rewards-program-terms-agreement": {
+    "defaultMessage": "我同意《<terms-link>獎勵計畫條款</terms-link>》"
+  },
+  "label.saved": {
+    "defaultMessage": "已儲存"
+  },
+  "label.scopes": {
+    "defaultMessage": "權限範圍"
+  },
+  "label.search": {
+    "defaultMessage": "搜尋"
+  },
+  "label.select-all": {
+    "defaultMessage": "選擇全部"
+  },
+  "label.selected": {
+    "defaultMessage": "已選取"
+  },
+  "label.selection-actions": {
+    "defaultMessage": "選擇動作"
+  },
+  "label.server": {
+    "defaultMessage": "伺服器"
+  },
+  "label.servers": {
+    "defaultMessage": "伺服器"
+  },
+  "label.settings": {
+    "defaultMessage": "設定"
+  },
+  "label.singleplayer": {
+    "defaultMessage": "單人遊戲"
+  },
+  "label.sort-by": {
+    "defaultMessage": "排序依據："
+  },
+  "label.success": {
+    "defaultMessage": "成功"
+  },
+  "label.title": {
+    "defaultMessage": "標題"
+  },
+  "label.unknown": {
+    "defaultMessage": "未知"
+  },
+  "label.unlisted": {
+    "defaultMessage": "不公開"
+  },
+  "label.update-available": {
+    "defaultMessage": "有可用的更新"
+  },
+  "label.updating": {
+    "defaultMessage": "更新中..."
+  },
+  "label.upload-failed": {
+    "defaultMessage": "上傳失敗"
+  },
+  "label.username": {
+    "defaultMessage": "使用者名稱"
+  },
+  "label.validating": {
+    "defaultMessage": "驗證中"
+  },
+  "label.version": {
+    "defaultMessage": "版本"
+  },
+  "label.view": {
+    "defaultMessage": "檢視方式"
+  },
+  "label.visibility": {
+    "defaultMessage": "瀏覽權限"
+  },
+  "label.visit-your-profile": {
+    "defaultMessage": "瀏覽個人檔案"
+  },
+  "label.yes": {
+    "defaultMessage": "是"
+  },
+  "locale.cs-CZ": {
+    "defaultMessage": "捷克文"
+  },
+  "locale.da-DK": {
+    "defaultMessage": "丹麥文"
+  },
+  "locale.de-CH": {
+    "defaultMessage": "德文（瑞士）"
+  },
+  "locale.de-DE": {
+    "defaultMessage": "德文（德國）"
+  },
+  "locale.en-US": {
+    "defaultMessage": "英文（美國）"
+  },
+  "locale.es-419": {
+    "defaultMessage": "西班牙文（拉丁美洲）"
+  },
+  "locale.es-ES": {
+    "defaultMessage": "西班牙文（西班牙）"
+  },
+  "locale.fi-FI": {
+    "defaultMessage": "芬蘭文"
+  },
+  "locale.fil-PH": {
+    "defaultMessage": "菲律賓文"
+  },
+  "locale.fr-FR": {
+    "defaultMessage": "法文"
+  },
+  "locale.he-IL": {
+    "defaultMessage": "希伯來文"
+  },
+  "locale.hu-HU": {
+    "defaultMessage": "匈牙利文"
+  },
+  "locale.id-ID": {
+    "defaultMessage": "印尼文"
+  },
+  "locale.it-IT": {
+    "defaultMessage": "義大利文（義大利）"
+  },
+  "locale.ja-JP": {
+    "defaultMessage": "日文"
+  },
+  "locale.ko-KR": {
+    "defaultMessage": "韓文"
+  },
+  "locale.ms-MY": {
+    "defaultMessage": "馬來文"
+  },
+  "locale.nl-NL": {
+    "defaultMessage": "荷蘭文"
+  },
+  "locale.no-NO": {
+    "defaultMessage": "書面挪威文"
+  },
+  "locale.pl-PL": {
+    "defaultMessage": "波蘭文"
+  },
+  "locale.pt-BR": {
+    "defaultMessage": "葡萄牙文（巴西）"
+  },
+  "locale.pt-PT": {
+    "defaultMessage": "葡萄牙文（葡萄牙）"
+  },
+  "locale.ro-RO": {
+    "defaultMessage": "羅馬尼亞文"
+  },
+  "locale.ru-RU": {
+    "defaultMessage": "俄文"
+  },
+  "locale.sr-CS": {
+    "defaultMessage": "塞爾維亞文（拉丁）"
+  },
+  "locale.sv-SE": {
+    "defaultMessage": "瑞典文"
+  },
+  "locale.th-TH": {
+    "defaultMessage": "泰文"
+  },
+  "locale.tr-TR": {
+    "defaultMessage": "土耳其文"
+  },
+  "locale.uk-UA": {
+    "defaultMessage": "烏克蘭文"
+  },
+  "locale.vi-VN": {
+    "defaultMessage": "越南文"
+  },
+  "locale.zh-CN": {
+    "defaultMessage": "簡體中文"
+  },
+  "locale.zh-TW": {
+    "defaultMessage": "正體中文"
+  },
+  "markdown-editor.default-image-alt-text": {
+    "defaultMessage": "請將此內容替換為描述"
+  },
+  "markdown-editor.error-label": {
+    "defaultMessage": "錯誤"
+  },
+  "markdown-editor.image-modal.description-field.description": {
+    "defaultMessage": "請盡可能詳細描述這張圖片，如同對一位看不見這張圖片的人說明一般。"
+  },
+  "markdown-editor.image-modal.description-field.placeholder": {
+    "defaultMessage": "描述這張圖片..."
+  },
+  "markdown-editor.image-modal.description-field.title": {
+    "defaultMessage": "描述（替代文字）"
+  },
+  "markdown-editor.image-modal.header": {
+    "defaultMessage": "插入圖片"
+  },
+  "markdown-editor.image-modal.upload-mode.label": {
+    "defaultMessage": "圖片來源"
+  },
+  "markdown-editor.image-modal.upload-mode.link": {
+    "defaultMessage": "連結"
+  },
+  "markdown-editor.image-modal.upload-mode.upload": {
+    "defaultMessage": "上傳"
+  },
+  "markdown-editor.image-modal.upload.prompt": {
+    "defaultMessage": "拖曳檔案以上傳或點擊選擇檔案"
+  },
+  "markdown-editor.image-modal.url-field.placeholder": {
+    "defaultMessage": "輸入圖片網址..."
+  },
+  "markdown-editor.insert-button": {
+    "defaultMessage": "插入"
+  },
+  "markdown-editor.link-modal.header": {
+    "defaultMessage": "插入連結"
+  },
+  "markdown-editor.link-modal.label-field.placeholder": {
+    "defaultMessage": "輸入標籤..."
+  },
+  "markdown-editor.link-modal.label-field.title": {
+    "defaultMessage": "標籤"
+  },
+  "markdown-editor.link-modal.url-field.placeholder": {
+    "defaultMessage": "輸入連結網址..."
+  },
+  "markdown-editor.markdown-formatting-support": {
+    "defaultMessage": "這個編輯器支援 <markdown-link>Markdown 格式</markdown-link>。"
+  },
+  "markdown-editor.max-length.label": {
+    "defaultMessage": "長度限制："
+  },
+  "markdown-editor.max-length.unlimited": {
+    "defaultMessage": "無限制"
+  },
+  "markdown-editor.max-length.value": {
+    "defaultMessage": "{currentLength}/{maxLength}"
+  },
+  "markdown-editor.placeholder": {
+    "defaultMessage": "寫點什麼..."
+  },
+  "markdown-editor.preview-label": {
+    "defaultMessage": "預覽"
+  },
+  "markdown-editor.preview-toggle.label": {
+    "defaultMessage": "預覽"
+  },
+  "markdown-editor.toolbar.bold": {
+    "defaultMessage": "粗體"
+  },
+  "markdown-editor.toolbar.bulleted-list": {
+    "defaultMessage": "項目符號清單"
+  },
+  "markdown-editor.toolbar.code": {
+    "defaultMessage": "程式碼"
+  },
+  "markdown-editor.toolbar.heading-1": {
+    "defaultMessage": "標題 1"
+  },
+  "markdown-editor.toolbar.heading-2": {
+    "defaultMessage": "標題 2"
+  },
+  "markdown-editor.toolbar.heading-3": {
+    "defaultMessage": "標題 3"
+  },
+  "markdown-editor.toolbar.image": {
+    "defaultMessage": "圖片"
+  },
+  "markdown-editor.toolbar.italic": {
+    "defaultMessage": "斜體"
+  },
+  "markdown-editor.toolbar.link": {
+    "defaultMessage": "連結"
+  },
+  "markdown-editor.toolbar.ordered-list": {
+    "defaultMessage": "排序清單"
+  },
+  "markdown-editor.toolbar.quote": {
+    "defaultMessage": "引用"
+  },
+  "markdown-editor.toolbar.spoiler": {
+    "defaultMessage": "暴雷內容"
+  },
+  "markdown-editor.toolbar.strikethrough": {
+    "defaultMessage": "刪除線"
+  },
+  "markdown-editor.toolbar.video": {
+    "defaultMessage": "影片"
+  },
+  "markdown-editor.upload-error.no-file": {
+    "defaultMessage": "未提供檔案"
+  },
+  "markdown-editor.upload-error.no-handler": {
+    "defaultMessage": "未提供圖片上傳處理常式"
+  },
+  "markdown-editor.url-label": {
+    "defaultMessage": "網址"
+  },
+  "markdown-editor.url-validation-error.blocked-domain": {
+    "defaultMessage": "無效的網址。不允許這個網域。"
+  },
+  "markdown-editor.url-validation-error.malformed": {
+    "defaultMessage": "無效的網址。請確保網址格式正確。"
+  },
+  "markdown-editor.url-validation-error.unsupported-protocol": {
+    "defaultMessage": "不支援的協定。請使用 http 或 https。"
+  },
+  "markdown-editor.video-embed.title": {
+    "defaultMessage": "YouTube 影片播放器"
+  },
+  "markdown-editor.video-modal.header": {
+    "defaultMessage": "插入 YouTube 影片"
+  },
+  "markdown-editor.video-modal.url-field.description": {
+    "defaultMessage": "請輸入有效的 YouTube 影片連結。"
+  },
+  "markdown-editor.video-modal.url-field.placeholder": {
+    "defaultMessage": "輸入 YouTube 影片網址"
+  },
+  "markdown-editor.video-modal.url-field.title": {
+    "defaultMessage": "YouTube 影片網址"
+  },
+  "modal.open-in-app.benefit.install": {
+    "defaultMessage": "自動安裝所需內容"
+  },
+  "modal.open-in-app.benefit.launch": {
+    "defaultMessage": "直接啟動遊戲並加入伺服器"
+  },
+  "modal.open-in-app.benefit.update": {
+    "defaultMessage": "當伺服器變動時，維持檔案為最新狀態"
+  },
+  "modal.open-in-app.get-app": {
+    "defaultMessage": "取得 Modrinth App"
+  },
+  "modal.open-in-app.opening-automatically": {
+    "defaultMessage": "Modrinth App 將自動開啟..."
+  },
+  "modal.open-in-app.title": {
+    "defaultMessage": "正在開啟 Modrinth App"
+  },
+  "modal.open-in-app.why-use": {
+    "defaultMessage": "為何使用 Modrinth App"
+  },
+  "notification.error.title": {
+    "defaultMessage": "發生錯誤"
+  },
+  "omorphia.component.badge.label.accepted": {
+    "defaultMessage": "已接受"
+  },
+  "omorphia.component.badge.label.approved": {
+    "defaultMessage": "已核准"
+  },
+  "omorphia.component.badge.label.archived": {
+    "defaultMessage": "已封存"
+  },
+  "omorphia.component.badge.label.closed": {
+    "defaultMessage": "已關閉"
+  },
+  "omorphia.component.badge.label.creator": {
+    "defaultMessage": "創作者"
+  },
+  "omorphia.component.badge.label.draft": {
+    "defaultMessage": "草稿"
+  },
+  "omorphia.component.badge.label.failed": {
+    "defaultMessage": "失敗"
+  },
+  "omorphia.component.badge.label.listed": {
+    "defaultMessage": "公開"
+  },
+  "omorphia.component.badge.label.moderator": {
+    "defaultMessage": "管理員"
+  },
+  "omorphia.component.badge.label.modrinth-team": {
+    "defaultMessage": "Modrinth 團隊"
+  },
+  "omorphia.component.badge.label.pending": {
+    "defaultMessage": "待處理"
+  },
+  "omorphia.component.badge.label.private": {
+    "defaultMessage": "私人"
+  },
+  "omorphia.component.badge.label.processed": {
+    "defaultMessage": "已處理"
+  },
+  "omorphia.component.badge.label.rejected": {
+    "defaultMessage": "已拒絕"
+  },
+  "omorphia.component.badge.label.returned": {
+    "defaultMessage": "已退回"
+  },
+  "omorphia.component.badge.label.safe": {
+    "defaultMessage": "通過"
+  },
+  "omorphia.component.badge.label.scheduled": {
+    "defaultMessage": "已排定"
+  },
+  "omorphia.component.badge.label.under-review": {
+    "defaultMessage": "審查中"
+  },
+  "omorphia.component.badge.label.unlisted": {
+    "defaultMessage": "不公開"
+  },
+  "omorphia.component.badge.label.unsafe": {
+    "defaultMessage": "不通過"
+  },
+  "omorphia.component.badge.label.withheld": {
+    "defaultMessage": "由工作人員設為不公開"
+  },
+  "omorphia.component.copy.action.copy": {
+    "defaultMessage": "將程式碼複製到剪貼簿"
+  },
+  "omorphia.component.environment-indicator.label.client": {
+    "defaultMessage": "用戶端"
+  },
+  "omorphia.component.environment-indicator.label.client-and-server": {
+    "defaultMessage": "用戶端與伺服器端"
+  },
+  "omorphia.component.environment-indicator.label.client-or-server": {
+    "defaultMessage": "用戶端或伺服器端"
+  },
+  "omorphia.component.environment-indicator.label.server": {
+    "defaultMessage": "伺服器端"
+  },
+  "omorphia.component.environment-indicator.label.type": {
+    "defaultMessage": "{type}"
+  },
+  "omorphia.component.environment-indicator.label.unsupported": {
+    "defaultMessage": "不支援"
+  },
+  "payment-method.amazon_pay": {
+    "defaultMessage": "Amazon Pay"
+  },
+  "payment-method.amex": {
+    "defaultMessage": "美國運通"
+  },
+  "payment-method.card_display": {
+    "defaultMessage": "{card_brand}（末四碼 {last_four}）"
+  },
+  "payment-method.cashapp": {
+    "defaultMessage": "Cash App"
+  },
+  "payment-method.charity": {
+    "defaultMessage": "慈善機構"
+  },
+  "payment-method.charity-plural": {
+    "defaultMessage": "慈善機構"
+  },
+  "payment-method.diners": {
+    "defaultMessage": "大來卡"
+  },
+  "payment-method.discover": {
+    "defaultMessage": "Discover"
+  },
+  "payment-method.eftpos": {
+    "defaultMessage": "EFTPOS"
+  },
+  "payment-method.gift-card": {
+    "defaultMessage": "禮品卡"
+  },
+  "payment-method.gift-card-plural": {
+    "defaultMessage": "禮品卡"
+  },
+  "payment-method.jcb": {
+    "defaultMessage": "JCB"
+  },
+  "payment-method.mastercard": {
+    "defaultMessage": "萬事達卡"
+  },
+  "payment-method.paypal": {
+    "defaultMessage": "PayPal"
+  },
+  "payment-method.paypal_international": {
+    "defaultMessage": "PayPal 國際"
+  },
+  "payment-method.unionpay": {
+    "defaultMessage": "銀聯"
+  },
+  "payment-method.unknown": {
+    "defaultMessage": "未知的付款方式"
+  },
+  "payment-method.venmo": {
+    "defaultMessage": "Venmo"
+  },
+  "payment-method.virtual-visa": {
+    "defaultMessage": "虛擬 Visa 卡"
+  },
+  "payment-method.virtual-visa-plural": {
+    "defaultMessage": "虛擬 Visa 卡"
+  },
+  "payment-method.visa": {
+    "defaultMessage": "Visa"
+  },
+  "project-card.date.published.tooltip": {
+    "defaultMessage": "發布時間：{date}"
+  },
+  "project-card.date.updated.tooltip": {
+    "defaultMessage": "更新時間：{date}"
+  },
+  "project-card.environment.client": {
+    "defaultMessage": "用戶端"
+  },
+  "project-card.environment.client-and-server": {
+    "defaultMessage": "用戶端與伺服器端"
+  },
+  "project-card.environment.client-or-server": {
+    "defaultMessage": "用戶端或伺服器端"
+  },
+  "project-card.environment.server": {
+    "defaultMessage": "伺服器"
+  },
+  "project-type.all": {
+    "defaultMessage": "全部"
+  },
+  "project-type.datapack.capital": {
+    "defaultMessage": "{count, plural, other {資料包}}"
+  },
+  "project-type.datapack.category": {
+    "defaultMessage": "資料包"
+  },
+  "project-type.datapack.lowercase": {
+    "defaultMessage": "{count, plural, other {資料包}}"
+  },
+  "project-type.mod.capital": {
+    "defaultMessage": "{count, plural, other {模組}}"
+  },
+  "project-type.mod.category": {
+    "defaultMessage": "模組"
+  },
+  "project-type.mod.lowercase": {
+    "defaultMessage": "{count, plural, other {模組}}"
+  },
+  "project-type.modpack.capital": {
+    "defaultMessage": "{count, plural, other {模組包}}"
+  },
+  "project-type.modpack.category": {
+    "defaultMessage": "模組包"
+  },
+  "project-type.modpack.lowercase": {
+    "defaultMessage": "{count, plural, other {模組包}}"
+  },
+  "project-type.plugin.capital": {
+    "defaultMessage": "{count, plural, other {插件}}"
+  },
+  "project-type.plugin.category": {
+    "defaultMessage": "插件"
+  },
+  "project-type.plugin.lowercase": {
+    "defaultMessage": "{count, plural, other {插件}}"
+  },
+  "project-type.project.capital": {
+    "defaultMessage": "{count, plural, other {專案}}"
+  },
+  "project-type.project.category": {
+    "defaultMessage": "專案"
+  },
+  "project-type.project.lowercase": {
+    "defaultMessage": "{count, plural, other {專案}}"
+  },
+  "project-type.resourcepack.capital": {
+    "defaultMessage": "{count, plural, other {資源包}}"
+  },
+  "project-type.resourcepack.category": {
+    "defaultMessage": "資源包"
+  },
+  "project-type.resourcepack.lowercase": {
+    "defaultMessage": "{count, plural, other {資源包}}"
+  },
+  "project-type.server.capital": {
+    "defaultMessage": "{count, plural, one {伺服器} other {伺服器}}"
+  },
+  "project-type.server.category": {
+    "defaultMessage": "伺服器"
+  },
+  "project-type.server.lowercase": {
+    "defaultMessage": "{count, plural, other {伺服器}}"
+  },
+  "project-type.shader.capital": {
+    "defaultMessage": "{count, plural, other {光影包}}"
+  },
+  "project-type.shader.category": {
+    "defaultMessage": "光影包"
+  },
+  "project-type.shader.lowercase": {
+    "defaultMessage": "{count, plural, other {光影包}}"
+  },
+  "project.about.compatibility.environments": {
+    "defaultMessage": "支援環境"
+  },
+  "project.about.compatibility.environments.client-and-server": {
+    "defaultMessage": "用戶端與伺服器端"
+  },
+  "project.about.compatibility.environments.client-side": {
+    "defaultMessage": "用戶端"
+  },
+  "project.about.compatibility.environments.dedicated-servers-only": {
+    "defaultMessage": "僅限專用伺服器"
+  },
+  "project.about.compatibility.environments.server-side": {
+    "defaultMessage": "伺服器端"
+  },
+  "project.about.compatibility.environments.singleplayer": {
+    "defaultMessage": "單人遊戲"
+  },
+  "project.about.compatibility.environments.singleplayer-only": {
+    "defaultMessage": "僅限單人遊戲"
+  },
+  "project.about.compatibility.game.minecraftJava": {
+    "defaultMessage": "Minecraft Java 版"
+  },
+  "project.about.compatibility.platforms": {
+    "defaultMessage": "平臺"
+  },
+  "project.about.compatibility.platforms-plural": {
+    "defaultMessage": "{count, plural, other {平臺}}"
+  },
+  "project.about.compatibility.title": {
+    "defaultMessage": "相容性"
+  },
+  "project.about.creators.organization": {
+    "defaultMessage": "組織"
+  },
+  "project.about.creators.owner": {
+    "defaultMessage": "專案擁有者"
+  },
+  "project.about.creators.title": {
+    "defaultMessage": "創作者"
+  },
+  "project.about.details.created": {
+    "defaultMessage": "建立時間：{date}"
+  },
+  "project.about.details.licensed": {
+    "defaultMessage": "授權條款：{license}"
+  },
+  "project.about.details.published": {
+    "defaultMessage": "發布時間：{date}"
+  },
+  "project.about.details.submitted": {
+    "defaultMessage": "提交時間：{date}"
+  },
+  "project.about.details.updated": {
+    "defaultMessage": "更新時間：{date}"
+  },
+  "project.about.links.discord": {
+    "defaultMessage": "加入 Discord 伺服器"
+  },
+  "project.about.links.donate.bmac": {
+    "defaultMessage": "Buy Me a Coffee"
+  },
+  "project.about.links.donate.generic": {
+    "defaultMessage": "贊助"
+  },
+  "project.about.links.donate.github": {
+    "defaultMessage": "GitHub Sponsors 贊助"
+  },
+  "project.about.links.donate.kofi": {
+    "defaultMessage": "Ko-fi 贊助"
+  },
+  "project.about.links.donate.patreon": {
+    "defaultMessage": "Patreon 贊助"
+  },
+  "project.about.links.donate.paypal": {
+    "defaultMessage": "PayPal 贊助"
+  },
+  "project.about.links.issues": {
+    "defaultMessage": "回報問題"
+  },
+  "project.about.links.site": {
+    "defaultMessage": "前往網站"
+  },
+  "project.about.links.source": {
+    "defaultMessage": "檢視原始碼"
+  },
+  "project.about.links.store": {
+    "defaultMessage": "前往商店頁面"
+  },
+  "project.about.links.title": {
+    "defaultMessage": "相關連結"
+  },
+  "project.about.links.wiki": {
+    "defaultMessage": "前往 wiki"
+  },
+  "project.about.server.address.tooltip": {
+    "defaultMessage": "複製 Java 伺服器位址"
+  },
+  "project.about.server.copied": {
+    "defaultMessage": "已複製！"
+  },
+  "project.about.server.copiedText": {
+    "defaultMessage": "已將伺服器位址複製到剪貼簿"
+  },
+  "project.about.server.downloadModpack": {
+    "defaultMessage": "下載模組包"
+  },
+  "project.about.server.languages": {
+    "defaultMessage": "語言"
+  },
+  "project.about.server.recommendedVersion": {
+    "defaultMessage": "（推薦）"
+  },
+  "project.about.server.region": {
+    "defaultMessage": "地區"
+  },
+  "project.about.server.requiredContent": {
+    "defaultMessage": "必需內容"
+  },
+  "project.about.server.title": {
+    "defaultMessage": "伺服器詳細資訊"
+  },
+  "project.about.tags.title": {
+    "defaultMessage": "標籤"
+  },
+  "project.download-count-tooltip": {
+    "defaultMessage": "{count, number} 次{count, plural, other {下載}}"
+  },
+  "project.follower-count-tooltip": {
+    "defaultMessage": "{count, number} 位{count, plural, other {追蹤者}}"
+  },
+  "project.online-player-count": {
+    "defaultMessage": "{count, number} 人在線上"
+  },
+  "project.online-player-count.tooltip": {
+    "defaultMessage": "{count} 位{countPlural, plural, other {玩家}}在線上"
+  },
+  "project.recent-plays": {
+    "defaultMessage": "{count} 次{countPlural, plural, other {近期遊玩}}"
+  },
+  "project.recent-plays.tooltip": {
+    "defaultMessage": "過去 2 週內來自 Modrinth 的 {count} 次{countPlural, plural, other {最近遊玩次數}}"
+  },
+  "project.server.customModpackTooltip": {
+    "defaultMessage": "這個專案使用了自訂模組包"
+  },
+  "project.server.language.af": {
+    "defaultMessage": "南非文"
+  },
+  "project.server.language.am": {
+    "defaultMessage": "阿姆哈拉文"
+  },
+  "project.server.language.ar": {
+    "defaultMessage": "阿拉伯文"
+  },
+  "project.server.language.az": {
+    "defaultMessage": "亞塞拜然文"
+  },
+  "project.server.language.be": {
+    "defaultMessage": "白俄羅斯文"
+  },
+  "project.server.language.bg": {
+    "defaultMessage": "保加利亞文"
+  },
+  "project.server.language.bn": {
+    "defaultMessage": "孟加拉文"
+  },
+  "project.server.language.bs": {
+    "defaultMessage": "波士尼亞文"
+  },
+  "project.server.language.ca": {
+    "defaultMessage": "加泰隆尼亞文"
+  },
+  "project.server.language.cs": {
+    "defaultMessage": "捷克文"
+  },
+  "project.server.language.da": {
+    "defaultMessage": "丹麥文"
+  },
+  "project.server.language.de": {
+    "defaultMessage": "德文"
+  },
+  "project.server.language.el": {
+    "defaultMessage": "希臘文"
+  },
+  "project.server.language.en": {
+    "defaultMessage": "英文"
+  },
+  "project.server.language.eo": {
+    "defaultMessage": "世界語"
+  },
+  "project.server.language.es": {
+    "defaultMessage": "西班牙文"
+  },
+  "project.server.language.et": {
+    "defaultMessage": "愛沙尼亞文"
+  },
+  "project.server.language.eu": {
+    "defaultMessage": "巴斯克文"
+  },
+  "project.server.language.fa": {
+    "defaultMessage": "波斯文"
+  },
+  "project.server.language.fi": {
+    "defaultMessage": "芬蘭文"
+  },
+  "project.server.language.fr": {
+    "defaultMessage": "法文"
+  },
+  "project.server.language.ga": {
+    "defaultMessage": "愛爾蘭文"
+  },
+  "project.server.language.gl": {
+    "defaultMessage": "加利西亞文"
+  },
+  "project.server.language.he": {
+    "defaultMessage": "希伯來文"
+  },
+  "project.server.language.hi": {
+    "defaultMessage": "印地文"
+  },
+  "project.server.language.hr": {
+    "defaultMessage": "克羅埃西亞文"
+  },
+  "project.server.language.hu": {
+    "defaultMessage": "匈牙利文"
+  },
+  "project.server.language.hy": {
+    "defaultMessage": "亞美尼亞文"
+  },
+  "project.server.language.id": {
+    "defaultMessage": "印尼文"
+  },
+  "project.server.language.is": {
+    "defaultMessage": "冰島文"
+  },
+  "project.server.language.it": {
+    "defaultMessage": "義大利文"
+  },
+  "project.server.language.ja": {
+    "defaultMessage": "日文"
+  },
+  "project.server.language.ka": {
+    "defaultMessage": "喬治亞文"
+  },
+  "project.server.language.kk": {
+    "defaultMessage": "哈薩克文"
+  },
+  "project.server.language.km": {
+    "defaultMessage": "高棉文"
+  },
+  "project.server.language.kn": {
+    "defaultMessage": "坎那達文"
+  },
+  "project.server.language.ko": {
+    "defaultMessage": "韓文"
+  },
+  "project.server.language.lo": {
+    "defaultMessage": "寮文"
+  },
+  "project.server.language.lt": {
+    "defaultMessage": "立陶宛文"
+  },
+  "project.server.language.lv": {
+    "defaultMessage": "拉脫維亞文"
+  },
+  "project.server.language.mk": {
+    "defaultMessage": "馬其頓文"
+  },
+  "project.server.language.ml": {
+    "defaultMessage": "馬來亞拉姆文"
+  },
+  "project.server.language.mn": {
+    "defaultMessage": "蒙古文"
+  },
+  "project.server.language.mr": {
+    "defaultMessage": "馬拉提文"
+  },
+  "project.server.language.ms": {
+    "defaultMessage": "馬來文"
+  },
+  "project.server.language.my": {
+    "defaultMessage": "緬甸文"
+  },
+  "project.server.language.ne": {
+    "defaultMessage": "尼泊爾文"
+  },
+  "project.server.language.nl": {
+    "defaultMessage": "荷蘭文"
+  },
+  "project.server.language.no": {
+    "defaultMessage": "挪威文"
+  },
+  "project.server.language.pa": {
+    "defaultMessage": "旁遮普文"
+  },
+  "project.server.language.pl": {
+    "defaultMessage": "波蘭文"
+  },
+  "project.server.language.pt": {
+    "defaultMessage": "葡萄牙文"
+  },
+  "project.server.language.ro": {
+    "defaultMessage": "羅馬尼亞文"
+  },
+  "project.server.language.ru": {
+    "defaultMessage": "俄文"
+  },
+  "project.server.language.si": {
+    "defaultMessage": "僧伽羅文"
+  },
+  "project.server.language.sk": {
+    "defaultMessage": "斯洛伐克文"
+  },
+  "project.server.language.sl": {
+    "defaultMessage": "斯洛維尼亞文"
+  },
+  "project.server.language.sq": {
+    "defaultMessage": "阿爾巴尼亞文"
+  },
+  "project.server.language.sr": {
+    "defaultMessage": "塞爾維亞文"
+  },
+  "project.server.language.sv": {
+    "defaultMessage": "瑞典文"
+  },
+  "project.server.language.sw": {
+    "defaultMessage": "斯瓦希里文"
+  },
+  "project.server.language.ta": {
+    "defaultMessage": "泰米爾文"
+  },
+  "project.server.language.te": {
+    "defaultMessage": "泰盧固文"
+  },
+  "project.server.language.th": {
+    "defaultMessage": "泰文"
+  },
+  "project.server.language.tl": {
+    "defaultMessage": "菲律賓文"
+  },
+  "project.server.language.tr": {
+    "defaultMessage": "土耳其文"
+  },
+  "project.server.language.uk": {
+    "defaultMessage": "烏克蘭文"
+  },
+  "project.server.language.ur": {
+    "defaultMessage": "烏爾都文"
+  },
+  "project.server.language.uz": {
+    "defaultMessage": "烏茲別克文"
+  },
+  "project.server.language.vi": {
+    "defaultMessage": "越南文"
+  },
+  "project.server.language.yo": {
+    "defaultMessage": "約魯巴文"
+  },
+  "project.server.language.zh": {
+    "defaultMessage": "中文"
+  },
+  "project.server.language.zu": {
+    "defaultMessage": "祖魯文"
+  },
+  "project.server.ping.ms": {
+    "defaultMessage": "{ping, number} 毫秒"
+  },
+  "project.server.region.asia": {
+    "defaultMessage": "亞洲"
+  },
+  "project.server.region.australia": {
+    "defaultMessage": "澳洲"
+  },
+  "project.server.region.europe": {
+    "defaultMessage": "歐洲"
+  },
+  "project.server.region.middle_east": {
+    "defaultMessage": "中東"
+  },
+  "project.server.region.russia": {
+    "defaultMessage": "俄羅斯"
+  },
+  "project.server.region.south_america": {
+    "defaultMessage": "南美洲"
+  },
+  "project.server.region.tooltip": {
+    "defaultMessage": "伺服器位於{regionName}"
+  },
+  "project.server.region.us_east": {
+    "defaultMessage": "美國東部"
+  },
+  "project.server.region.us_west": {
+    "defaultMessage": "美國西部"
+  },
+  "project.server.status.offline": {
+    "defaultMessage": "離線"
+  },
+  "project.server.status.offline.tooltip": {
+    "defaultMessage": "伺服器已離線"
+  },
+  "project.server.status.online": {
+    "defaultMessage": "線上"
+  },
+  "project.settings.analytics.title": {
+    "defaultMessage": "數據分析"
+  },
+  "project.settings.content.title": {
+    "defaultMessage": "內容"
+  },
+  "project.settings.description.title": {
+    "defaultMessage": "描述"
+  },
+  "project.settings.environment.title": {
+    "defaultMessage": "環境"
+  },
+  "project.settings.gallery.title": {
+    "defaultMessage": "圖庫"
+  },
+  "project.settings.general.title": {
+    "defaultMessage": "一般"
+  },
+  "project.settings.license.title": {
+    "defaultMessage": "授權條款"
+  },
+  "project.settings.links.title": {
+    "defaultMessage": "連結"
+  },
+  "project.settings.members.title": {
+    "defaultMessage": "成員"
+  },
+  "project.settings.notice.no-permission.description": {
+    "defaultMessage": "你沒有編輯這個設定的權限。"
+  },
+  "project.settings.notice.no-permission.title": {
+    "defaultMessage": "沒有權限"
+  },
+  "project.settings.server.title": {
+    "defaultMessage": "伺服器"
+  },
+  "project.settings.tags.title": {
+    "defaultMessage": "標籤"
+  },
+  "project.settings.upload.title": {
+    "defaultMessage": "上傳"
+  },
+  "project.settings.versions.permissions": {
+    "defaultMessage": "權限"
+  },
+  "project.settings.versions.title": {
+    "defaultMessage": "版本"
+  },
+  "project.settings.view.title": {
+    "defaultMessage": "檢視"
+  },
+  "project.versions.channel.alpha.symbol": {
+    "defaultMessage": "A"
+  },
+  "project.versions.channel.beta.symbol": {
+    "defaultMessage": "B"
+  },
+  "project.versions.channel.release.symbol": {
+    "defaultMessage": "R"
+  },
+  "project.versions.version.withheld": {
+    "defaultMessage": "保留"
+  },
+  "project.versions.version.withheld.tooltip": {
+    "defaultMessage": "版本由於缺少授權資訊而被保留"
+  },
+  "project.versions.withheld-versions-warning.resolve-button": {
+    "defaultMessage": "解決"
+  },
+  "project.visibility.archived": {
+    "defaultMessage": "已封存"
+  },
+  "project.visibility.draft": {
+    "defaultMessage": "草稿"
+  },
+  "project.visibility.private": {
+    "defaultMessage": "私人"
+  },
+  "project.visibility.public": {
+    "defaultMessage": "公開"
+  },
+  "project.visibility.rejected": {
+    "defaultMessage": "已拒絕"
+  },
+  "project.visibility.scheduled": {
+    "defaultMessage": "已排定"
+  },
+  "project.visibility.under-review": {
+    "defaultMessage": "審查中"
+  },
+  "project.visibility.unknown": {
+    "defaultMessage": "未知"
+  },
+  "project.visibility.unlisted": {
+    "defaultMessage": "不公開"
+  },
+  "project.visibility.unlisted-by-staff": {
+    "defaultMessage": "由工作人員設為不公開"
+  },
+  "report.item-type.content": {
+    "defaultMessage": "內容"
+  },
+  "report.item-type.project": {
+    "defaultMessage": "專案"
+  },
+  "report.item-type.user": {
+    "defaultMessage": "使用者"
+  },
+  "report.item-type.version": {
+    "defaultMessage": "版本"
+  },
+  "search.filter.locked.default": {
+    "defaultMessage": "篩選器已鎖定"
+  },
+  "search.filter.locked.default.description": {
+    "defaultMessage": "解鎖這個篩選器可能導致安裝不相容的內容。"
+  },
+  "search.filter.locked.default.sync": {
+    "defaultMessage": "同步篩選器"
+  },
+  "search.filter.locked.default.title": {
+    "defaultMessage": "{type} 已鎖定"
+  },
+  "search.filter.locked.default.unlock": {
+    "defaultMessage": "解鎖篩選器"
+  },
+  "search.filter.option.exclusion.add.tooltip": {
+    "defaultMessage": "排除"
+  },
+  "search.filter.option.search.clear.aria_label": {
+    "defaultMessage": "清除搜尋"
+  },
+  "search.filter.option.search.placeholder": {
+    "defaultMessage": "搜尋..."
+  },
+  "search.filter.option.show_fewer": {
+    "defaultMessage": "只顯示部分內容"
+  },
+  "search.filter.option.show_more": {
+    "defaultMessage": "顯示更多內容"
+  },
+  "search.filter_type.environment": {
+    "defaultMessage": "環境"
+  },
+  "search.filter_type.environment.client": {
+    "defaultMessage": "用戶端"
+  },
+  "search.filter_type.environment.server": {
+    "defaultMessage": "伺服器端"
+  },
+  "search.filter_type.game_version": {
+    "defaultMessage": "遊戲版本"
+  },
+  "search.filter_type.game_version.all_versions": {
+    "defaultMessage": "顯示所有版本"
+  },
+  "search.filter_type.license": {
+    "defaultMessage": "授權條款"
+  },
+  "search.filter_type.license.open_source": {
+    "defaultMessage": "開放原始碼"
+  },
+  "search.filter_type.mod_loader": {
+    "defaultMessage": "載入器"
+  },
+  "search.filter_type.modpack_loader": {
+    "defaultMessage": "載入器"
+  },
+  "search.filter_type.plugin_loader": {
+    "defaultMessage": "載入器"
+  },
+  "search.filter_type.plugin_platform": {
+    "defaultMessage": "平臺"
+  },
+  "search.filter_type.project_id": {
+    "defaultMessage": "專案 ID"
+  },
+  "search.filter_type.server_content_type": {
+    "defaultMessage": "類型"
+  },
+  "search.filter_type.server_language": {
+    "defaultMessage": "語言"
+  },
+  "search.filter_type.server_region": {
+    "defaultMessage": "地區"
+  },
+  "search.filter_type.server_status": {
+    "defaultMessage": "狀態"
+  },
+  "search.filter_type.shader_loader": {
+    "defaultMessage": "載入器"
+  },
+  "search.server_content_type.modpack": {
+    "defaultMessage": "模組支援"
+  },
+  "search.server_content_type.vanilla": {
+    "defaultMessage": "原版"
+  },
+  "servers.notice.dismiss": {
+    "defaultMessage": "撤銷"
+  },
+  "servers.notice.dismissable": {
+    "defaultMessage": "可撤銷"
+  },
+  "servers.notice.heading.attention": {
+    "defaultMessage": "注意"
+  },
+  "servers.notice.heading.info": {
+    "defaultMessage": "資訊"
+  },
+  "servers.notice.level.critical.name": {
+    "defaultMessage": "重要"
+  },
+  "servers.notice.level.info.name": {
+    "defaultMessage": "資訊"
+  },
+  "servers.notice.level.survey.name": {
+    "defaultMessage": "問卷"
+  },
+  "servers.notice.level.warn.name": {
+    "defaultMessage": "警告"
+  },
+  "servers.notice.undismissable": {
+    "defaultMessage": "不可撤銷"
+  },
+  "servers.region.australia": {
+    "defaultMessage": "澳洲"
+  },
+  "servers.region.central-europe": {
+    "defaultMessage": "中歐"
+  },
+  "servers.region.north-america-central": {
+    "defaultMessage": "北美中部"
+  },
+  "servers.region.north-america-east": {
+    "defaultMessage": "北美東部"
+  },
+  "servers.region.north-america-west": {
+    "defaultMessage": "北美西部"
+  },
+  "servers.region.southeast-asia": {
+    "defaultMessage": "東南亞"
+  },
+  "servers.region.western-europe": {
+    "defaultMessage": "西歐"
+  },
+  "servers.setup.upload-warning": {
+    "defaultMessage": "上傳時請勿關閉此頁面。"
+  },
+  "servers.setup.uploading-modpack.header": {
+    "defaultMessage": "正在上傳模組包"
+  },
+  "settings.account.title": {
+    "defaultMessage": "帳號和安全性"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "外觀"
+  },
+  "settings.applications.title": {
+    "defaultMessage": "你的應用程式"
+  },
+  "settings.authorized-apps.title": {
+    "defaultMessage": "已授權的應用程式"
+  },
+  "settings.display.theme.dark": {
+    "defaultMessage": "深色"
+  },
+  "settings.display.theme.description": {
+    "defaultMessage": "依照偏好，設定這部裝置的 Modrinth 主題顏色。"
+  },
+  "settings.display.theme.light": {
+    "defaultMessage": "淺色"
+  },
+  "settings.display.theme.oled": {
+    "defaultMessage": "OLED"
+  },
+  "settings.display.theme.preferred-dark-theme": {
+    "defaultMessage": "偏好深色主題"
+  },
+  "settings.display.theme.preferred-light-theme": {
+    "defaultMessage": "偏好淺色主題"
+  },
+  "settings.display.theme.retro": {
+    "defaultMessage": "復古"
+  },
+  "settings.display.theme.system": {
+    "defaultMessage": "與系統同步"
+  },
+  "settings.display.theme.title": {
+    "defaultMessage": "色彩主題"
+  },
+  "settings.feature-flags.title": {
+    "defaultMessage": "功能旗標"
+  },
+  "settings.language.categories.default": {
+    "defaultMessage": "標準語言"
+  },
+  "settings.language.categories.search-result": {
+    "defaultMessage": "搜尋結果"
+  },
+  "settings.language.description": {
+    "defaultMessage": "選擇你偏好的{platform}語言。翻譯由 <crowdin-link>Crowdin</crowdin-link> 上的志願者所貢獻。"
+  },
+  "settings.language.languages.search-field.placeholder": {
+    "defaultMessage": "搜尋語言..."
+  },
+  "settings.language.languages.search-results-announcement": {
+    "defaultMessage": "{matches, plural, =0 {未搜尋到相關語言} other {有 # 個語言符合搜尋字詞}}。"
+  },
+  "settings.language.languages.search.no-results": {
+    "defaultMessage": "沒有語言符合你的搜尋字詞。"
+  },
+  "settings.language.platform.app": {
+    "defaultMessage": "應用程式"
+  },
+  "settings.language.platform.site": {
+    "defaultMessage": "網站"
+  },
+  "settings.language.title": {
+    "defaultMessage": "語言"
+  },
+  "settings.language.warning": {
+    "defaultMessage": "變更{platform}的語言後，若部分內容尚未提供翻譯，則會以英文顯示。{platform}目前尚未完全翻譯，因此，在某些語言下，部分內容仍可能以英文顯示。"
+  },
+  "settings.pats.title": {
+    "defaultMessage": "個人存取權杖"
+  },
+  "settings.profile.title": {
+    "defaultMessage": "公開個人檔案"
+  },
+  "settings.sessions.title": {
+    "defaultMessage": "工作階段"
+  },
+  "tag.category.128x": {
+    "defaultMessage": "128x"
+  },
+  "tag.category.16x": {
+    "defaultMessage": "16x"
+  },
+  "tag.category.256x": {
+    "defaultMessage": "256x"
+  },
+  "tag.category.32x": {
+    "defaultMessage": "32x"
+  },
+  "tag.category.48x": {
+    "defaultMessage": "48x"
+  },
+  "tag.category.512x+": {
+    "defaultMessage": "512× 以上"
+  },
+  "tag.category.64x": {
+    "defaultMessage": "64x"
+  },
+  "tag.category.8x-": {
+    "defaultMessage": "8× 以下"
+  },
+  "tag.category.adventure": {
+    "defaultMessage": "冒險"
+  },
+  "tag.category.adventure-mode": {
+    "defaultMessage": "冒險模式"
+  },
+  "tag.category.anarchy": {
+    "defaultMessage": "無政府"
+  },
+  "tag.category.atmosphere": {
+    "defaultMessage": "大氣效果"
+  },
+  "tag.category.audio": {
+    "defaultMessage": "音效"
+  },
+  "tag.category.battle-royale": {
+    "defaultMessage": "大逃殺"
+  },
+  "tag.category.bedwars": {
+    "defaultMessage": "床戰"
+  },
+  "tag.category.blocks": {
+    "defaultMessage": "方塊"
+  },
+  "tag.category.bloom": {
+    "defaultMessage": "泛光"
+  },
+  "tag.category.bosses": {
+    "defaultMessage": "Boss"
+  },
+  "tag.category.cartoon": {
+    "defaultMessage": "卡通"
+  },
+  "tag.category.challenging": {
+    "defaultMessage": "挑戰"
+  },
+  "tag.category.classes": {
+    "defaultMessage": "職業"
+  },
+  "tag.category.colored-lighting": {
+    "defaultMessage": "彩色光照"
+  },
+  "tag.category.combat": {
+    "defaultMessage": "戰鬥"
+  },
+  "tag.category.competitive": {
+    "defaultMessage": "競技"
+  },
+  "tag.category.core-shaders": {
+    "defaultMessage": "核心著色器"
+  },
+  "tag.category.creative-mode": {
+    "defaultMessage": "創造模式"
+  },
+  "tag.category.creator-community": {
+    "defaultMessage": "創作者社群"
+  },
+  "tag.category.crossplay": {
+    "defaultMessage": "跨平臺"
+  },
+  "tag.category.cursed": {
+    "defaultMessage": "邪門"
+  },
+  "tag.category.custom-content": {
+    "defaultMessage": "自訂內容"
+  },
+  "tag.category.decoration": {
+    "defaultMessage": "裝飾"
+  },
+  "tag.category.dungeons": {
+    "defaultMessage": "副本"
+  },
+  "tag.category.economy": {
+    "defaultMessage": "經濟"
+  },
+  "tag.category.entities": {
+    "defaultMessage": "實體"
+  },
+  "tag.category.environment": {
+    "defaultMessage": "環境"
+  },
+  "tag.category.equipment": {
+    "defaultMessage": "裝備"
+  },
+  "tag.category.factions": {
+    "defaultMessage": "派系"
+  },
+  "tag.category.fantasy": {
+    "defaultMessage": "奇幻"
+  },
+  "tag.category.foliage": {
+    "defaultMessage": "植被"
+  },
+  "tag.category.fonts": {
+    "defaultMessage": "字型"
+  },
+  "tag.category.food": {
+    "defaultMessage": "食物"
+  },
+  "tag.category.game-mechanics": {
+    "defaultMessage": "遊戲機制"
+  },
+  "tag.category.gens": {
+    "defaultMessage": "生成器"
+  },
+  "tag.category.gui": {
+    "defaultMessage": "GUI"
+  },
+  "tag.category.hardcore-mode": {
+    "defaultMessage": "極限模式"
+  },
+  "tag.category.high": {
+    "defaultMessage": "高"
+  },
+  "tag.category.items": {
+    "defaultMessage": "物品"
+  },
+  "tag.category.keep-inventory": {
+    "defaultMessage": "保留物品欄"
+  },
+  "tag.category.kitchen-sink": {
+    "defaultMessage": "大雜燴"
+  },
+  "tag.category.kitpvp": {
+    "defaultMessage": "Kit PvP"
+  },
+  "tag.category.library": {
+    "defaultMessage": "程式庫"
+  },
+  "tag.category.lifesteal": {
+    "defaultMessage": "生命竊取"
+  },
+  "tag.category.lightweight": {
+    "defaultMessage": "輕量"
+  },
+  "tag.category.locale": {
+    "defaultMessage": "在地化"
+  },
+  "tag.category.low": {
+    "defaultMessage": "低"
+  },
+  "tag.category.magic": {
+    "defaultMessage": "魔法"
+  },
+  "tag.category.management": {
+    "defaultMessage": "管理"
+  },
+  "tag.category.media": {
+    "defaultMessage": "媒體"
+  },
+  "tag.category.medium": {
+    "defaultMessage": "中"
+  },
+  "tag.category.microgames": {
+    "defaultMessage": "微型遊戲"
+  },
+  "tag.category.minigame": {
+    "defaultMessage": "小遊戲"
+  },
+  "tag.category.minigames": {
+    "defaultMessage": "小遊戲"
+  },
+  "tag.category.mmo": {
+    "defaultMessage": "MMO"
+  },
+  "tag.category.mobs": {
+    "defaultMessage": "生物"
+  },
+  "tag.category.modded": {
+    "defaultMessage": "模組支援"
+  },
+  "tag.category.models": {
+    "defaultMessage": "模型"
+  },
+  "tag.category.multiplayer": {
+    "defaultMessage": "多人遊戲"
+  },
+  "tag.category.network": {
+    "defaultMessage": "群組伺服器"
+  },
+  "tag.category.offline-mode": {
+    "defaultMessage": "離線模式"
+  },
+  "tag.category.oneblock": {
+    "defaultMessage": "一格方塊"
+  },
+  "tag.category.op": {
+    "defaultMessage": "OP"
+  },
+  "tag.category.optimization": {
+    "defaultMessage": "最佳化"
+  },
+  "tag.category.parkour": {
+    "defaultMessage": "跑酷"
+  },
+  "tag.category.path-tracing": {
+    "defaultMessage": "光線追蹤"
+  },
+  "tag.category.pbr": {
+    "defaultMessage": "PBR"
+  },
+  "tag.category.personal-worlds": {
+    "defaultMessage": "個人世界"
+  },
+  "tag.category.plots": {
+    "defaultMessage": "地塊"
+  },
+  "tag.category.pokemon": {
+    "defaultMessage": "寶可夢"
+  },
+  "tag.category.potato": {
+    "defaultMessage": "馬鈴薯"
+  },
+  "tag.category.prison": {
+    "defaultMessage": "監獄"
+  },
+  "tag.category.pve": {
+    "defaultMessage": "PvE"
+  },
+  "tag.category.pvp": {
+    "defaultMessage": "PvP"
+  },
+  "tag.category.questing": {
+    "defaultMessage": "任務"
+  },
+  "tag.category.quests": {
+    "defaultMessage": "任務"
+  },
+  "tag.category.racing": {
+    "defaultMessage": "競速"
+  },
+  "tag.category.realistic": {
+    "defaultMessage": "寫實"
+  },
+  "tag.category.recording-smp": {
+    "defaultMessage": "錄影 SMP"
+  },
+  "tag.category.reflections": {
+    "defaultMessage": "折射"
+  },
+  "tag.category.roleplay": {
+    "defaultMessage": "角色扮演"
+  },
+  "tag.category.rpg": {
+    "defaultMessage": "RPG"
+  },
+  "tag.category.screenshot": {
+    "defaultMessage": "擷圖用"
+  },
+  "tag.category.semi-realistic": {
+    "defaultMessage": "半寫實"
+  },
+  "tag.category.shadows": {
+    "defaultMessage": "陰影"
+  },
+  "tag.category.simplistic": {
+    "defaultMessage": "簡約"
+  },
+  "tag.category.skyblock": {
+    "defaultMessage": "空島生存"
+  },
+  "tag.category.smp": {
+    "defaultMessage": "SMP"
+  },
+  "tag.category.social": {
+    "defaultMessage": "社交"
+  },
+  "tag.category.storage": {
+    "defaultMessage": "儲物管理"
+  },
+  "tag.category.survival-mode": {
+    "defaultMessage": "生存模式"
+  },
+  "tag.category.teams": {
+    "defaultMessage": "團隊"
+  },
+  "tag.category.technical": {
+    "defaultMessage": "技術性"
+  },
+  "tag.category.technology": {
+    "defaultMessage": "科技"
+  },
+  "tag.category.themed": {
+    "defaultMessage": "特定主題"
+  },
+  "tag.category.towns": {
+    "defaultMessage": "城鎮"
+  },
+  "tag.category.transportation": {
+    "defaultMessage": "交通"
+  },
+  "tag.category.tweaks": {
+    "defaultMessage": "微調"
+  },
+  "tag.category.utility": {
+    "defaultMessage": "工具"
+  },
+  "tag.category.vanilla-like": {
+    "defaultMessage": "類原版"
+  },
+  "tag.category.whitelisted": {
+    "defaultMessage": "白名單"
+  },
+  "tag.category.world-resets": {
+    "defaultMessage": "世界重設"
+  },
+  "tag.category.worldgen": {
+    "defaultMessage": "世界生成"
+  },
+  "tag.loader.babric": {
+    "defaultMessage": "Babric"
+  },
+  "tag.loader.bta-babric": {
+    "defaultMessage": "BTA（Babric）"
+  },
+  "tag.loader.bukkit": {
+    "defaultMessage": "Bukkit"
+  },
+  "tag.loader.bungeecord": {
+    "defaultMessage": "BungeeCord"
+  },
+  "tag.loader.canvas": {
+    "defaultMessage": "Canvas"
+  },
+  "tag.loader.datapack": {
+    "defaultMessage": "資料包"
+  },
+  "tag.loader.fabric": {
+    "defaultMessage": "Fabric"
+  },
+  "tag.loader.folia": {
+    "defaultMessage": "Folia"
+  },
+  "tag.loader.forge": {
+    "defaultMessage": "Forge"
+  },
+  "tag.loader.geyser": {
+    "defaultMessage": "Geyser 擴充"
+  },
+  "tag.loader.iris": {
+    "defaultMessage": "Iris"
+  },
+  "tag.loader.java-agent": {
+    "defaultMessage": "Java 代理"
+  },
+  "tag.loader.legacy-fabric": {
+    "defaultMessage": "Legacy Fabric"
+  },
+  "tag.loader.liteloader": {
+    "defaultMessage": "LiteLoader"
+  },
+  "tag.loader.minecraft": {
+    "defaultMessage": "資源包"
+  },
+  "tag.loader.modloader": {
+    "defaultMessage": "Risugami's ModLoader"
+  },
+  "tag.loader.mrpack": {
+    "defaultMessage": "模組包"
+  },
+  "tag.loader.neoforge": {
+    "defaultMessage": "NeoForge"
+  },
+  "tag.loader.nilloader": {
+    "defaultMessage": "NilLoader"
+  },
+  "tag.loader.optifine": {
+    "defaultMessage": "OptiFine"
+  },
+  "tag.loader.ornithe": {
+    "defaultMessage": "Ornithe"
+  },
+  "tag.loader.paper": {
+    "defaultMessage": "Paper"
+  },
+  "tag.loader.purpur": {
+    "defaultMessage": "Purpur"
+  },
+  "tag.loader.quilt": {
+    "defaultMessage": "Quilt"
+  },
+  "tag.loader.rift": {
+    "defaultMessage": "Rift"
+  },
+  "tag.loader.spigot": {
+    "defaultMessage": "Spigot"
+  },
+  "tag.loader.sponge": {
+    "defaultMessage": "Sponge"
+  },
+  "tag.loader.vanilla": {
+    "defaultMessage": "原版著色器"
+  },
+  "tag.loader.velocity": {
+    "defaultMessage": "Velocity"
+  },
+  "tag.loader.waterfall": {
+    "defaultMessage": "Waterfall"
+  },
+  "time-frame-picker.apply": {
+    "defaultMessage": "套用"
+  },
+  "time-frame-picker.cancel": {
+    "defaultMessage": "取消"
+  },
+  "time-frame-picker.clear-range": {
+    "defaultMessage": "清除"
+  },
+  "time-frame-picker.custom-range": {
+    "defaultMessage": "自訂日期範圍..."
+  },
+  "time-frame-picker.decrease-amount": {
+    "defaultMessage": "減少時間範圍時長"
+  },
+  "time-frame-picker.empty-range": {
+    "defaultMessage": "未選取日期範圍。"
+  },
+  "time-frame-picker.end-date": {
+    "defaultMessage": "結束日期"
+  },
+  "time-frame-picker.increase-amount": {
+    "defaultMessage": "增加時間範圍時長"
+  },
+  "time-frame-picker.last-timeframe": {
+    "defaultMessage": "在過去 {amount} {unit, select, hours {{amount, plural, other {小時}}} days {{amount, plural, other {天}}} weeks {{amount, plural, other {週}}} months {{amount, plural, other {月}}} other {天}}"
+  },
+  "time-frame-picker.last-timeframe-prefix": {
+    "defaultMessage": "在過去"
+  },
+  "time-frame-picker.option.all-time": {
+    "defaultMessage": "所有時間"
+  },
+  "time-frame-picker.option.last-14-days": {
+    "defaultMessage": "過去 14 天"
+  },
+  "time-frame-picker.option.last-180-days": {
+    "defaultMessage": "過去 180 天"
+  },
+  "time-frame-picker.option.last-30-days": {
+    "defaultMessage": "過去 30 天"
+  },
+  "time-frame-picker.option.last-7-days": {
+    "defaultMessage": "過去 7 天"
+  },
+  "time-frame-picker.option.last-90-days": {
+    "defaultMessage": "過去 90 天"
+  },
+  "time-frame-picker.option.today": {
+    "defaultMessage": "今天"
+  },
+  "time-frame-picker.option.year-to-date": {
+    "defaultMessage": "今年迄今"
+  },
+  "time-frame-picker.option.yesterday": {
+    "defaultMessage": "昨天"
+  },
+  "time-frame-picker.select-timeframe": {
+    "defaultMessage": "選取時間範圍"
+  },
+  "time-frame-picker.selected-range": {
+    "defaultMessage": "選取範圍"
+  },
+  "time-frame-picker.selecting-range": {
+    "defaultMessage": "選取中"
+  },
+  "time-frame-picker.start-date": {
+    "defaultMessage": "開始日期"
+  },
+  "time-frame-picker.timeframe-amount": {
+    "defaultMessage": "時間範圍時長"
+  },
+  "time-frame-picker.timeframe-unit": {
+    "defaultMessage": "時間範圍單位"
+  },
+  "time-frame-picker.unit.days": {
+    "defaultMessage": "天"
+  },
+  "time-frame-picker.unit.hours": {
+    "defaultMessage": "小時"
+  },
+  "time-frame-picker.unit.months": {
+    "defaultMessage": "月"
+  },
+  "time-frame-picker.unit.weeks": {
+    "defaultMessage": "週"
+  },
+  "ui.component.unsaved-changes-popup.body": {
+    "defaultMessage": "你的變更尚未儲存。"
+  },
+  "ui.confirm-leave-modal.body": {
+    "defaultMessage": "您有未儲存的變更，如果離開此頁面將會遺失"
+  },
+  "ui.confirm-leave-modal.header": {
+    "defaultMessage": "您有未儲存的變更"
+  },
+  "ui.confirm-leave-modal.leave": {
+    "defaultMessage": "離開頁面"
+  },
+  "ui.confirm-leave-modal.stay": {
+    "defaultMessage": "留在頁面"
+  },
+  "ui.confirm-leave-modal.title": {
+    "defaultMessage": "離開頁面？"
+  },
+  "ui.stacked-admonitions.alert-count": {
+    "defaultMessage": "{count, plural, other {# 個警示}}"
+  },
+  "ui.stacked-admonitions.dismiss-all": {
+    "defaultMessage": "忽略全部"
+  },
+  "version.content.name": {
+    "defaultMessage": "名稱"
+  },
+  "version.content.version": {
+    "defaultMessage": "版本"
+  },
+  "version.file-type.dev-jar": {
+    "defaultMessage": "開發用 jar"
+  },
+  "version.file-type.javadoc-jar": {
+    "defaultMessage": "Javadoc jar"
+  },
+  "version.file-type.optional-resource-pack": {
+    "defaultMessage": "可選資源包"
+  },
+  "version.file-type.primary": {
+    "defaultMessage": "主要"
+  },
+  "version.file-type.required-resource-pack": {
+    "defaultMessage": "所需資源包"
+  },
+  "version.file-type.signature": {
+    "defaultMessage": "簽署文件"
+  },
+  "version.file-type.sources-jar": {
+    "defaultMessage": "原始碼 jar"
+  },
+  "version.file-type.unknown": {
+    "defaultMessage": "其他"
+  },
+  "version.section.changes": {
+    "defaultMessage": "變更"
+  },
+  "version.section.compatibility": {
+    "defaultMessage": "相容性"
+  },
+  "version.section.content": {
+    "defaultMessage": "內容"
+  },
+  "version.section.content.search-placeholder": {
+    "defaultMessage": "搜尋內容..."
+  },
+  "version.section.dependencies.any-compatible-version": {
+    "defaultMessage": "任何相容的版本"
+  },
+  "version.section.dependencies.any-version": {
+    "defaultMessage": "任何版本"
+  },
+  "version.section.dependencies.unavailable-version": {
+    "defaultMessage": "不可用版本"
+  },
+  "version.section.dependencies.unavailable-version.description": {
+    "defaultMessage": "這個版本可能已被刪除，或正在由管理員審查。"
+  },
+  "version.section.dependencies.unavailable-version.description.required": {
+    "defaultMessage": "所需版本可能已被刪除，或正在由管理員審查。"
+  },
+  "version.section.files": {
+    "defaultMessage": "檔案"
+  },
+  "version.section.included-content": {
+    "defaultMessage": "包含的內容"
+  },
+  "version.section.known-incompatibilities": {
+    "defaultMessage": "已知不相容"
+  },
+  "version.section.no-changes": {
+    "defaultMessage": "未提供變更日誌。"
+  },
+  "version.section.no-modpack-mod-loader": {
+    "defaultMessage": "無模組載入器"
+  },
+  "version.section.optional-dependencies": {
+    "defaultMessage": "可選相依項"
+  },
+  "version.section.required-content": {
+    "defaultMessage": "所需內容"
+  },
+  "version.section.supplementary-resources": {
+    "defaultMessage": "補充資源"
+  },
+  "version.supplementary-resources.file": {
+    "defaultMessage": "檔案"
+  },
+  "version.supplementary-resources.size": {
+    "defaultMessage": "檔案大小"
+  },
+  "version.supplementary-resources.type": {
+    "defaultMessage": "類型"
+  },
+  "files.row.parent-folder": {
+    "message": "Parent folder"
+  },
+  "omorphia.component.loading-indicator.label": {
+    "message": "Loading"
+  },
+  "drop.confirm.title": {
+    "message": "你想以什麼類型匯入？"
+  },
+  "drop.confirm.cancel": {
+    "message": "取消"
+  },
+  "drop.confirm.help": {
+    "message": "我可以拖入什麼？"
+  },
+  "drop.confirm.as-mod": {
+    "message": "模組"
+  },
+  "drop.confirm.as-mod-desc": {
+    "message": "將模組 JAR 安裝到 Minecraft 實例"
+  },
+  "drop.confirm.as-instance": {
+    "message": "實例"
+  },
+  "drop.confirm.as-instance-desc": {
+    "message": "從其他啟動器匯入 Minecraft 實例"
+  },
+  "drop.confirm.as-modpack": {
+    "message": "整合包"
+  },
+  "drop.confirm.as-modpack-desc": {
+    "message": "從整合包建立新實例"
+  },
+  "drop.confirm.as-resource-pack": {
+    "message": "資源包"
+  },
+  "drop.confirm.as-resource-pack-desc": {
+    "message": "將資源包安裝到實例"
+  },
+  "drop.confirm.as-shader-pack": {
+    "message": "光影包"
+  },
+  "drop.confirm.as-shader-pack-desc": {
+    "message": "將光影包安裝到實例"
+  },
+  "drop.confirm.as-world": {
+    "message": "存檔"
+  },
+  "drop.confirm.as-world-desc": {
+    "message": "將存檔匯入到實例中"
+  },
+  "drop.confirm.as-schematic": {
+    "message": "投影"
+  },
+  "drop.confirm.as-schematic-desc": {
+    "message": "匯入 Litematic 投影檔案"
+  },
+  "drop.confirm.as-dot-minecraft": {
+    "message": ".minecraft"
+  },
+  "drop.confirm.as-dot-minecraft-desc": {
+    "message": "掃描 .minecraft 資料夾以建立實例"
+  },
+  "drop.confirm.as-launcher": {
+    "message": "啟動器"
+  },
+  "drop.confirm.as-hmcl-launcher": {
+    "message": "HMCL 啟動器"
+  },
+  "drop.generic_install.title": {
+    "message": "安裝 {type}"
+  },
+  "drop.generic_install.search": {
+    "message": "搜尋實例..."
+  },
+  "drop.generic_install.install": {
+    "message": "安裝"
+  },
+  "drop.generic_install.cancel": {
+    "message": "取消"
+  },
+  "drop.generic_install.create_new": {
+    "message": "建立新實例..."
+  },
+  "drop.generic_install.no_instances": {
+    "message": "找不到實例"
+  },
+  "drop.launcher_import.title": {
+    "message": "從 {launcherName} 匯入實例"
+  },
+  "drop.launcher_import.subtitle": {
+    "message": "在 {basePath} 中掃描到 {count} 個實例"
+  },
+  "drop.launcher_import.select_all": {
+    "message": "全選"
+  },
+  "drop.launcher_import.deselect_all": {
+    "message": "取消全選"
+  },
+  "drop.launcher_import.selected": {
+    "message": "已選 {n} 個"
+  },
+  "drop.launcher_import.cancel": {
+    "message": "取消"
+  },
+  "drop.launcher_import.import": {
+    "message": "匯入（{n}）"
+  },
+  "drop.launcher_import.no_instances": {
+    "message": "找不到實例"
+  },
+  "drop.symlink_method.title": {
+    "message": "選擇匯入方式"
+  },
+  "drop.symlink_method.subtitle": {
+    "message": "正在匯入 {n} 個實例"
+  },
+  "drop.symlink_method.copy_title": {
+    "message": "複製檔案"
+  },
+  "drop.symlink_method.copy_desc": {
+    "message": "複製到 Axolotl 目錄"
+  },
+  "drop.symlink_method.symlink_title": {
+    "message": "符號連結"
+  },
+  "drop.symlink_method.symlink_desc": {
+    "message": "引用原始位置"
+  },
+  "drop.symlink_method.requires_admin": {
+    "message": "建立連結時將要求一次系統管理員授權（UAC）"
+  },
+  "drop.symlink_method.unsupported_warning": {
+    "message": "此系統不支援符號連結"
+  },
+  "drop.symlink_method.cancel": {
+    "message": "取消"
+  },
+  "drop.symlink_method.confirm": {
+    "message": "確認"
+  },
+  "project.versions.filter.toggle-tooltip": {
+    "message": "Toggle filter for {filter}"
+  },
+  "project.versions.platform.modloader.short": {
+    "message": "ModLoader"
+  },
+  "skin.preview.drag-to-rotate": {
+    "message": "Drag to rotate"
+  },
+  "browse.sort.relevance": {
+    "message": "Relevance"
+  },
+  "browse.sort.downloads": {
+    "message": "Downloads"
+  },
+  "browse.sort.followers": {
+    "message": "Followers"
+  },
+  "browse.sort.date-published": {
+    "message": "Date published"
+  },
+  "browse.sort.date-updated": {
+    "message": "Date updated"
+  },
+  "browse.sort.verified-plays": {
+    "message": "Verified plays"
+  },
+  "browse.sort.players": {
+    "message": "Players"
+  },
+  "content.card.pending-manual-download": {
+    "message": "Manual download required"
+  },
+  "content.card.rollback-tooltip": {
+    "defaultMessage": "回滾到 {fileName}"
+  },
+  "app.symlink-warning.write.header": {
+    "message": "Shared instance"
+  },
+  "app.symlink-warning.write.body": {
+    "message": "This instance is linked to "
+  },
+  "instances.updater-modal.search-compat": {
+    "message": "尋找相容版本"
+  },
+  "files.delete-modal.bulk-header": {
+    "message": "Delete multiple items"
+  },
+  "files.delete-modal.deleting-multiple": {
+    "message": "Deleting {count} items"
+  },
+  "files.delete-modal.bulk-warning": {
+    "message": "The selected items will be permanently deleted. This action cannot be undone."
+  },
+  "files.delete-modal.symlink-warning-header": {
+    "message": "Shared instance"
+  },
+  "files.delete-modal.symlink-warning-body": {
+    "message": "You are modifying files in a shared instance linked to "
+  },
+  "button.open-in-browser": {
+    "message": "Open in browser"
+  },
+  "label.server-only": {
+    "message": "Server only"
+  },
+  "button.switch-to-version": {
+    "message": "Switch to version"
+  },
+  "project-type.schematic.category": {
+    "message": "投影"
+  },
+  "project-type.schematic.capital": {
+    "message": "{count, plural, one {投影} other {投影}}"
+  },
+  "project-type.schematic.lowercase": {
+    "message": "{count, plural, one {投影} other {投影}}"
+  },
+  "search.filter_type.advanced.exclude_mod": {
+    "message": "Exclude mods"
+  },
+  "search.filter_type.advanced.exclude_plugin": {
+    "message": "Exclude plugins"
+  },
+  "search.filter_type.advanced.exclude_datapack": {
+    "message": "Exclude data packs"
+  },
+  "search.filter_type.advanced": {
+    "message": "Advanced"
+  },
+  "header.category.cf-extra": {
+    "message": "More CurseForge categories"
+  },
+  "project.environment.tag.not-applicable": {
+    "defaultMessage": "不適用"
+  },
+  "project.environment.tag.unknown": {
+    "defaultMessage": "未知"
+  },
+  "browse.selected-projects-floating-bar.hide-projects": {
+    "defaultMessage": "隱藏已選專案"
+  },
+  "browse.selected-projects-floating-bar.show-projects": {
+    "defaultMessage": "顯示{count, plural, other {#個已選專案}}"
+  },
+  "console.notification.share-truncated": {
+    "defaultMessage": "日誌過大，已自動擷取最後 9MB 上傳。"
+  },
+  "console.log.toggle-wrap": {
+    "defaultMessage": "切換換行"
+  },
+  "console.log.wrap-label": {
+    "defaultMessage": "換行"
+  },
+  "console.empty.instance-title": {
+    "defaultMessage": "暫無日誌"
+  },
+  "console.empty.instance-description": {
+    "defaultMessage": "點選右上角「開始遊戲」即可接收實時日誌"
+  },
+  "console.empty.server-title": {
+    "defaultMessage": "歡迎使用 Modrinth 伺服器！"
+  },
+  "console.empty.server-description": {
+    "defaultMessage": "點選啟動按鈕即可啟動伺服器！"
+  },
+  "content.card.dependency-badge": {
+    "defaultMessage": "前置"
+  },
+  "content.card.duplicate-mod": {
+    "defaultMessage": "此模組已安裝 {count, number} 次。"
+  },
+  "content.card.group.hardcore": {
+    "defaultMessage": "硬核模式"
+  },
+  "content.card.group.not-played-yet": {
+    "defaultMessage": "尚未遊玩"
+  },
+  "content.card.orphaned-dependency-badge": {
+    "defaultMessage": "孤立前置"
+  },
+  "content.filter.duplicates": {
+    "defaultMessage": "重複"
+  },
+  "content.metadata-filter.author": {
+    "defaultMessage": "作者"
+  },
+  "content.metadata-filter.clear": {
+    "defaultMessage": "清除"
+  },
+  "content.metadata-filter.environment": {
+    "defaultMessage": "環境"
+  },
+  "content.metadata-filter.environment.client": {
+    "defaultMessage": "客戶端"
+  },
+  "content.metadata-filter.environment.client-and-server": {
+    "defaultMessage": "客戶端和服務端"
+  },
+  "content.metadata-filter.environment.server": {
+    "defaultMessage": "服務端"
+  },
+  "content.metadata-filter.environment.singleplayer": {
+    "defaultMessage": "單人遊戲"
+  },
+  "content.metadata-filter.external": {
+    "defaultMessage": "外部檔案"
+  },
+  "content.metadata-filter.external.external": {
+    "defaultMessage": "外部檔案"
+  },
+  "content.metadata-filter.external.linked": {
+    "defaultMessage": "線上專案"
+  },
+  "content.metadata-filter.loader": {
+    "defaultMessage": "載入器"
+  },
+  "content.metadata-filter.loader.fabric": {
+    "defaultMessage": "Fabric"
+  },
+  "content.metadata-filter.loader.forge": {
+    "defaultMessage": "Forge"
+  },
+  "content.metadata-filter.loader.neoforge": {
+    "defaultMessage": "NeoForge"
+  },
+  "content.metadata-filter.loader.other": {
+    "defaultMessage": "其他"
+  },
+  "content.metadata-filter.loader.quilt": {
+    "defaultMessage": "Quilt"
+  },
+  "content.metadata-filter.long-press-reset": {
+    "defaultMessage": "長按重置篩選"
+  },
+  "content.metadata-filter.open-source": {
+    "defaultMessage": "開源"
+  },
+  "content.metadata-filter.open-source.closed": {
+    "defaultMessage": "非開源"
+  },
+  "content.metadata-filter.open-source.open": {
+    "defaultMessage": "開源"
+  },
+  "content.metadata-filter.search": {
+    "defaultMessage": "搜尋..."
+  },
+  "content.metadata-filter.select-all": {
+    "defaultMessage": "全選"
+  },
+  "content.metadata-filter.source": {
+    "defaultMessage": "來源"
+  },
+  "content.metadata-filter.source.curseforge": {
+    "defaultMessage": "CurseForge"
+  },
+  "content.metadata-filter.source.imported-modpack": {
+    "defaultMessage": "匯入整合包"
+  },
+  "content.metadata-filter.source.local": {
+    "defaultMessage": "本地"
+  },
+  "content.metadata-filter.source.modrinth-modpack": {
+    "defaultMessage": "Modrinth 整合包"
+  },
+  "content.metadata-filter.source.server-project": {
+    "defaultMessage": "伺服器專案"
+  },
+  "content.metadata-filter.source.shared-instance": {
+    "defaultMessage": "共享例項"
+  },
+  "content.metadata-filter.state": {
+    "defaultMessage": "狀態"
+  },
+  "content.metadata-filter.state.disabled": {
+    "defaultMessage": "已禁用"
+  },
+  "content.metadata-filter.state.enabled": {
+    "defaultMessage": "已啟用"
+  },
+  "content.metadata-filter.toggle": {
+    "defaultMessage": "篩選"
+  },
+  "content.metadata-filter.toggle-active": {
+    "defaultMessage": "篩選（已啟用 {count, number} 項）"
+  },
+  "content.metadata-filter.unknown": {
+    "defaultMessage": "未知"
+  },
+  "content.metadata-filter.update.available": {
+    "defaultMessage": "可更新"
+  },
+  "content.metadata-filter.update.up-to-date": {
+    "defaultMessage": "已是最新"
+  },
+  "content.metadata-filter.updates": {
+    "defaultMessage": "更新"
+  },
+  "content.page-layout.sort.file-name-ascending": {
+    "defaultMessage": "檔名 A-Z"
+  },
+  "content.page-layout.sort.file-name-descending": {
+    "defaultMessage": "檔名 Z-A"
+  },
+  "content.page-layout.sort.project-name-ascending": {
+    "defaultMessage": "專案名稱 A-Z"
+  },
+  "content.page-layout.sort.project-name-descending": {
+    "defaultMessage": "專案名稱 Z-A"
+  },
+  "content.page-layout.pin-view": {
+    "defaultMessage": "固定當前檢視"
+  },
+  "content.page-layout.reset-view": {
+    "defaultMessage": "重置檢視"
+  },
+  "content.page-layout.unpin-view": {
+    "defaultMessage": "取消固定當前檢視"
+  },
+  "content.page-layout.view-options": {
+    "defaultMessage": "檢視選項"
+  },
+  "creation-flow.modal.custom-setup.adjunct.hint": {
+    "defaultMessage": "下載前會自動選擇相容版本。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.checking-compatibility": {
+    "defaultMessage": "正在檢查相容性……"
+  },
+  "creation-flow.modal.custom-setup.adjunct.compatibility-load-failed": {
+    "defaultMessage": "無法驗證 {loader} 的相容性。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.label": {
+    "defaultMessage": "附加載入器"
+  },
+  "creation-flow.modal.custom-setup.adjunct.optifabric-load-failed": {
+    "defaultMessage": "無法驗證 OptiFabric 相容性。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.optifabric-unsupported": {
+    "defaultMessage": "OptiFine 需要 OptiFabric，但當前遊戲版本沒有相容版本。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.primary-unsupported": {
+    "defaultMessage": "所選主載入器不支援當前遊戲版本。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.select-game-version": {
+    "defaultMessage": "請先選擇遊戲版本以檢查相容性。"
+  },
+  "creation-flow.modal.custom-setup.adjunct.unsupported": {
+    "defaultMessage": "{loader} 沒有支援當前遊戲版本的相容版本。"
+  },
+  "creation-flow.modal.custom-setup.loader.compatibility-load-failed": {
+    "defaultMessage": "無法驗證載入器相容性"
+  },
+  "creation-flow.modal.import-instance.import-prompt": {
+    "defaultMessage": "拖拽啟動器資料夾、整合包檔案或 .minecraft 資料夾即可一鍵匯入例項"
+  },
+  "creation-flow.modal.import-instance.select-file": {
+    "defaultMessage": "選擇要匯入的檔案"
+  },
+  "files.editor.share-truncated-warning": {
+    "defaultMessage": "日誌檔案過大，已自動擷取最後 9MB 上傳。"
+  },
+  "files.navbar.share-log": {
+    "defaultMessage": "分享日誌"
+  },
+  "installation-settings.loader-version.error": {
+    "defaultMessage": "載入載入器版本資料失敗"
+  },
+  "installation-settings.loader-version.unsupported": {
+    "defaultMessage": "此載入器不支援所選遊戲版本"
+  },
+  "multiselect.selection-actions.label": {
+    "defaultMessage": "已選 {count, number} 項"
+  },
+  "project.about.links.mcmod": {
+    "defaultMessage": "MC Mod"
+  },
+  "project.versions.table.downloads": {
+    "defaultMessage": "下載量"
+  },
+  "project.versions.table.environment": {
+    "defaultMessage": "執行環境"
+  },
+  "project.versions.table.game-version": {
+    "defaultMessage": "遊戲版本"
+  },
+  "project.versions.table.platform": {
+    "defaultMessage": "平臺"
+  },
+  "project.versions.table.published": {
+    "defaultMessage": "釋出時間"
+  },
+  "project.versions.table.version": {
+    "defaultMessage": "版本"
+  },
+  "project.versions.filter.projectChannels": {
+    "defaultMessage": "更新通道"
+  },
+  "project.versions.filter.gameVersions": {
+    "defaultMessage": "遊戲版本"
+  },
+  "drop.confirm.not-this": {
+    "message": "作为其他内容导入"
+  },
+  "app.drop.batch.scan.title": {
+    "message": "正在识别 {count, plural, one {# 个文件} other {# 个文件}}…"
+  },
+  "app.drop.batch.scan.subtitle": {
+    "message": "已识别 {done} / {total}"
+  },
+  "app.drop.batch.scan.cancel": {
+    "message": "取消"
+  },
+  "app.drop.batch.scan.pending": {
+    "message": "等待"
+  },
+  "app.drop.batch.scan.scanning": {
+    "message": "扫描中"
+  },
+  "app.drop.batch.scan.done": {
+    "message": "已识别"
+  },
+  "app.drop.batch.scan.skipped": {
+    "message": "已跳过"
+  },
+  "app.drop.batch.scan.error": {
+    "message": "失败"
+  },
+  "drop.symlink_method.reset_changes": {
+    "message": "重置更改"
+  },
+  "drop.symlink_method.next": {
+    "message": "下一步"
+  },
+  "drop.symlink_method.instance_nav_label": {
+    "message": "切换到 {name}"
+  },
+  "drop.symlink_method.detecting": {
+    "message": "检测中..."
+  },
+  "drop.symlink_method.game_version": {
+    "message": "游戏版本"
+  },
+  "drop.symlink_method.import_path": {
+    "message": "版本路径"
+  },
+  "drop.symlink_method.import_path_tooltip": {
+    "message": "导入路径"
+  },
+  "drop.symlink_method.instance": {
+    "message": "实例"
+  },
+  "drop.symlink_method.loader": {
+    "message": "加载器"
+  },
+  "drop.symlink_method.loader_type_unknown_tooltip": {
+    "message": "此版本安装有Mod，但未识别到加载器。"
+  },
+  "drop.symlink_method.loader_version": {
+    "message": "加载器版本"
+  },
+  "drop.symlink_method.loader_version_unknown_tooltip": {
+    "message": "未检测到加载器版本，将使用自定义版本。"
+  },
+  "drop.symlink_method.latest": {
+    "message": "最新"
+  },
+  "drop.symlink_method.method": {
+    "message": "导入方式"
+  },
+  "drop.symlink_method.missing": {
+    "message": "缺失"
+  },
+  "drop.symlink_method.missing_path": {
+    "message": "没有可用的导入路径"
+  },
+  "drop.symlink_method.not_available": {
+    "message": "不可用"
+  },
+  "drop.symlink_method.plan_failed": {
+    "message": "未能估算进度"
+  },
+  "drop.symlink_method.unrecognized": {
+    "message": "未识别"
+  },
+  "drop.symlink_method.custom": {
+    "message": "自定义"
+  },
+  "drop.symlink_method.custom_tooltip": {
+    "message": "通常您不应该自定义它，除非您确认它识别错误。"
+  },
+  "drop.symlink_method.runtime_root": {
+    "message": "根目录"
+  },
+  "drop.symlink_method.runtime_root_tooltip": {
+    "message": "Runtime 根目录"
+  },
+  "drop.symlink_method.search_game_version": {
+    "message": "搜索游戏版本"
+  },
+  "drop.symlink_method.search_loader_version": {
+    "message": "搜索加载器版本"
+  },
+  "drop.symlink_method.select_game_version": {
+    "message": "选择游戏版本"
+  },
+  "drop.symlink_method.select_instance": {
+    "message": "选择实例"
+  },
+  "drop.symlink_method.select_loader_version": {
+    "message": "选择加载器版本"
+  },
+  "drop.symlink_method.stats": {
+    "message": "估计"
+  },
+  "drop.symlink_method.stats_cache": {
+    "message": "缓存"
+  },
+  "drop.symlink_method.stats_cache_tooltip": {
+    "message": "Axolotl 缓存"
+  },
+  "drop.symlink_method.stats_local": {
+    "message": "复用"
+  },
+  "drop.symlink_method.stats_local_tooltip": {
+    "message": "本地复用"
+  },
+  "drop.symlink_method.stats_migrate": {
+    "message": "迁移"
+  },
+  "drop.symlink_method.stats_migrate_tooltip": {
+    "message": "需要迁移"
+  },
+  "drop.symlink_method.stats_files": {
+    "message": "{files} 个文件"
+  },
+  "drop.symlink_method.stats_network": {
+    "message": "下载"
+  },
+  "drop.symlink_method.stats_network_tooltip": {
+    "message": "需要下载"
+  },
+  "creation-flow.modal.import-instance.select-folder.description": {
+    "defaultMessage": "匯入啟動器資料夾或 .minecraft 資料夾"
+  },
+  "creation-flow.modal.import-instance.select-folder": {
+    "defaultMessage": "選擇要匯入的資料夾"
+  },
+  "creation-flow.modal.import-instance.select-file.description": {
+    "defaultMessage": "匯入整合包檔案或啟動器(HMCL、PCL)"
+  },
+  "drop.confirm.as-data-pack": {
+    "defaultMessage": "資料包"
+  },
+  "drop.confirm.as-data-pack-desc": {
+    "defaultMessage": "將資料包安裝到存檔"
+  },
+  "app.translation-settings.provider.deepl": "DeepL 翻译",
+  "app.settings.updates.miawa": "柠泽镜像"
 }

--- a/packages/ui/src/locales/zh-TW/index.json
+++ b/packages/ui/src/locales/zh-TW/index.json
@@ -1,4085 +1,4504 @@
 {
-  "action.no-permission": {
-    "defaultMessage": "你沒有權限。"
-  },
-  "badge.alpha": {
-    "defaultMessage": "Alpha 版"
-  },
-  "badge.beta": {
-    "defaultMessage": "Beta 版"
-  },
-  "badge.beta-release": {
-    "defaultMessage": "Beta 版發布"
-  },
-  "badge.new": {
-    "defaultMessage": "新功能"
-  },
-  "badge.release": {
-    "defaultMessage": "正式版"
-  },
-  "browse.filter-results": {
-    "defaultMessage": "篩選結果..."
-  },
-  "browse.no-results": {
-    "defaultMessage": "找不到符合你查詢的結果！"
-  },
-  "browse.offline": {
-    "defaultMessage": "你目前處於離線狀態，請連線至網路以瀏覽 Modrinth！"
-  },
-  "browse.search.placeholder": {
-    "defaultMessage": "搜尋{projectType}..."
-  },
-  "browse.selected-projects-floating-bar.aria-label": {
-    "defaultMessage": "已選取專案"
-  },
-  "browse.selected-projects-floating-bar.install": {
-    "defaultMessage": "安裝 {count, plural, other {# 個專案}}"
-  },
-  "browse.selected-projects-floating-bar.selected-count": {
-    "defaultMessage": "{count, plural, other {已選取 # 個專案}}"
-  },
-  "browse.selected-projects-leave-modal.admonition-body": {
-    "defaultMessage": "你已選取 {count, plural, other {# 個專案}}來安裝。立即安裝專案，或返回而不安裝。"
-  },
-  "browse.selected-projects-leave-modal.admonition-header": {
-    "defaultMessage": "你選取的專案尚未安裝"
-  },
-  "browse.selected-projects-leave-modal.discard": {
-    "defaultMessage": "捨棄"
-  },
-  "browse.selected-projects-leave-modal.header": {
-    "defaultMessage": "你選取的專案尚未安裝"
-  },
-  "browse.view-prefix": {
-    "defaultMessage": "檢視模式："
-  },
-  "button.accept": {
-    "defaultMessage": "接受"
-  },
-  "button.add-server-to-instance": {
-    "defaultMessage": "將伺服器新增至實例"
-  },
-  "button.affiliate-links": {
-    "defaultMessage": "聯盟連結"
-  },
-  "button.analytics": {
-    "defaultMessage": "數據分析"
-  },
-  "button.back": {
-    "defaultMessage": "返回"
-  },
-  "button.cancel": {
-    "defaultMessage": "取消"
-  },
-  "button.change-version": {
-    "defaultMessage": "變更版本"
-  },
-  "button.clear": {
-    "defaultMessage": "清除"
-  },
-  "button.close": {
-    "defaultMessage": "關閉"
-  },
-  "button.continue": {
-    "defaultMessage": "繼續"
-  },
-  "button.copy-filename": {
-    "defaultMessage": "複製檔案名稱"
-  },
-  "button.copy-full-path": {
-    "defaultMessage": "複製完整路徑"
-  },
-  "button.copy-id": {
-    "defaultMessage": "複製 ID"
-  },
-  "button.copy-link": {
-    "defaultMessage": "複製連結"
-  },
-  "button.copy-permalink": {
-    "defaultMessage": "複製永久連結"
-  },
-  "button.create-a-project": {
-    "defaultMessage": "建立專案"
-  },
-  "button.decline": {
-    "defaultMessage": "拒絕"
-  },
-  "button.disable": {
-    "defaultMessage": "停用"
-  },
-  "button.download": {
-    "defaultMessage": "下載"
-  },
-  "button.downloading": {
-    "defaultMessage": "下載中"
-  },
-  "button.edit": {
-    "defaultMessage": "編輯"
-  },
-  "button.enable": {
-    "defaultMessage": "啟用"
-  },
-  "button.extract": {
-    "defaultMessage": "解壓縮"
-  },
-  "button.follow": {
-    "defaultMessage": "追蹤"
-  },
-  "button.hide-snapshots": {
-    "defaultMessage": "隱藏快照版本"
-  },
-  "button.install": {
-    "defaultMessage": "安裝"
-  },
-  "button.max": {
-    "defaultMessage": "最大值"
-  },
-  "button.more-options": {
-    "defaultMessage": "更多選項"
-  },
-  "button.move": {
-    "defaultMessage": "移動"
-  },
-  "button.next": {
-    "defaultMessage": "下一步"
-  },
-  "button.open-folder": {
-    "defaultMessage": "開啟資料夾"
-  },
-  "button.open-in-folder": {
-    "defaultMessage": "在資料夾中開啟"
-  },
-  "button.open-in-modrinth": {
-    "defaultMessage": "在 Modrinth 中開啟"
-  },
-  "button.play": {
-    "defaultMessage": "遊玩"
-  },
-  "button.refresh": {
-    "defaultMessage": "重新整理"
-  },
-  "button.reinstall-modpack": {
-    "defaultMessage": "重新安裝模組包"
-  },
-  "button.remove": {
-    "defaultMessage": "刪除通行金鑰"
-  },
-  "button.remove-image": {
-    "defaultMessage": "移除圖片"
-  },
-  "button.rename": {
-    "defaultMessage": "重新命名"
-  },
-  "button.repair": {
-    "defaultMessage": "修復"
-  },
-  "button.repairing": {
-    "defaultMessage": "修復中..."
-  },
-  "button.report": {
-    "defaultMessage": "檢舉"
-  },
-  "button.reset": {
-    "defaultMessage": "重設"
-  },
-  "button.reset-server": {
-    "defaultMessage": "重設伺服器"
-  },
-  "button.retry": {
-    "defaultMessage": "重試"
-  },
-  "button.save": {
-    "defaultMessage": "儲存"
-  },
-  "button.save-changes": {
-    "defaultMessage": "儲存變更"
-  },
-  "button.saving": {
-    "defaultMessage": "儲存中"
-  },
-  "button.show-all-versions": {
-    "defaultMessage": "顯示所有版本"
-  },
-  "button.show-file": {
-    "defaultMessage": "顯示檔案"
-  },
-  "button.sign-in": {
-    "defaultMessage": "登入"
-  },
-  "button.sign-out": {
-    "defaultMessage": "登出"
-  },
-  "button.sign-up": {
-    "defaultMessage": "註冊"
-  },
-  "button.stop": {
-    "defaultMessage": "停止"
-  },
-  "button.switch-version": {
-    "defaultMessage": "切換版本"
-  },
-  "button.unfollow": {
-    "defaultMessage": "取消追蹤"
-  },
-  "button.unlink-modpack": {
-    "defaultMessage": "取消連結模組包"
-  },
-  "button.update": {
-    "defaultMessage": "更新"
-  },
-  "button.upload-image": {
-    "defaultMessage": "上傳圖片"
-  },
-  "collections.label.private": {
-    "defaultMessage": "私人"
-  },
-  "console.action.collapse": {
-    "defaultMessage": "收合"
-  },
-  "console.action.expand": {
-    "defaultMessage": "展開"
-  },
-  "console.action.share": {
-    "defaultMessage": "分享"
-  },
-  "console.command.disabled-placeholder": {
-    "defaultMessage": "指令輸入已停用"
-  },
-  "console.command.server-not-running-placeholder": {
-    "defaultMessage": "伺服器未執行"
-  },
-  "console.crash.export-context": {
-    "defaultMessage": "匯出崩潰內容"
-  },
-  "console.crash.finding.amd-driver.action": {
-    "defaultMessage": "全新安裝最新版 AMD 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
-  },
-  "console.crash.finding.amd-driver.title": {
-    "defaultMessage": "AMD 顯示卡驅動程式崩潰"
-  },
-  "console.crash.finding.content-verification.action": {
-    "defaultMessage": "從可信來源重新安裝證據中指出的檔案。"
-  },
-  "console.crash.finding.content-verification.title": {
-    "defaultMessage": "jar 簽章驗證失敗"
-  },
-  "console.crash.finding.definite-mod-fabric.action": {
-    "defaultMessage": "更新或暫時移除 Fabric 載入器證據中指出的模組。"
-  },
-  "console.crash.finding.definite-mod-fabric.title": {
-    "defaultMessage": "Fabric 發現特定模組故障"
-  },
-  "console.crash.finding.definite-mod.action": {
-    "defaultMessage": "更新、修復或暫時移除證據和相符 jar 中指出的模組。"
-  },
-  "console.crash.finding.definite-mod.title": {
-    "defaultMessage": "特定模組導致崩潰"
-  },
-  "console.crash.finding.duplicate-mod.action": {
-    "defaultMessage": "在 mods 資料夾中，每個模組只保留一個相容版本。"
-  },
-  "console.crash.finding.duplicate-mod.title": {
-    "defaultMessage": "安裝了重複模組"
-  },
-  "console.crash.finding.extracted-mod.action": {
-    "defaultMessage": "從 mods 資料夾移除解壓縮後的目錄，並安裝原始 jar 檔案。"
-  },
-  "console.crash.finding.extracted-mod.title": {
-    "defaultMessage": "發現已解壓縮的模組"
-  },
-  "console.crash.finding.fabric-solution.action": {
-    "defaultMessage": "依證據中列出的相依性變更處理後再啟動。"
-  },
-  "console.crash.finding.fabric-solution.title": {
-    "defaultMessage": "Fabric 發現不相容模組或缺少相依性"
-  },
-  "console.crash.finding.fallback-action": {
-    "defaultMessage": "檢視下方證據和本機實例中相符的模組。"
-  },
-  "console.crash.finding.fallback-title": {
-    "defaultMessage": "未知診斷：{finding}"
-  },
-  "console.crash.finding.forge-error.action": {
-    "defaultMessage": "檢視 Forge 故障證據，並在撤銷近期變更後測試指出的模組。"
-  },
-  "console.crash.finding.forge-error.title": {
-    "defaultMessage": "Forge 回報了遊戲錯誤"
-  },
-  "console.crash.finding.forge-incomplete.action": {
-    "defaultMessage": "修復或重新安裝此實例的 Forge 載入器。"
-  },
-  "console.crash.finding.forge-incomplete.title": {
-    "defaultMessage": "Forge 安裝不完整"
-  },
-  "console.crash.finding.forge-java-incompatible.action": {
-    "defaultMessage": "使用此 Forge 版本所需的 Java 版本，或更新 Forge。"
-  },
-  "console.crash.finding.forge-java-incompatible.title": {
-    "defaultMessage": "此 Forge 版本與所選 Java 執行環境不相容"
-  },
-  "console.crash.finding.incompatible-mods.action": {
-    "defaultMessage": "依證據中的相容性詳情更新、移除或替換衝突模組。"
-  },
-  "console.crash.finding.incompatible-mods.title": {
-    "defaultMessage": "已安裝的模組互不相容"
-  },
-  "console.crash.finding.intel-driver.action": {
-    "defaultMessage": "安裝最新版 Intel 顯示卡驅動程式，或改用其他可用 GPU 執行 Minecraft。"
-  },
-  "console.crash.finding.intel-driver.title": {
-    "defaultMessage": "Intel 顯示卡驅動程式崩潰"
-  },
-  "console.crash.finding.java-11-required.action": {
-    "defaultMessage": "選擇 Java 11，或安裝與所選 Java 版本相容的模組版本。"
-  },
-  "console.crash.finding.java-11-required.title": {
-    "defaultMessage": "模組需要 Java 11"
-  },
-  "console.crash.finding.java-32bit.action": {
-    "defaultMessage": "安裝並選擇 64 位元 Java 執行環境，然後重試啟動。"
-  },
-  "console.crash.finding.java-32bit.title": {
-    "defaultMessage": "32 位元 Java 執行環境無法配置所需記憶體"
-  },
-  "console.crash.finding.java-incompatible.action": {
-    "defaultMessage": "使用相容的 Java 執行環境，或安裝適用於此 Java 版本的模組版本。"
-  },
-  "console.crash.finding.java-incompatible.title": {
-    "defaultMessage": "模組需要其他 Java 版本"
-  },
-  "console.crash.finding.java-too-new.action": {
-    "defaultMessage": "選擇此 Minecraft 和模組載入器版本所需的 Java 主要版本。"
-  },
-  "console.crash.finding.java-too-new.title": {
-    "defaultMessage": "Java 執行環境版本對此實例過新"
-  },
-  "console.crash.finding.jdk-runtime.action": {
-    "defaultMessage": "為此 Minecraft 版本選擇標準 HotSpot Java 執行環境。"
-  },
-  "console.crash.finding.jdk-runtime.title": {
-    "defaultMessage": "選擇了 JDK 而不是 JRE"
-  },
-  "console.crash.finding.jvm-arguments.action": {
-    "defaultMessage": "移除報告中指出的自訂 JVM 參數，然後重新啟動實例。"
-  },
-  "console.crash.finding.jvm-arguments.title": {
-    "defaultMessage": "JVM 參數無效"
-  },
-  "console.crash.finding.large-resource-pack.action": {
-    "defaultMessage": "停用該資源包，或改用解析度較低的版本。"
-  },
-  "console.crash.finding.large-resource-pack.title": {
-    "defaultMessage": "目前資源包對圖形設定而言過大"
-  },
-  "console.crash.finding.manual-debug-crash.action": {
-    "defaultMessage": "重新啟動，並避免長按手動偵錯崩潰快速鍵。"
-  },
-  "console.crash.finding.manual-debug-crash.title": {
-    "defaultMessage": "觸發了偵錯崩潰快速鍵"
-  },
-  "console.crash.finding.matched-mod": {
-    "defaultMessage": "相符模組：{identity}{modId} - {fileName}"
-  },
-  "console.crash.finding.missing-dependency.action": {
-    "defaultMessage": "安裝所需的相依性版本，或使用與此 Minecraft 版本相符的模組版本。"
-  },
-  "console.crash.finding.missing-dependency.title": {
-    "defaultMessage": "模組相依性缺少或不受支援"
-  },
-  "console.crash.finding.mixin-bootstrap.action": {
-    "defaultMessage": "修復模組載入器安裝，並確認所有模組均適用於已安裝的載入器。"
-  },
-  "console.crash.finding.mixin-bootstrap.title": {
-    "defaultMessage": "缺少 Mixin 啟動程序"
-  },
-  "console.crash.finding.mixin-failure.action": {
-    "defaultMessage": "更新或移除相符的模組，並檢查其 Minecraft 和載入器版本是否相容。"
-  },
-  "console.crash.finding.mixin-failure.title": {
-    "defaultMessage": "模組 Mixin 套用失敗"
-  },
-  "console.crash.finding.mod-config.action": {
-    "defaultMessage": "備份並移除指出的設定檔，讓模組重新產生它。"
-  },
-  "console.crash.finding.mod-config.title": {
-    "defaultMessage": "無法讀取模組設定檔"
-  },
-  "console.crash.finding.mod-filename.action": {
-    "defaultMessage": "使用簡單的拉丁字母檔名重新命名或安裝模組 jar。"
-  },
-  "console.crash.finding.mod-filename.title": {
-    "defaultMessage": "模組檔名包含不支援的字元"
-  },
-  "console.crash.finding.mod-id-limit.action": {
-    "defaultMessage": "移除未使用的模組，或將安裝內容拆分為較小的相容設定檔。"
-  },
-  "console.crash.finding.mod-id-limit.title": {
-    "defaultMessage": "模組過多，超出 ID 限制"
-  },
-  "console.crash.finding.mod-initialization.action": {
-    "defaultMessage": "更新指出的模組，並確認其所需相依性均已安裝。"
-  },
-  "console.crash.finding.mod-initialization.title": {
-    "defaultMessage": "模組初始化失敗"
-  },
-  "console.crash.finding.mod-loader-error.action": {
-    "defaultMessage": "修復載入器安裝，並確認列出的模組檔案與此遊戲版本相符。"
-  },
-  "console.crash.finding.mod-loader-error.title": {
-    "defaultMessage": "模組載入器回報了故障"
-  },
-  "console.crash.finding.mod-loader-failure.action": {
-    "defaultMessage": "修復載入器安裝，並依證據中顯示的故障訊息處理。"
-  },
-  "console.crash.finding.mod-loader-failure.title": {
-    "defaultMessage": "模組載入器在識別模組檔案前失敗"
-  },
-  "console.crash.finding.multiple-forge-versions.action": {
-    "defaultMessage": "修復實例，使其版本設定檔中只包含一個 Forge 安裝。"
-  },
-  "console.crash.finding.multiple-forge-versions.title": {
-    "defaultMessage": "版本設定檔中包含多個 Forge 版本"
-  },
-  "console.crash.finding.nightconfig-bug.action": {
-    "defaultMessage": "備份 config 資料夾，移除損壞設定，讓模組重新產生它。"
-  },
-  "console.crash.finding.nightconfig-bug.title": {
-    "defaultMessage": "NightConfig 無法讀取設定檔"
-  },
-  "console.crash.finding.nvidia-driver.action": {
-    "defaultMessage": "全新安裝最新版 NVIDIA 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
-  },
-  "console.crash.finding.nvidia-driver.title": {
-    "defaultMessage": "NVIDIA 顯示卡驅動程式崩潰"
-  },
-  "console.crash.finding.opengl-unsupported.action": {
-    "defaultMessage": "安裝 GPU 製造商提供的顯示卡驅動程式，並確認 Minecraft 使用預期的 GPU。"
-  },
-  "console.crash.finding.opengl-unsupported.title": {
-    "defaultMessage": "目前顯示卡驅動程式不支援 OpenGL"
-  },
-  "console.crash.finding.openj9.action": {
-    "defaultMessage": "選擇以 HotSpot 為基礎的 Java 執行環境，例如 Eclipse Temurin 或內建 Minecraft 執行環境。"
-  },
-  "console.crash.finding.openj9.title": {
-    "defaultMessage": "所選 OpenJ9 執行環境不相容"
-  },
-  "console.crash.finding.optifine-incompatible.action": {
-    "defaultMessage": "安裝相容的 OptiFine 版本，或移除 OptiFine 和衝突的光影模組。"
-  },
-  "console.crash.finding.optifine-incompatible.title": {
-    "defaultMessage": "OptiFine 與已安裝的載入器或模組衝突"
-  },
-  "console.crash.finding.optifine-world.action": {
-    "defaultMessage": "移除 OptiFine，或安裝與此 Minecraft 和 Forge 版本相容的版本。"
-  },
-  "console.crash.finding.optifine-world.title": {
-    "defaultMessage": "OptiFine 阻止世界載入"
-  },
-  "console.crash.finding.out-of-memory.action": {
-    "defaultMessage": "增加實例記憶體配置，或移除占用大量記憶體的模組和資源包。"
-  },
-  "console.crash.finding.out-of-memory.title": {
-    "defaultMessage": "Minecraft 記憶體不足"
-  },
-  "console.crash.finding.pixel-format.action": {
-    "defaultMessage": "更新或重新安裝顯示卡驅動程式，停用衝突的覆蓋層後重試。"
-  },
-  "console.crash.finding.pixel-format.title": {
-    "defaultMessage": "顯示卡驅動程式無法設定像素格式"
-  },
-  "console.crash.finding.resource-pack.action": {
-    "defaultMessage": "停用目前光影和資源包，再逐一重新啟用。"
-  },
-  "console.crash.finding.resource-pack.title": {
-    "defaultMessage": "光影或資源包觸發圖形錯誤"
-  },
-  "console.crash.finding.shaders-optifine.action": {
-    "defaultMessage": "移除單獨的光影模組，因為 OptiFine 已提供光影支援。"
-  },
-  "console.crash.finding.shaders-optifine.title": {
-    "defaultMessage": "同時安裝了光影模組和 OptiFine"
-  },
-  "console.crash.finding.short-output.action": {
-    "defaultMessage": "重試一次，然後檢查 Java、載入器安裝和啟動器輸出中較早出現的錯誤。"
-  },
-  "console.crash.finding.short-output.title": {
-    "defaultMessage": "遊戲在產生有效日誌前停止"
-  },
-  "console.crash.finding.specific-block.action": {
-    "defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的方塊。"
-  },
-  "console.crash.finding.specific-block.title": {
-    "defaultMessage": "特定方塊導致崩潰"
-  },
-  "console.crash.finding.specific-entity.action": {
-    "defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的實體。"
-  },
-  "console.crash.finding.specific-entity.title": {
-    "defaultMessage": "特定實體導致崩潰"
-  },
-  "console.crash.finding.stack-analysis.action": {
-    "defaultMessage": "更新或暫時移除相符的模組，然後重新測試實例。"
-  },
-  "console.crash.finding.stack-analysis.title": {
-    "defaultMessage": "堆疊追蹤指向已安裝的模組"
-  },
-  "console.crash.finding.suspected-mod.action": {
-    "defaultMessage": "更新或暫時移除報告懷疑且本機相符的模組，然後重試。"
-  },
-  "console.crash.finding.suspected-mod.title": {
-    "defaultMessage": "崩潰報告懷疑一個或多個模組"
-  },
-  "console.crash.local-header": {
-    "defaultMessage": "{findings, plural, other {# 項本機診斷結果}}，來自 {sources, plural, other {# 個相關檔案}}"
-  },
-  "console.crash.problems-detected": {
-    "defaultMessage": "偵測到 {count, plural, other {# 個問題}}"
-  },
-  "console.delete-modal.confirmation": {
-    "defaultMessage": "刪除後無法復原此日誌檔案。確定要繼續嗎？"
-  },
-  "console.delete-modal.irreversible-title": {
-    "defaultMessage": "此操作無法復原"
-  },
-  "console.delete-modal.title": {
-    "defaultMessage": "刪除日誌檔案"
-  },
-  "console.filter.error": {
-    "defaultMessage": "錯誤"
-  },
-  "console.filter.info": {
-    "defaultMessage": "資訊"
-  },
-  "console.filter.warn": {
-    "defaultMessage": "警告"
-  },
-  "console.notification.delete-failed": {
-    "defaultMessage": "刪除日誌檔案失敗"
-  },
-  "console.notification.share-failed": {
-    "defaultMessage": "分享日誌失敗"
-  },
-  "console.notification.unknown-error": {
-    "defaultMessage": "未知錯誤。"
-  },
-  "console.search.placeholder": {
-    "defaultMessage": "搜尋日誌"
-  },
-  "console.share-modal.title": {
-    "defaultMessage": "分享日誌"
-  },
-  "content-type.content.lowercase": {
-    "defaultMessage": "內容"
-  },
-  "content-type.item.lowercase": {
-    "defaultMessage": "{count, plural, other {項目}}"
-  },
-  "content.card.select-project": {
-    "defaultMessage": "選取「{project}」"
-  },
-  "content.confirm-bulk-update.admonition-body": {
-    "defaultMessage": "確定要將這 {count, plural, other {# 個專案}}更新至最新的相容版本嗎？建議你逐一進行更新。"
-  },
-  "content.confirm-bulk-update.admonition-header": {
-    "defaultMessage": "更新警告"
-  },
-  "content.confirm-bulk-update.header": {
-    "defaultMessage": "更新專案"
-  },
-  "content.confirm-bulk-update.update-button": {
-    "defaultMessage": "更新 {count, plural, other {# 個專案}}"
-  },
-  "content.confirm-deletion.admonition-body": {
-    "defaultMessage": "刪除模組可能會對你的世界造成永久性影響，並在重新載入時導致內容遺失或發生非預期的問題。"
-  },
-  "content.confirm-deletion.admonition-header": {
-    "defaultMessage": "刪除警告"
-  },
-  "content.confirm-deletion.delete-button": {
-    "defaultMessage": "刪除 {count, number} 個{itemType}"
-  },
-  "content.confirm-deletion.header": {
-    "defaultMessage": "刪除{itemType}"
-  },
-  "content.confirm-modpack-update.admonition-body": {
-    "defaultMessage": "{action, select, downgrade {降級} other {更新}}可能會導致相容性問題。你額外新增至模組包的模組或內容將保留，但可能與新版本不相容。"
-  },
-  "content.confirm-modpack-update.admonition-header": {
-    "defaultMessage": "{action, select, downgrade {降級} other {更新}}警告"
-  },
-  "content.confirm-modpack-update.confirm-button": {
-    "defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
-  },
-  "content.confirm-modpack-update.header": {
-    "defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
-  },
-  "content.confirm-unlink.admonition-body": {
-    "defaultMessage": "模組與內容將與你額外新增至模組包的內容合併，且將不再接收更新。"
-  },
-  "content.confirm-unlink.admonition-header": {
-    "defaultMessage": "取消連結模組包"
-  },
-  "content.confirm-unlink.header": {
-    "defaultMessage": "取消連結模組包"
-  },
-  "content.confirm-unlink.unlink-button": {
-    "defaultMessage": "取消連結"
-  },
-  "content.dependency-warning.admonition-header": {
-    "defaultMessage": "其他內容需要此內容"
-  },
-  "content.dependency-warning.affected-dependents-label": {
-    "defaultMessage": "受影響{count, plural, other {專案}}"
-  },
-  "content.dependency-warning.bulk-admonition-body": {
-    "defaultMessage": "部分所選的專案已作為相依項安裝。刪除這些專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
-  },
-  "content.dependency-warning.context.instance": {
-    "defaultMessage": "實例"
-  },
-  "content.dependency-warning.context.server": {
-    "defaultMessage": "伺服器"
-  },
-  "content.dependency-warning.delete-anyway-button": {
-    "defaultMessage": "仍要刪除"
-  },
-  "content.dependency-warning.delete-many-anyway-button": {
-    "defaultMessage": "仍要刪除 {count, number} 個{itemType}"
-  },
-  "content.dependency-warning.deleting-label": {
-    "defaultMessage": "刪除"
-  },
-  "content.dependency-warning.disable-dependents-label": {
-    "defaultMessage": "刪除後停用依賴項"
-  },
-  "content.dependency-warning.effect-dependent-content": {
-    "defaultMessage": "依賴項內容可能會無法載入，或自主停用"
-  },
-  "content.dependency-warning.effect-instance": {
-    "defaultMessage": "你的{context}可能會崩潰、無法啟動，或出現異常行為"
-  },
-  "content.dependency-warning.header": {
-    "defaultMessage": "相依項警告"
-  },
-  "content.dependency-warning.single-admonition-body": {
-    "defaultMessage": "{project} 已作為相依項安裝。刪除這個專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
-  },
-  "content.dependency-warning.what-happens-label": {
-    "defaultMessage": "會發生什麼事？"
-  },
-  "content.diff-modal.added-count": {
-    "defaultMessage": "已新增 {count} 個"
-  },
-  "content.diff-modal.diff-type.added": {
-    "defaultMessage": "已新增（相依項）"
-  },
-  "content.diff-modal.diff-type.removed": {
-    "defaultMessage": "已停用"
-  },
-  "content.diff-modal.diff-type.updated": {
-    "defaultMessage": "已更新"
-  },
-  "content.diff-modal.removed-count": {
-    "defaultMessage": "已移除 {count} 個"
-  },
-  "content.diff-modal.unknown-content-body": {
-    "defaultMessage": "你伺服器上的部分內容無法進行分析，且可能會受到這項變更的影響。"
-  },
-  "content.diff-modal.updated-count": {
-    "defaultMessage": "已更新 {count} 個"
-  },
-  "content.filter.disabled": {
-    "defaultMessage": "停用"
-  },
-  "content.filter.enabled": {
-    "defaultMessage": "啟用"
-  },
-  "content.filter.updates": {
-    "defaultMessage": "更新"
-  },
-  "content.filter.warnings": {
-    "defaultMessage": "警告"
-  },
-  "content.page-layout.browse-content": {
-    "defaultMessage": "瀏覽內容"
-  },
-  "content.page-layout.empty.hint": {
-    "defaultMessage": "瀏覽或上傳{contentType}即可開始"
-  },
-  "content.page-layout.empty.no-content-installed": {
-    "defaultMessage": "未安裝內容"
-  },
-  "content.page-layout.failed-to-load": {
-    "defaultMessage": "無法載入內容"
-  },
-  "content.page-layout.no-content-found": {
-    "defaultMessage": "找不到內容。"
-  },
-  "content.page-layout.search-placeholder": {
-    "defaultMessage": "搜尋 {count, number} 個{contentType}..."
-  },
-  "content.page-layout.share.file-names": {
-    "defaultMessage": "檔案名稱"
-  },
-  "content.page-layout.share.label": {
-    "defaultMessage": "分享"
-  },
-  "content.page-layout.share.markdown-links": {
-    "defaultMessage": "Markdown 連結"
-  },
-  "content.page-layout.share.project-links": {
-    "defaultMessage": "專案連結"
-  },
-  "content.page-layout.share.project-names": {
-    "defaultMessage": "專案名稱"
-  },
-  "content.page-layout.sort.alphabetical": {
-    "defaultMessage": "字母順序"
-  },
-  "content.page-layout.sort.date-added-newest": {
-    "defaultMessage": "最新在前"
-  },
-  "content.page-layout.sort.date-added-oldest": {
-    "defaultMessage": "最舊在前"
-  },
-  "content.page-layout.sort.label": {
-    "defaultMessage": "排序依據：{mode}"
-  },
-  "content.page-layout.update-all": {
-    "defaultMessage": "更新全部"
-  },
-  "content.selection-bar.all-already-disabled": {
-    "defaultMessage": "所有已選擇的內容已經停用"
-  },
-  "content.selection-bar.all-already-enabled": {
-    "defaultMessage": "所有已選擇的內容已經啟用"
-  },
-  "content.selection-bar.bulk.deleting": {
-    "defaultMessage": "正在刪除 {progress}/{total} {contentType}..."
-  },
-  "content.selection-bar.bulk.deleting-count": {
-    "defaultMessage": "正在刪除 {count, number} 個{contentType}"
-  },
-  "content.selection-bar.bulk.deleting-waiting": {
-    "defaultMessage": "正在刪除{contentType}..."
-  },
-  "content.selection-bar.bulk.disabling": {
-    "defaultMessage": "正在停用 {progress}/{total} {contentType}..."
-  },
-  "content.selection-bar.bulk.disabling-count": {
-    "defaultMessage": "正在停用 {count, number} 個{contentType}"
-  },
-  "content.selection-bar.bulk.disabling-waiting": {
-    "defaultMessage": "正在停用{contentType}..."
-  },
-  "content.selection-bar.bulk.enabling": {
-    "defaultMessage": "正在啟用 {progress}/{total} {contentType}..."
-  },
-  "content.selection-bar.bulk.enabling-count": {
-    "defaultMessage": "正在啟用 {count, number} 個{contentType}"
-  },
-  "content.selection-bar.bulk.enabling-waiting": {
-    "defaultMessage": "正在啟用{contentType}..."
-  },
-  "content.selection-bar.bulk.updating": {
-    "defaultMessage": "正在更新 {progress}/{total} {contentType}..."
-  },
-  "content.selection-bar.bulk.updating-count": {
-    "defaultMessage": "正在更新 {count, number} 個{contentType}"
-  },
-  "content.selection-bar.bulk.updating-waiting": {
-    "defaultMessage": "正在更新{contentType}..."
-  },
-  "content.selection-bar.selected-count": {
-    "defaultMessage": "已選取 {count, number} 個{contentType}"
-  },
-  "content.selection-bar.selected-count-simple": {
-    "defaultMessage": "已選取 {count, number} 個項目"
-  },
-  "creation-flow.button.create-instance": {
-    "defaultMessage": "建立實例"
-  },
-  "creation-flow.button.create-world": {
-    "defaultMessage": "建立世界"
-  },
-  "creation-flow.button.finish": {
-    "defaultMessage": "完成"
-  },
-  "creation-flow.button.import": {
-    "defaultMessage": "匯入"
-  },
-  "creation-flow.button.import-instances": {
-    "defaultMessage": "匯入 {count, plural, other {# 個實例}}"
-  },
-  "creation-flow.button.setup-server": {
-    "defaultMessage": "設定伺服器"
-  },
-  "creation-flow.modal.custom-setup.build-number.label": {
-    "defaultMessage": "組建編號"
-  },
-  "creation-flow.modal.custom-setup.build-number.placeholder": {
-    "defaultMessage": "選擇組建編號"
-  },
-  "creation-flow.modal.custom-setup.build-number.search-placeholder": {
-    "defaultMessage": "搜尋組建編號..."
-  },
-  "creation-flow.modal.custom-setup.content-loader.label": {
-    "defaultMessage": "內容載入器"
-  },
-  "creation-flow.modal.custom-setup.game-version.load-failed": {
-    "defaultMessage": "遊戲版本載入失敗"
-  },
-  "creation-flow.modal.custom-setup.game-version.no-supported-versions": {
-    "defaultMessage": "沒有遊戲版本支援此載入器"
-  },
-  "creation-flow.modal.custom-setup.game-version.placeholder": {
-    "defaultMessage": "選擇遊戲版本"
-  },
-  "creation-flow.modal.custom-setup.game-version.search-placeholder": {
-    "defaultMessage": "搜尋遊戲版本..."
-  },
-  "creation-flow.modal.custom-setup.game-version-type.alpha": {
-    "defaultMessage": "愚人節版"
-  },
-  "creation-flow.modal.custom-setup.game-version-type.release": {
-    "defaultMessage": "正式版"
-  },
-  "creation-flow.modal.custom-setup.game-version-type.snapshot": {
-    "defaultMessage": "快照版"
-  },
-  "creation-flow.modal.custom-setup.icon.remove": {
-    "defaultMessage": "移除圖示"
-  },
-  "creation-flow.modal.custom-setup.icon.select": {
-    "defaultMessage": "選擇圖示"
-  },
-  "creation-flow.modal.custom-setup.loader-version-type.latest": {
-    "defaultMessage": "最新版"
-  },
-  "creation-flow.modal.custom-setup.loader-version-type.other": {
-    "defaultMessage": "其他"
-  },
-  "creation-flow.modal.custom-setup.loader-version-type.stable": {
-    "defaultMessage": "穩定版"
-  },
-  "creation-flow.modal.custom-setup.loader-version.label": {
-    "defaultMessage": "載入器版本"
-  },
-  "creation-flow.modal.custom-setup.loader-version.placeholder": {
-    "defaultMessage": "選擇載入器版本"
-  },
-  "creation-flow.modal.custom-setup.loader-version.search-placeholder": {
-    "defaultMessage": "搜尋載入器版本..."
-  },
-  "creation-flow.modal.custom-setup.loader.label": {
-    "defaultMessage": "載入器"
-  },
-  "creation-flow.modal.custom-setup.loader.no-such-versions-available": {
-    "defaultMessage": "無此版本"
-  },
-  "creation-flow.modal.custom-setup.loader.unsupported-tooltip": {
-    "defaultMessage": "此載入器不支援所選遊戲版本"
-  },
-  "creation-flow.modal.custom-setup.name.label": {
-    "defaultMessage": "名稱"
-  },
-  "creation-flow.modal.custom-setup.name.placeholder": {
-    "defaultMessage": "輸入實例名稱"
-  },
-  "creation-flow.modal.custom-setup.options.no-versions-available": {
-    "defaultMessage": "沒有可用的版本"
-  },
-  "creation-flow.modal.custom-setup.will-install-loader-version": {
-    "defaultMessage": "將會安裝：{loader} {version}"
-  },
-  "creation-flow.modal.setup-type.instance.description": {
-    "defaultMessage": "實例是指具有特定載入器、版本及模組的 Minecraft 設定。"
-  },
-  "creation-flow.modal.setup-type.option.custom-setup.description": {
-    "defaultMessage": "從頭開始，先選擇載入器與遊戲版本。"
-  },
-  "creation-flow.modal.setup-type.option.custom-setup.title": {
-    "defaultMessage": "自訂設定"
-  },
-  "creation-flow.modal.setup-type.option.import-instance.description": {
-    "defaultMessage": "從 Prism、CurseForge 或類似啟動器匯入實例。"
-  },
-  "creation-flow.modal.setup-type.option.import-instance.title": {
-    "defaultMessage": "匯入實例"
-  },
-  "creation-flow.modal.setup-type.option.modpack-base.description": {
-    "defaultMessage": "在 Modrinth 上瀏覽模組包，或從檔案匯入。"
-  },
-  "creation-flow.modal.setup-type.option.modpack-base.title": {
-    "defaultMessage": "安裝模組包"
-  },
-  "creation-flow.modal.setup-type.option.vanilla-minecraft.description": {
-    "defaultMessage": "不含任何模組或插件的經典 Minecraft。"
-  },
-  "creation-flow.modal.setup-type.option.vanilla-minecraft.title": {
-    "defaultMessage": "原版 Minecraft"
-  },
-  "creation-flow.modal.setup-type.title.installation": {
-    "defaultMessage": "選擇安裝類型"
-  },
-  "creation-flow.modal.setup-type.title.instance": {
-    "defaultMessage": "選擇實例類型"
-  },
-  "creation-flow.modal.setup-type.title.world": {
-    "defaultMessage": "選擇世界類型"
-  },
-  "creation-flow.title.choose-modpack": {
-    "defaultMessage": "選擇模組包"
-  },
-  "creation-flow.title.create-instance": {
-    "defaultMessage": "建立實例"
-  },
-  "creation-flow.title.create-world": {
-    "defaultMessage": "建立世界"
-  },
-  "creation-flow.title.import-instance": {
-    "defaultMessage": "匯入實例"
-  },
-  "creation-flow.title.reset-server": {
-    "defaultMessage": "重設伺服器"
-  },
-  "creation-flow.title.set-up-server": {
-    "defaultMessage": "設定伺服器"
-  },
-  "external-project-license-status.no": {
-    "defaultMessage": "否"
-  },
-  "external-project-license-status.permanent-no": {
-    "defaultMessage": "永久禁止"
-  },
-  "external-project-license-status.unidentified": {
-    "defaultMessage": "未識別"
-  },
-  "external-project-license-status.with-attribution": {
-    "defaultMessage": "附帶引用標註"
-  },
-  "external-project-license-status.with-attribution-and-source": {
-    "defaultMessage": "附帶引用標註與來源"
-  },
-  "external-project-license-status.yes": {
-    "defaultMessage": "是"
-  },
-  "files.conflict-modal.header": {
-    "defaultMessage": "解壓縮摘要"
-  },
-  "files.conflict-modal.overwrite-button": {
-    "defaultMessage": "覆寫"
-  },
-  "files.conflict-modal.overwrite-file-label": {
-    "defaultMessage": "將覆寫 <file-path>{path}</file-path>"
-  },
-  "files.conflict-modal.overwrite-many-warning": {
-    "defaultMessage": "若你繼續執行解壓縮，將有超過 100 個檔案被覆寫；以下列出部分檔案。"
-  },
-  "files.conflict-modal.overwrite-warning": {
-    "defaultMessage": "下列 {count} 個檔案已存在於你的伺服器上，若你繼續執行解壓縮，這些檔案將被覆寫。"
-  },
-  "files.conflict-modal.overwritten-count": {
-    "defaultMessage": "將覆寫 {count} 個檔案"
-  },
-  "files.conflict-modal.warning-header": {
-    "defaultMessage": "檔案將被覆寫"
-  },
-  "files.create-modal.create-button": {
-    "defaultMessage": "建立 {type}"
-  },
-  "files.create-modal.header": {
-    "defaultMessage": "建立一個 {type}"
-  },
-  "files.create-modal.placeholder-directory": {
-    "defaultMessage": "例如：my-folder"
-  },
-  "files.create-modal.placeholder-file": {
-    "defaultMessage": "例如：config.yml"
-  },
-  "files.delete-modal.deleting-name": {
-    "defaultMessage": "正在刪除「{name}」"
-  },
-  "files.delete-modal.header": {
-    "defaultMessage": "刪除檔案"
-  },
-  "files.delete-modal.warning.file": {
-    "defaultMessage": "此檔案將永久刪除。此操作無法撤銷。"
-  },
-  "files.delete-modal.warning.folder": {
-    "defaultMessage": "此資料夾及其所有內容將永久刪除。此操作無法撤銷。"
-  },
-  "files.editor.failed-to-open-text": {
-    "defaultMessage": "無法載入檔案內容。"
-  },
-  "files.editor.failed-to-open-title": {
-    "defaultMessage": "無法開啟檔案"
-  },
-  "files.editor.failed-to-share-text": {
-    "defaultMessage": "無法上傳至 mclo.gs。"
-  },
-  "files.editor.failed-to-share-title": {
-    "defaultMessage": "無法分享檔案"
-  },
-  "files.editor.file-saved-text": {
-    "defaultMessage": "你的檔案已儲存。"
-  },
-  "files.editor.file-saved-title": {
-    "defaultMessage": "已儲存檔案"
-  },
-  "files.editor.find-close": {
-    "defaultMessage": "關閉"
-  },
-  "files.editor.find-in-file": {
-    "defaultMessage": "尋找"
-  },
-  "files.editor.find-match-count": {
-    "defaultMessage": "{current}/{total}"
-  },
-  "files.editor.find-next-match": {
-    "defaultMessage": "下一個相符項"
-  },
-  "files.editor.find-no-results": {
-    "defaultMessage": "沒有結果"
-  },
-  "files.editor.find-previous-match": {
-    "defaultMessage": "上一個相符項"
-  },
-  "files.editor.find-toggle-replace": {
-    "defaultMessage": "切換取代功能"
-  },
-  "files.editor.log-url-copied-text": {
-    "defaultMessage": "你的記錄檔網址已複製到剪貼簿。"
-  },
-  "files.editor.log-url-copied-title": {
-    "defaultMessage": "記錄檔網址已複製"
-  },
-  "files.editor.replace": {
-    "defaultMessage": "取代"
-  },
-  "files.editor.replace-all": {
-    "defaultMessage": "取代全部"
-  },
-  "files.editor.replace-in-file": {
-    "defaultMessage": "取代"
-  },
-  "files.editor.save-failed-text": {
-    "defaultMessage": "無法儲存檔案。"
-  },
-  "files.editor.save-failed-title": {
-    "defaultMessage": "儲存失敗"
-  },
-  "files.error.go-to-home": {
-    "defaultMessage": "前往家資料夾"
-  },
-  "files.error.try-again": {
-    "defaultMessage": "再試一次"
-  },
-  "files.image_viewer.image_too_large": {
-    "defaultMessage": "圖片過大無法預覽 (最大 {maxDimension}x{maxDimension} 像素)"
-  },
-  "files.image_viewer.invalid_image": {
-    "defaultMessage": "圖片檔案無效或內容為空。"
-  },
-  "files.image_viewer.load_failed": {
-    "defaultMessage": "無法載入圖片"
-  },
-  "files.image_viewer.reset_zoom": {
-    "defaultMessage": "重設縮放"
-  },
-  "files.image_viewer.viewed_image_alt": {
-    "defaultMessage": "已檢視圖片"
-  },
-  "files.image_viewer.zoom_in": {
-    "defaultMessage": "放大"
-  },
-  "files.image_viewer.zoom_out": {
-    "defaultMessage": "縮小"
-  },
-  "files.item-type.file": {
-    "defaultMessage": "檔案"
-  },
-  "files.item-type.files": {
-    "defaultMessage": "檔案"
-  },
-  "files.item-type.folder": {
-    "defaultMessage": "資料夾"
-  },
-  "files.item-type.folders": {
-    "defaultMessage": "資料夾"
-  },
-  "files.layout.dry-run-failed-text": {
-    "defaultMessage": "執行模擬測試時發生錯誤"
-  },
-  "files.layout.dry-run-failed-title": {
-    "defaultMessage": "模擬測試失敗"
-  },
-  "files.layout.empty-folder-description": {
-    "defaultMessage": "沒有任何檔案或資料夾"
-  },
-  "files.layout.empty-folder-title": {
-    "defaultMessage": "此資料夾是空的"
-  },
-  "files.layout.error-message": {
-    "defaultMessage": "該資料夾可能不存在"
-  },
-  "files.layout.error-title": {
-    "defaultMessage": "無法載入檔案"
-  },
-  "files.layout.extraction-started-title": {
-    "defaultMessage": "解壓縮已開始"
-  },
-  "files.layout.selected-count": {
-    "defaultMessage": "已選擇 {count} 個"
-  },
-  "files.layout.unsaved-changes": {
-    "defaultMessage": "您有未儲存的變更"
-  },
-  "files.move-modal.current-location": {
-    "defaultMessage": "目前位置"
-  },
-  "files.move-modal.destination-path": {
-    "defaultMessage": "目標路徑"
-  },
-  "files.move-modal.destination-placeholder": {
-    "defaultMessage": "例如：/my-folder"
-  },
-  "files.move-modal.header": {
-    "defaultMessage": "移動{type}"
-  },
-  "files.navbar.back-to-home": {
-    "defaultMessage": "回到首頁"
-  },
-  "files.navbar.breadcrumb-navigation": {
-    "defaultMessage": "麵包屑導覽"
-  },
-  "files.navbar.create-new": {
-    "defaultMessage": "建立新的..."
-  },
-  "files.navbar.file-navigation": {
-    "defaultMessage": "檔案導覽"
-  },
-  "files.navbar.find-in-file": {
-    "defaultMessage": "在檔案中尋找"
-  },
-  "files.navbar.home": {
-    "defaultMessage": "首頁"
-  },
-  "files.navbar.install-curseforge-pack": {
-    "defaultMessage": "安裝 CurseForge 整合包"
-  },
-  "files.navbar.new-file": {
-    "defaultMessage": "新增檔案"
-  },
-  "files.navbar.new-folder": {
-    "defaultMessage": "新增資料夾"
-  },
-  "files.navbar.search-files": {
-    "defaultMessage": "搜尋檔案"
-  },
-  "files.navbar.upload-from-zip": {
-    "defaultMessage": "從 .zip 檔案上傳"
-  },
-  "files.navbar.upload-from-zip-url": {
-    "defaultMessage": "從 .zip 網址上傳"
-  },
-  "files.rename-modal.header": {
-    "defaultMessage": "重新命名 {name}"
-  },
-  "files.rename-modal.new-name-label": {
-    "defaultMessage": "新名稱"
-  },
-  "files.row.item-count": {
-    "defaultMessage": "{count, plural, other {# 個項目}}"
-  },
-  "files.table-header.created": {
-    "defaultMessage": "建立時間"
-  },
-  "files.table-header.modified": {
-    "defaultMessage": "修改時間"
-  },
-  "files.table-header.name": {
-    "defaultMessage": "名稱"
-  },
-  "files.table-header.size": {
-    "defaultMessage": "大小"
-  },
-  "files.unsaved-changes-modal.body": {
-    "defaultMessage": "您有未儲存的變更，如果離開將會遺失。離開前要儲存嗎？"
-  },
-  "files.unsaved-changes-modal.discard": {
-    "defaultMessage": "捨棄"
-  },
-  "files.unsaved-changes-modal.header": {
-    "defaultMessage": "未儲存的變更"
-  },
-  "files.validation.name-invalid-directory": {
-    "defaultMessage": "名稱只能包含英數字、破折號、底線或空格"
-  },
-  "files.validation.name-invalid-file": {
-    "defaultMessage": "名稱只能包含英數字、破折號、底線、點或空格"
-  },
-  "files.validation.name-label": {
-    "defaultMessage": "名稱"
-  },
-  "files.validation.name-required": {
-    "defaultMessage": "名稱為必填項目"
-  },
-  "files.zip-url-modal.cf-header": {
-    "defaultMessage": "安裝 CurseForge 整合包"
-  },
-  "files.zip-url-modal.cf-not-found-text": {
-    "defaultMessage": "在該網址找不到 CurseForge 整合包"
-  },
-  "files.zip-url-modal.cf-not-found-title": {
-    "defaultMessage": "找不到 CurseForge 整合包"
-  },
-  "files.zip-url-modal.enter-link": {
-    "defaultMessage": "輸入連結"
-  },
-  "files.zip-url-modal.error-cf-url": {
-    "defaultMessage": "網址必須是 CurseForge 整合包版本網址"
-  },
-  "files.zip-url-modal.error-url-invalid": {
-    "defaultMessage": "網址必須有效"
-  },
-  "files.zip-url-modal.error-url-required": {
-    "defaultMessage": "網址為必填項目"
-  },
-  "files.zip-url-modal.install-button": {
-    "defaultMessage": "安裝"
-  },
-  "files.zip-url-modal.install-failed-title": {
-    "defaultMessage": "安裝失敗"
-  },
-  "files.zip-url-modal.step-copy-description": {
-    "defaultMessage": "複製版本頁面網址並貼到下方"
-  },
-  "files.zip-url-modal.step-copy-title": {
-    "defaultMessage": "複製網址"
-  },
-  "files.zip-url-modal.step-find-description": {
-    "defaultMessage": "瀏覽 CurseForge 並找到您想要的整合包"
-  },
-  "files.zip-url-modal.step-find-title": {
-    "defaultMessage": "尋找整合包"
-  },
-  "files.zip-url-modal.step-select-description": {
-    "defaultMessage": "前往「檔案」分頁並選擇要安裝的版本"
-  },
-  "files.zip-url-modal.step-select-title": {
-    "defaultMessage": "選擇版本"
-  },
-  "files.zip-url-modal.unknown-error": {
-    "defaultMessage": "發生未知錯誤"
-  },
-  "files.zip-url-modal.zip-description": {
-    "defaultMessage": "複製並貼上 .zip 檔案的直接下載網址"
-  },
-  "files.zip-url-modal.zip-header": {
-    "defaultMessage": "正在從網址上傳 .zip 內容"
-  },
-  "form.label.address-line": {
-    "defaultMessage": "地址行 1"
-  },
-  "form.label.address-line-2": {
-    "defaultMessage": "地址行 2（可選）"
-  },
-  "form.label.amount": {
-    "defaultMessage": "金額"
-  },
-  "form.label.bank-name": {
-    "defaultMessage": "銀行名稱"
-  },
-  "form.label.business-name": {
-    "defaultMessage": "企業名稱"
-  },
-  "form.label.city": {
-    "defaultMessage": "城市"
-  },
-  "form.label.country": {
-    "defaultMessage": "國家或地區"
-  },
-  "form.label.date-of-birth": {
-    "defaultMessage": "出生日期"
-  },
-  "form.label.email": {
-    "defaultMessage": "電子郵件"
-  },
-  "form.label.first-name": {
-    "defaultMessage": "名字"
-  },
-  "form.label.last-name": {
-    "defaultMessage": "姓氏"
-  },
-  "form.label.postal-code": {
-    "defaultMessage": "郵遞區號"
-  },
-  "form.label.state-province": {
-    "defaultMessage": "縣市／省／州"
-  },
-  "form.placeholder.address": {
-    "defaultMessage": "輸入地址"
-  },
-  "form.placeholder.address-2": {
-    "defaultMessage": "公寓、套房等"
-  },
-  "form.placeholder.amount": {
-    "defaultMessage": "輸入金額"
-  },
-  "form.placeholder.bank-name": {
-    "defaultMessage": "輸入銀行名稱"
-  },
-  "form.placeholder.bank-name-dropdown": {
-    "defaultMessage": "選擇銀行名稱"
-  },
-  "form.placeholder.business-name": {
-    "defaultMessage": "輸入企業名稱"
-  },
-  "form.placeholder.city": {
-    "defaultMessage": "輸入城市"
-  },
-  "form.placeholder.country": {
-    "defaultMessage": "選擇國家或地區"
-  },
-  "form.placeholder.email": {
-    "defaultMessage": "輸入電子郵件地址"
-  },
-  "form.placeholder.first-name": {
-    "defaultMessage": "輸入名字"
-  },
-  "form.placeholder.last-name": {
-    "defaultMessage": "輸入姓氏"
-  },
-  "form.placeholder.postal-code": {
-    "defaultMessage": "輸入郵遞區號"
-  },
-  "form.placeholder.state": {
-    "defaultMessage": "輸入縣市／省／州"
-  },
-  "format.bytes.0": {
-    "defaultMessage": "{count, plural, other {# 位元組}}"
-  },
-  "format.bytes.1": {
-    "defaultMessage": "{count, number} KiB"
-  },
-  "format.bytes.2": {
-    "defaultMessage": "{count, number} MiB"
-  },
-  "format.bytes.3": {
-    "defaultMessage": "{count, number} GiB"
-  },
-  "format.bytes.4": {
-    "defaultMessage": "{count, number} TiB"
-  },
-  "header.category.category": {
-    "defaultMessage": "類別"
-  },
-  "header.category.feature": {
-    "defaultMessage": "功能"
-  },
-  "header.category.minecraft-server-community": {
-    "defaultMessage": "社群"
-  },
-  "header.category.minecraft-server-features": {
-    "defaultMessage": "特色"
-  },
-  "header.category.minecraft-server-gameplay": {
-    "defaultMessage": "遊戲玩法"
-  },
-  "header.category.minecraft-server-meta": {
-    "defaultMessage": "設定與機制"
-  },
-  "header.category.performance-impact": {
-    "defaultMessage": "效能影響"
-  },
-  "header.category.resolutions": {
-    "defaultMessage": "解析度"
-  },
-  "icon-select.edit": {
-    "defaultMessage": "編輯圖示"
-  },
-  "icon-select.remove": {
-    "defaultMessage": "移除圖示"
-  },
-  "icon-select.replace": {
-    "defaultMessage": "取代圖示"
-  },
-  "icon-select.select": {
-    "defaultMessage": "選擇圖示"
-  },
-  "input.search-version.placeholder": {
-    "defaultMessage": "搜尋版本..."
-  },
-  "input.search.placeholder": {
-    "defaultMessage": "搜尋..."
-  },
-  "input.select-version.placeholder": {
-    "defaultMessage": "選擇版本"
-  },
-  "input.view.gallery": {
-    "defaultMessage": "圖庫檢視"
-  },
-  "input.view.grid": {
-    "defaultMessage": "格狀檢視"
-  },
-  "input.view.list": {
-    "defaultMessage": "清單檢視"
-  },
-  "installation-settings.aria.select-game-version": {
-    "defaultMessage": "選擇遊戲版本"
-  },
-  "installation-settings.aria.select-loader-version": {
-    "defaultMessage": "選擇 {loader} 版本"
-  },
-  "installation-settings.aria.select-platform": {
-    "defaultMessage": "選擇平臺"
-  },
-  "installation-settings.confirm-version-change": {
-    "defaultMessage": "確定"
-  },
-  "installation-settings.confirm-version-change-description": {
-    "defaultMessage": "變更為 {gameVersion} 將會修改你伺服器上的下列內容。"
-  },
-  "installation-settings.confirm-version-change-header": {
-    "defaultMessage": "檢視內容變更"
-  },
-  "installation-settings.edit-installation.title": {
-    "defaultMessage": "編輯安裝"
-  },
-  "installation-settings.edit.warning-instance": {
-    "defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你仍想修改，請務必謹慎，因為這可能會導致問題。"
-  },
-  "installation-settings.edit.warning-server": {
-    "defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你想進行變更，請重設你的伺服器。"
-  },
-  "installation-settings.incompatible-content.auto-fix-button": {
-    "defaultMessage": "自動修復"
-  },
-  "installation-settings.incompatible-content.change-loader-button": {
-    "defaultMessage": "變更載入器"
-  },
-  "installation-settings.incompatible-content.disable-conflicts-button": {
-    "defaultMessage": "停用衝突項目"
-  },
-  "installation-settings.incompatible-content.game-version-warning-body": {
-    "defaultMessage": "變更遊戲版本時，我們可以停用不相容的已安裝內容，或是嘗試解決相容性問題。"
-  },
-  "installation-settings.incompatible-content.game-version-warning-title": {
-    "defaultMessage": "不相容警告"
-  },
-  "installation-settings.incompatible-content.header": {
-    "defaultMessage": "安裝了不相容的內容"
-  },
-  "installation-settings.incompatible-content.loader-change-body": {
-    "defaultMessage": "變更載入器時，所有已安裝的內容都將被停用。我們建議改為重設你的伺服器。"
-  },
-  "installation-settings.incompatible-content.loader-change-title": {
-    "defaultMessage": "變更載入器具有破壞性"
-  },
-  "installation-settings.linked-instance.title": {
-    "defaultMessage": "已連接{projectType}"
-  },
-  "installation-settings.linked.modpack": {
-    "defaultMessage": "模組包"
-  },
-  "installation-settings.linked.server-project": {
-    "defaultMessage": "伺服器專案"
-  },
-  "installation-settings.loader-version": {
-    "defaultMessage": "{loader} 版本"
-  },
-  "installation-settings.platform-lock-tooltip": {
-    "defaultMessage": "你需要重設伺服器才能切換載入器。"
-  },
-  "installation-settings.reinstall-modpack.description": {
-    "defaultMessage": "重新安裝模組包會將{type}內容重設為原始狀態，你新增的所有模組或內容都將被移除。"
-  },
-  "installation-settings.reinstall-modpack.title": {
-    "defaultMessage": "重新安裝模組包"
-  },
-  "installation-settings.reinstalling-modpack": {
-    "defaultMessage": "正在重新安裝模組包"
-  },
-  "installation-settings.removed-incompatible": {
-    "defaultMessage": "已移除（不相容）"
-  },
-  "installation-settings.repair.instance-description": {
-    "defaultMessage": "重新安裝 Minecraft 的必要元件並檢查檔案是否損毀。這或許能修復你的遊戲因啟動器出錯而打不開的問題。"
-  },
-  "installation-settings.repair.instance-title": {
-    "defaultMessage": "修復實例"
-  },
-  "installation-settings.repair.server-description": {
-    "defaultMessage": "在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的必要元件。這或許能修復你伺服器無法正常啟動的問題。"
-  },
-  "installation-settings.repair.server-title": {
-    "defaultMessage": "修復伺服器"
-  },
-  "installation-settings.saving": {
-    "defaultMessage": "儲存中..."
-  },
-  "installation-settings.search-game-version": {
-    "defaultMessage": "搜尋遊戲版本..."
-  },
-  "installation-settings.type.instance": {
-    "defaultMessage": "實例"
-  },
-  "installation-settings.type.instance-possessive": {
-    "defaultMessage": "實例"
-  },
-  "installation-settings.type.server": {
-    "defaultMessage": "伺服器"
-  },
-  "installation-settings.type.server-possessive": {
-    "defaultMessage": "伺服器"
-  },
-  "installation-settings.unlink": {
-    "defaultMessage": "取消連結"
-  },
-  "installation-settings.unlink.description": {
-    "defaultMessage": "取消連結將會永久中斷這個{type}與{projectType}的連結。這讓你可以變更載入器與 Minecraft 版本，但你將無法收到未來的更新。"
-  },
-  "installation-settings.verifying": {
-    "defaultMessage": "驗證中..."
-  },
-  "instance.confirm-reinstall.admonition-body": {
-    "defaultMessage": "重新安裝將會把所有已安裝或修改過的內容，重設回模組包原始的狀態。這將會移除所有你在原始安裝上額外添加的模組或內容。"
-  },
-  "instance.confirm-reinstall.admonition-header": {
-    "defaultMessage": "重新安裝警告"
-  },
-  "instance.confirm-reinstall.header": {
-    "defaultMessage": "重新安裝模組包"
-  },
-  "instance.confirm-reinstall.reinstall-button": {
-    "defaultMessage": "重新安裝模組包"
-  },
-  "instance.confirm-repair.body.instance": {
-    "defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復遊戲因啟動器出錯而無法啟動的問題。"
-  },
-  "instance.confirm-repair.body.server": {
-    "defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復伺服器無法正常啟動的問題。"
-  },
-  "instance.confirm-repair.header": {
-    "defaultMessage": "修復{type}"
-  },
-  "instance.confirm-repair.instance-label": {
-    "defaultMessage": "實例"
-  },
-  "instance.confirm-repair.repair-button": {
-    "defaultMessage": "修復"
-  },
-  "instance.confirm-repair.server-label": {
-    "defaultMessage": "伺服器"
-  },
-  "instance.worlds.game_mode.adventure": {
-    "defaultMessage": "冒險模式"
-  },
-  "instance.worlds.game_mode.creative": {
-    "defaultMessage": "創造模式"
-  },
-  "instance.worlds.game_mode.spectator": {
-    "defaultMessage": "旁觀者模式"
-  },
-  "instance.worlds.game_mode.survival": {
-    "defaultMessage": "生存模式"
-  },
-  "instance.worlds.game_mode.unknown": {
-    "defaultMessage": "未知的遊戲模式"
-  },
-  "instances.content-install.compatible-count": {
-    "defaultMessage": "{count} 個相容{count, plural, other {實例}}"
-  },
-  "instances.content-install.existing-tab": {
-    "defaultMessage": "已有實例"
-  },
-  "instances.content-install.game-version-placeholder": {
-    "defaultMessage": "選擇遊戲版本"
-  },
-  "instances.content-install.header": {
-    "defaultMessage": "安裝專案"
-  },
-  "instances.content-install.incompatible-tooltip": {
-    "defaultMessage": "這個專案支援的載入器或遊戲版本與這個實例所使用的不同。"
-  },
-  "instances.content-install.install-button": {
-    "defaultMessage": "安裝"
-  },
-  "instances.content-install.installed-badge": {
-    "defaultMessage": "已安裝"
-  },
-  "instances.content-install.instance-type": {
-    "defaultMessage": "實例類型"
-  },
-  "instances.content-install.loader-label": {
-    "defaultMessage": "載入器"
-  },
-  "instances.content-install.name-label": {
-    "defaultMessage": "名稱"
-  },
-  "instances.content-install.name-placeholder": {
-    "defaultMessage": "輸入實例名稱"
-  },
-  "instances.content-install.new-tab": {
-    "defaultMessage": "新的實例"
-  },
-  "instances.content-install.no-instances": {
-    "defaultMessage": "找不到相容的實例"
-  },
-  "instances.content-install.remove-icon": {
-    "defaultMessage": "移除圖示"
-  },
-  "instances.content-install.search-placeholder": {
-    "defaultMessage": "搜尋實例"
-  },
-  "instances.content-install.select-icon": {
-    "defaultMessage": "選擇圖示"
-  },
-  "instances.modpack-content-modal.empty-description": {
-    "defaultMessage": "這個模組包不包含任何額外內容。"
-  },
-  "instances.modpack-content-modal.empty-title": {
-    "defaultMessage": "找不到內容"
-  },
-  "instances.modpack-content-modal.header": {
-    "defaultMessage": "模組包內容"
-  },
-  "instances.modpack-content-modal.loading": {
-    "defaultMessage": "正在載入內容..."
-  },
-  "instances.modpack-content-modal.no-results": {
-    "defaultMessage": "沒有專案符合你的搜尋字詞。"
-  },
-  "instances.modpack-content-modal.search-placeholder": {
-    "defaultMessage": "搜尋 {count, number} {count, plural, other {個專案}}"
-  },
-  "instances.updater-modal.badge.current": {
-    "defaultMessage": "目前"
-  },
-  "instances.updater-modal.badge.incompatible": {
-    "defaultMessage": "不相容"
-  },
-  "instances.updater-modal.downgrade-to": {
-    "defaultMessage": "降級到 {version}"
-  },
-  "instances.updater-modal.header": {
-    "defaultMessage": "更新版本"
-  },
-  "instances.updater-modal.header-modpack": {
-    "defaultMessage": "切換模組包版本"
-  },
-  "instances.updater-modal.header-switch": {
-    "defaultMessage": "切換版本"
-  },
-  "instances.updater-modal.hide-incompatible": {
-    "defaultMessage": "隱藏不相容項目"
-  },
-  "instances.updater-modal.incompatibility-warning": {
-    "defaultMessage": "這個版本與這個實例不相容。相依項將不會自動安裝。"
-  },
-  "instances.updater-modal.incompatibility-warning-header": {
-    "defaultMessage": "選擇版本"
-  },
-  "instances.updater-modal.incompatible-update.description": {
-    "defaultMessage": "{version} 與此實例不相容。它可能無法啟動或運行異常。"
-  },
-  "instances.updater-modal.incompatible-update.header": {
-    "defaultMessage": "更新到不相容版本？"
-  },
-  "instances.updater-modal.incompatible-update.proceed": {
-    "defaultMessage": "仍要更新"
-  },
-  "instances.updater-modal.install-anyway": {
-    "defaultMessage": "仍要安裝"
-  },
-  "instances.updater-modal.loading-changelog": {
-    "defaultMessage": "正在載入更新日誌..."
-  },
-  "instances.updater-modal.loading-versions": {
-    "defaultMessage": "正在載入版本..."
-  },
-  "instances.updater-modal.no-changelog": {
-    "defaultMessage": "這個版本沒有提供更新日誌。"
-  },
-  "instances.updater-modal.no-versions": {
-    "defaultMessage": "找不到版本"
-  },
-  "instances.updater-modal.search-placeholder": {
-    "defaultMessage": "搜尋版本..."
-  },
-  "instances.updater-modal.select-version": {
-    "defaultMessage": "選擇版本以查看更新日誌"
-  },
-  "instances.updater-modal.show-incompatible": {
-    "defaultMessage": "顯示不相容項目"
-  },
-  "instances.updater-modal.switch-to": {
-    "defaultMessage": "切換到 {version}"
-  },
-  "instances.updater-modal.update-to": {
-    "defaultMessage": "更新到 {version}"
-  },
-  "instances.updater-modal.warning-app": {
-    "defaultMessage": "更新可能會導致實例損壞。請先查看版本更新日誌並備份。"
-  },
-  "instances.updater-modal.warning-web": {
-    "defaultMessage": "更新可能會導致世界損壞。請先查看版本更新日誌並備份。"
-  },
-  "label.actions": {
-    "defaultMessage": "動作"
-  },
-  "label.available": {
-    "defaultMessage": "可用餘額 {amount}。"
-  },
-  "label.changelog": {
-    "defaultMessage": "更新日誌"
-  },
-  "label.changes-saved": {
-    "defaultMessage": "變更已儲存"
-  },
-  "label.client-depends-warning": {
-    "defaultMessage": "此模組依賴客戶端模組，啟動伺服器時可能會造成問題"
-  },
-  "label.client-only-warning": {
-    "defaultMessage": "此為用戶端模組，啟動伺服器時可能會導致問題"
-  },
-  "label.client-retained-warning": {
-    "defaultMessage": "這是一個作為依賴項安裝的客戶端模組，啟動伺服器時可能會造成問題"
-  },
-  "label.collections": {
-    "defaultMessage": "收藏"
-  },
-  "label.confirm-password": {
-    "defaultMessage": "確認密碼"
-  },
-  "label.content": {
-    "defaultMessage": "內容"
-  },
-  "label.copied-filename": {
-    "defaultMessage": "已複製檔案名稱"
-  },
-  "label.copied-path": {
-    "defaultMessage": "已複製路徑"
-  },
-  "label.create-failed": {
-    "defaultMessage": "建立失敗"
-  },
-  "label.created-ago": {
-    "defaultMessage": "建立時間：{ago}"
-  },
-  "label.dashboard": {
-    "defaultMessage": "資訊主頁"
-  },
-  "label.delete": {
-    "defaultMessage": "刪除"
-  },
-  "label.delete-failed": {
-    "defaultMessage": "刪除失敗"
-  },
-  "label.delete-immediately": {
-    "defaultMessage": "立即刪除"
-  },
-  "label.description": {
-    "defaultMessage": "描述"
-  },
-  "label.details": {
-    "defaultMessage": "詳細資訊"
-  },
-  "label.done": {
-    "defaultMessage": "完成"
-  },
-  "label.download-failed": {
-    "defaultMessage": "下載失敗"
-  },
-  "label.email": {
-    "defaultMessage": "電子郵件地址"
-  },
-  "label.email-username": {
-    "defaultMessage": "電子郵件地址或使用者名稱"
-  },
-  "label.error": {
-    "defaultMessage": "錯誤"
-  },
-  "label.extract-failed": {
-    "defaultMessage": "解壓縮失敗"
-  },
-  "label.filter-by": {
-    "defaultMessage": "篩選依據"
-  },
-  "label.filters": {
-    "defaultMessage": "篩選器"
-  },
-  "label.followed-projects": {
-    "defaultMessage": "追蹤的專案"
-  },
-  "label.game-version": {
-    "defaultMessage": "遊戲版本"
-  },
-  "label.hide-installed-content": {
-    "defaultMessage": "隱藏已安裝的內容"
-  },
-  "label.hide-selected-content": {
-    "defaultMessage": "隱藏已選取的內容"
-  },
-  "label.installation-info": {
-    "defaultMessage": "安裝資訊"
-  },
-  "label.installed": {
-    "defaultMessage": "已安裝"
-  },
-  "label.installed-modpack": {
-    "defaultMessage": "已安裝模組包"
-  },
-  "label.installing": {
-    "defaultMessage": "安裝中..."
-  },
-  "label.installing-content": {
-    "defaultMessage": "正在安裝內容"
-  },
-  "label.loading": {
-    "defaultMessage": "載入中..."
-  },
-  "label.moderation": {
-    "defaultMessage": "管理"
-  },
-  "label.modpack": {
-    "defaultMessage": "模組包"
-  },
-  "label.move-failed": {
-    "defaultMessage": "移動失敗"
-  },
-  "label.no": {
-    "defaultMessage": "否"
-  },
-  "label.no-items": {
-    "defaultMessage": "沒有項目"
-  },
-  "label.notifications": {
-    "defaultMessage": "通知"
-  },
-  "label.or": {
-    "defaultMessage": "或"
-  },
-  "label.password": {
-    "defaultMessage": "密碼"
-  },
-  "label.plan-custom": {
-    "defaultMessage": "自訂"
-  },
-  "label.plan-large": {
-    "defaultMessage": "大型"
-  },
-  "label.plan-medium": {
-    "defaultMessage": "中型"
-  },
-  "label.plan-small": {
-    "defaultMessage": "小型"
-  },
-  "label.plan-unknown": {
-    "defaultMessage": "未知"
-  },
-  "label.platform": {
-    "defaultMessage": "平臺"
-  },
-  "label.played": {
-    "defaultMessage": "上次遊玩時間：{ago}"
-  },
-  "label.project": {
-    "defaultMessage": "專案"
-  },
-  "label.public": {
-    "defaultMessage": "公開"
-  },
-  "label.rejected": {
-    "defaultMessage": "已拒絕"
-  },
-  "label.rename-failed": {
-    "defaultMessage": "重新命名失敗"
-  },
-  "label.rewards-program-terms-agreement": {
-    "defaultMessage": "我同意《<terms-link>獎勵計畫條款</terms-link>》"
-  },
-  "label.saved": {
-    "defaultMessage": "已儲存"
-  },
-  "label.scopes": {
-    "defaultMessage": "權限範圍"
-  },
-  "label.search": {
-    "defaultMessage": "搜尋"
-  },
-  "label.select-all": {
-    "defaultMessage": "選擇全部"
-  },
-  "label.selected": {
-    "defaultMessage": "已選取"
-  },
-  "label.selection-actions": {
-    "defaultMessage": "選擇動作"
-  },
-  "label.server": {
-    "defaultMessage": "伺服器"
-  },
-  "label.servers": {
-    "defaultMessage": "伺服器"
-  },
-  "label.settings": {
-    "defaultMessage": "設定"
-  },
-  "label.singleplayer": {
-    "defaultMessage": "單人遊戲"
-  },
-  "label.sort-by": {
-    "defaultMessage": "排序依據："
-  },
-  "label.success": {
-    "defaultMessage": "成功"
-  },
-  "label.title": {
-    "defaultMessage": "標題"
-  },
-  "label.unknown": {
-    "defaultMessage": "未知"
-  },
-  "label.unlisted": {
-    "defaultMessage": "不公開"
-  },
-  "label.update-available": {
-    "defaultMessage": "有可用的更新"
-  },
-  "label.updating": {
-    "defaultMessage": "更新中..."
-  },
-  "label.upload-failed": {
-    "defaultMessage": "上傳失敗"
-  },
-  "label.username": {
-    "defaultMessage": "使用者名稱"
-  },
-  "label.validating": {
-    "defaultMessage": "驗證中"
-  },
-  "label.version": {
-    "defaultMessage": "版本"
-  },
-  "label.view": {
-    "defaultMessage": "檢視方式"
-  },
-  "label.visibility": {
-    "defaultMessage": "瀏覽權限"
-  },
-  "label.visit-your-profile": {
-    "defaultMessage": "瀏覽個人檔案"
-  },
-  "label.yes": {
-    "defaultMessage": "是"
-  },
-  "locale.cs-CZ": {
-    "defaultMessage": "捷克文"
-  },
-  "locale.da-DK": {
-    "defaultMessage": "丹麥文"
-  },
-  "locale.de-CH": {
-    "defaultMessage": "德文（瑞士）"
-  },
-  "locale.de-DE": {
-    "defaultMessage": "德文（德國）"
-  },
-  "locale.en-US": {
-    "defaultMessage": "英文（美國）"
-  },
-  "locale.es-419": {
-    "defaultMessage": "西班牙文（拉丁美洲）"
-  },
-  "locale.es-ES": {
-    "defaultMessage": "西班牙文（西班牙）"
-  },
-  "locale.fi-FI": {
-    "defaultMessage": "芬蘭文"
-  },
-  "locale.fil-PH": {
-    "defaultMessage": "菲律賓文"
-  },
-  "locale.fr-FR": {
-    "defaultMessage": "法文"
-  },
-  "locale.he-IL": {
-    "defaultMessage": "希伯來文"
-  },
-  "locale.hu-HU": {
-    "defaultMessage": "匈牙利文"
-  },
-  "locale.id-ID": {
-    "defaultMessage": "印尼文"
-  },
-  "locale.it-IT": {
-    "defaultMessage": "義大利文（義大利）"
-  },
-  "locale.ja-JP": {
-    "defaultMessage": "日文"
-  },
-  "locale.ko-KR": {
-    "defaultMessage": "韓文"
-  },
-  "locale.ms-MY": {
-    "defaultMessage": "馬來文"
-  },
-  "locale.nl-NL": {
-    "defaultMessage": "荷蘭文"
-  },
-  "locale.no-NO": {
-    "defaultMessage": "書面挪威文"
-  },
-  "locale.pl-PL": {
-    "defaultMessage": "波蘭文"
-  },
-  "locale.pt-BR": {
-    "defaultMessage": "葡萄牙文（巴西）"
-  },
-  "locale.pt-PT": {
-    "defaultMessage": "葡萄牙文（葡萄牙）"
-  },
-  "locale.ro-RO": {
-    "defaultMessage": "羅馬尼亞文"
-  },
-  "locale.ru-RU": {
-    "defaultMessage": "俄文"
-  },
-  "locale.sr-CS": {
-    "defaultMessage": "塞爾維亞文（拉丁）"
-  },
-  "locale.sv-SE": {
-    "defaultMessage": "瑞典文"
-  },
-  "locale.th-TH": {
-    "defaultMessage": "泰文"
-  },
-  "locale.tr-TR": {
-    "defaultMessage": "土耳其文"
-  },
-  "locale.uk-UA": {
-    "defaultMessage": "烏克蘭文"
-  },
-  "locale.vi-VN": {
-    "defaultMessage": "越南文"
-  },
-  "locale.zh-CN": {
-    "defaultMessage": "簡體中文"
-  },
-  "locale.zh-TW": {
-    "defaultMessage": "正體中文"
-  },
-  "markdown-editor.default-image-alt-text": {
-    "defaultMessage": "請將此內容替換為描述"
-  },
-  "markdown-editor.error-label": {
-    "defaultMessage": "錯誤"
-  },
-  "markdown-editor.image-modal.description-field.description": {
-    "defaultMessage": "請盡可能詳細描述這張圖片，如同對一位看不見這張圖片的人說明一般。"
-  },
-  "markdown-editor.image-modal.description-field.placeholder": {
-    "defaultMessage": "描述這張圖片..."
-  },
-  "markdown-editor.image-modal.description-field.title": {
-    "defaultMessage": "描述（替代文字）"
-  },
-  "markdown-editor.image-modal.header": {
-    "defaultMessage": "插入圖片"
-  },
-  "markdown-editor.image-modal.upload-mode.label": {
-    "defaultMessage": "圖片來源"
-  },
-  "markdown-editor.image-modal.upload-mode.link": {
-    "defaultMessage": "連結"
-  },
-  "markdown-editor.image-modal.upload-mode.upload": {
-    "defaultMessage": "上傳"
-  },
-  "markdown-editor.image-modal.upload.prompt": {
-    "defaultMessage": "拖曳檔案以上傳或點擊選擇檔案"
-  },
-  "markdown-editor.image-modal.url-field.placeholder": {
-    "defaultMessage": "輸入圖片網址..."
-  },
-  "markdown-editor.insert-button": {
-    "defaultMessage": "插入"
-  },
-  "markdown-editor.link-modal.header": {
-    "defaultMessage": "插入連結"
-  },
-  "markdown-editor.link-modal.label-field.placeholder": {
-    "defaultMessage": "輸入標籤..."
-  },
-  "markdown-editor.link-modal.label-field.title": {
-    "defaultMessage": "標籤"
-  },
-  "markdown-editor.link-modal.url-field.placeholder": {
-    "defaultMessage": "輸入連結網址..."
-  },
-  "markdown-editor.markdown-formatting-support": {
-    "defaultMessage": "這個編輯器支援 <markdown-link>Markdown 格式</markdown-link>。"
-  },
-  "markdown-editor.max-length.label": {
-    "defaultMessage": "長度限制："
-  },
-  "markdown-editor.max-length.unlimited": {
-    "defaultMessage": "無限制"
-  },
-  "markdown-editor.max-length.value": {
-    "defaultMessage": "{currentLength}/{maxLength}"
-  },
-  "markdown-editor.placeholder": {
-    "defaultMessage": "寫點什麼..."
-  },
-  "markdown-editor.preview-label": {
-    "defaultMessage": "預覽"
-  },
-  "markdown-editor.preview-toggle.label": {
-    "defaultMessage": "預覽"
-  },
-  "markdown-editor.toolbar.bold": {
-    "defaultMessage": "粗體"
-  },
-  "markdown-editor.toolbar.bulleted-list": {
-    "defaultMessage": "項目符號清單"
-  },
-  "markdown-editor.toolbar.code": {
-    "defaultMessage": "程式碼"
-  },
-  "markdown-editor.toolbar.heading-1": {
-    "defaultMessage": "標題 1"
-  },
-  "markdown-editor.toolbar.heading-2": {
-    "defaultMessage": "標題 2"
-  },
-  "markdown-editor.toolbar.heading-3": {
-    "defaultMessage": "標題 3"
-  },
-  "markdown-editor.toolbar.image": {
-    "defaultMessage": "圖片"
-  },
-  "markdown-editor.toolbar.italic": {
-    "defaultMessage": "斜體"
-  },
-  "markdown-editor.toolbar.link": {
-    "defaultMessage": "連結"
-  },
-  "markdown-editor.toolbar.ordered-list": {
-    "defaultMessage": "排序清單"
-  },
-  "markdown-editor.toolbar.quote": {
-    "defaultMessage": "引用"
-  },
-  "markdown-editor.toolbar.spoiler": {
-    "defaultMessage": "暴雷內容"
-  },
-  "markdown-editor.toolbar.strikethrough": {
-    "defaultMessage": "刪除線"
-  },
-  "markdown-editor.toolbar.video": {
-    "defaultMessage": "影片"
-  },
-  "markdown-editor.upload-error.no-file": {
-    "defaultMessage": "未提供檔案"
-  },
-  "markdown-editor.upload-error.no-handler": {
-    "defaultMessage": "未提供圖片上傳處理常式"
-  },
-  "markdown-editor.url-label": {
-    "defaultMessage": "網址"
-  },
-  "markdown-editor.url-validation-error.blocked-domain": {
-    "defaultMessage": "無效的網址。不允許這個網域。"
-  },
-  "markdown-editor.url-validation-error.malformed": {
-    "defaultMessage": "無效的網址。請確保網址格式正確。"
-  },
-  "markdown-editor.url-validation-error.unsupported-protocol": {
-    "defaultMessage": "不支援的協定。請使用 http 或 https。"
-  },
-  "markdown-editor.video-embed.title": {
-    "defaultMessage": "YouTube 影片播放器"
-  },
-  "markdown-editor.video-modal.header": {
-    "defaultMessage": "插入 YouTube 影片"
-  },
-  "markdown-editor.video-modal.url-field.description": {
-    "defaultMessage": "請輸入有效的 YouTube 影片連結。"
-  },
-  "markdown-editor.video-modal.url-field.placeholder": {
-    "defaultMessage": "輸入 YouTube 影片網址"
-  },
-  "markdown-editor.video-modal.url-field.title": {
-    "defaultMessage": "YouTube 影片網址"
-  },
-  "modal.open-in-app.benefit.install": {
-    "defaultMessage": "自動安裝所需內容"
-  },
-  "modal.open-in-app.benefit.launch": {
-    "defaultMessage": "直接啟動遊戲並加入伺服器"
-  },
-  "modal.open-in-app.benefit.update": {
-    "defaultMessage": "當伺服器變動時，維持檔案為最新狀態"
-  },
-  "modal.open-in-app.get-app": {
-    "defaultMessage": "取得 Modrinth App"
-  },
-  "modal.open-in-app.opening-automatically": {
-    "defaultMessage": "Modrinth App 將自動開啟..."
-  },
-  "modal.open-in-app.title": {
-    "defaultMessage": "正在開啟 Modrinth App"
-  },
-  "modal.open-in-app.why-use": {
-    "defaultMessage": "為何使用 Modrinth App"
-  },
-  "notification.error.title": {
-    "defaultMessage": "發生錯誤"
-  },
-  "omorphia.component.badge.label.accepted": {
-    "defaultMessage": "已接受"
-  },
-  "omorphia.component.badge.label.approved": {
-    "defaultMessage": "已核准"
-  },
-  "omorphia.component.badge.label.archived": {
-    "defaultMessage": "已封存"
-  },
-  "omorphia.component.badge.label.closed": {
-    "defaultMessage": "已關閉"
-  },
-  "omorphia.component.badge.label.creator": {
-    "defaultMessage": "創作者"
-  },
-  "omorphia.component.badge.label.draft": {
-    "defaultMessage": "草稿"
-  },
-  "omorphia.component.badge.label.failed": {
-    "defaultMessage": "失敗"
-  },
-  "omorphia.component.badge.label.listed": {
-    "defaultMessage": "公開"
-  },
-  "omorphia.component.badge.label.moderator": {
-    "defaultMessage": "管理員"
-  },
-  "omorphia.component.badge.label.modrinth-team": {
-    "defaultMessage": "Modrinth 團隊"
-  },
-  "omorphia.component.badge.label.pending": {
-    "defaultMessage": "待處理"
-  },
-  "omorphia.component.badge.label.private": {
-    "defaultMessage": "私人"
-  },
-  "omorphia.component.badge.label.processed": {
-    "defaultMessage": "已處理"
-  },
-  "omorphia.component.badge.label.rejected": {
-    "defaultMessage": "已拒絕"
-  },
-  "omorphia.component.badge.label.returned": {
-    "defaultMessage": "已退回"
-  },
-  "omorphia.component.badge.label.safe": {
-    "defaultMessage": "通過"
-  },
-  "omorphia.component.badge.label.scheduled": {
-    "defaultMessage": "已排定"
-  },
-  "omorphia.component.badge.label.under-review": {
-    "defaultMessage": "審查中"
-  },
-  "omorphia.component.badge.label.unlisted": {
-    "defaultMessage": "不公開"
-  },
-  "omorphia.component.badge.label.unsafe": {
-    "defaultMessage": "不通過"
-  },
-  "omorphia.component.badge.label.withheld": {
-    "defaultMessage": "由工作人員設為不公開"
-  },
-  "omorphia.component.copy.action.copy": {
-    "defaultMessage": "將程式碼複製到剪貼簿"
-  },
-  "omorphia.component.environment-indicator.label.client": {
-    "defaultMessage": "用戶端"
-  },
-  "omorphia.component.environment-indicator.label.client-and-server": {
-    "defaultMessage": "用戶端與伺服器端"
-  },
-  "omorphia.component.environment-indicator.label.client-or-server": {
-    "defaultMessage": "用戶端或伺服器端"
-  },
-  "omorphia.component.environment-indicator.label.server": {
-    "defaultMessage": "伺服器端"
-  },
-  "omorphia.component.environment-indicator.label.type": {
-    "defaultMessage": "{type}"
-  },
-  "omorphia.component.environment-indicator.label.unsupported": {
-    "defaultMessage": "不支援"
-  },
-  "payment-method.amazon_pay": {
-    "defaultMessage": "Amazon Pay"
-  },
-  "payment-method.amex": {
-    "defaultMessage": "美國運通"
-  },
-  "payment-method.card_display": {
-    "defaultMessage": "{card_brand}（末四碼 {last_four}）"
-  },
-  "payment-method.cashapp": {
-    "defaultMessage": "Cash App"
-  },
-  "payment-method.charity": {
-    "defaultMessage": "慈善機構"
-  },
-  "payment-method.charity-plural": {
-    "defaultMessage": "慈善機構"
-  },
-  "payment-method.diners": {
-    "defaultMessage": "大來卡"
-  },
-  "payment-method.discover": {
-    "defaultMessage": "Discover"
-  },
-  "payment-method.eftpos": {
-    "defaultMessage": "EFTPOS"
-  },
-  "payment-method.gift-card": {
-    "defaultMessage": "禮品卡"
-  },
-  "payment-method.gift-card-plural": {
-    "defaultMessage": "禮品卡"
-  },
-  "payment-method.jcb": {
-    "defaultMessage": "JCB"
-  },
-  "payment-method.mastercard": {
-    "defaultMessage": "萬事達卡"
-  },
-  "payment-method.paypal": {
-    "defaultMessage": "PayPal"
-  },
-  "payment-method.paypal_international": {
-    "defaultMessage": "PayPal 國際"
-  },
-  "payment-method.unionpay": {
-    "defaultMessage": "銀聯"
-  },
-  "payment-method.unknown": {
-    "defaultMessage": "未知的付款方式"
-  },
-  "payment-method.venmo": {
-    "defaultMessage": "Venmo"
-  },
-  "payment-method.virtual-visa": {
-    "defaultMessage": "虛擬 Visa 卡"
-  },
-  "payment-method.virtual-visa-plural": {
-    "defaultMessage": "虛擬 Visa 卡"
-  },
-  "payment-method.visa": {
-    "defaultMessage": "Visa"
-  },
-  "project-card.date.published.tooltip": {
-    "defaultMessage": "發布時間：{date}"
-  },
-  "project-card.date.updated.tooltip": {
-    "defaultMessage": "更新時間：{date}"
-  },
-  "project-card.environment.client": {
-    "defaultMessage": "用戶端"
-  },
-  "project-card.environment.client-and-server": {
-    "defaultMessage": "用戶端與伺服器端"
-  },
-  "project-card.environment.client-or-server": {
-    "defaultMessage": "用戶端或伺服器端"
-  },
-  "project-card.environment.server": {
-    "defaultMessage": "伺服器"
-  },
-  "project-type.all": {
-    "defaultMessage": "全部"
-  },
-  "project-type.datapack.capital": {
-    "defaultMessage": "{count, plural, other {資料包}}"
-  },
-  "project-type.datapack.category": {
-    "defaultMessage": "資料包"
-  },
-  "project-type.datapack.lowercase": {
-    "defaultMessage": "{count, plural, other {資料包}}"
-  },
-  "project-type.mod.capital": {
-    "defaultMessage": "{count, plural, other {模組}}"
-  },
-  "project-type.mod.category": {
-    "defaultMessage": "模組"
-  },
-  "project-type.mod.lowercase": {
-    "defaultMessage": "{count, plural, other {模組}}"
-  },
-  "project-type.modpack.capital": {
-    "defaultMessage": "{count, plural, other {模組包}}"
-  },
-  "project-type.modpack.category": {
-    "defaultMessage": "模組包"
-  },
-  "project-type.modpack.lowercase": {
-    "defaultMessage": "{count, plural, other {模組包}}"
-  },
-  "project-type.plugin.capital": {
-    "defaultMessage": "{count, plural, other {插件}}"
-  },
-  "project-type.plugin.category": {
-    "defaultMessage": "插件"
-  },
-  "project-type.plugin.lowercase": {
-    "defaultMessage": "{count, plural, other {插件}}"
-  },
-  "project-type.project.capital": {
-    "defaultMessage": "{count, plural, other {專案}}"
-  },
-  "project-type.project.category": {
-    "defaultMessage": "專案"
-  },
-  "project-type.project.lowercase": {
-    "defaultMessage": "{count, plural, other {專案}}"
-  },
-  "project-type.resourcepack.capital": {
-    "defaultMessage": "{count, plural, other {資源包}}"
-  },
-  "project-type.resourcepack.category": {
-    "defaultMessage": "資源包"
-  },
-  "project-type.resourcepack.lowercase": {
-    "defaultMessage": "{count, plural, other {資源包}}"
-  },
-  "project-type.server.capital": {
-    "defaultMessage": "{count, plural, one {伺服器} other {伺服器}}"
-  },
-  "project-type.server.category": {
-    "defaultMessage": "伺服器"
-  },
-  "project-type.server.lowercase": {
-    "defaultMessage": "{count, plural, other {伺服器}}"
-  },
-  "project-type.shader.capital": {
-    "defaultMessage": "{count, plural, other {光影包}}"
-  },
-  "project-type.shader.category": {
-    "defaultMessage": "光影包"
-  },
-  "project-type.shader.lowercase": {
-    "defaultMessage": "{count, plural, other {光影包}}"
-  },
-  "project.about.compatibility.environments": {
-    "defaultMessage": "支援環境"
-  },
-  "project.about.compatibility.environments.client-and-server": {
-    "defaultMessage": "用戶端與伺服器端"
-  },
-  "project.about.compatibility.environments.client-side": {
-    "defaultMessage": "用戶端"
-  },
-  "project.about.compatibility.environments.dedicated-servers-only": {
-    "defaultMessage": "僅限專用伺服器"
-  },
-  "project.about.compatibility.environments.server-side": {
-    "defaultMessage": "伺服器端"
-  },
-  "project.about.compatibility.environments.singleplayer": {
-    "defaultMessage": "單人遊戲"
-  },
-  "project.about.compatibility.environments.singleplayer-only": {
-    "defaultMessage": "僅限單人遊戲"
-  },
-  "project.about.compatibility.game.minecraftJava": {
-    "defaultMessage": "Minecraft Java 版"
-  },
-  "project.about.compatibility.platforms": {
-    "defaultMessage": "平臺"
-  },
-  "project.about.compatibility.platforms-plural": {
-    "defaultMessage": "{count, plural, other {平臺}}"
-  },
-  "project.about.compatibility.title": {
-    "defaultMessage": "相容性"
-  },
-  "project.about.creators.organization": {
-    "defaultMessage": "組織"
-  },
-  "project.about.creators.owner": {
-    "defaultMessage": "專案擁有者"
-  },
-  "project.about.creators.title": {
-    "defaultMessage": "創作者"
-  },
-  "project.about.details.created": {
-    "defaultMessage": "建立時間：{date}"
-  },
-  "project.about.details.licensed": {
-    "defaultMessage": "授權條款：{license}"
-  },
-  "project.about.details.published": {
-    "defaultMessage": "發布時間：{date}"
-  },
-  "project.about.details.submitted": {
-    "defaultMessage": "提交時間：{date}"
-  },
-  "project.about.details.updated": {
-    "defaultMessage": "更新時間：{date}"
-  },
-  "project.about.links.discord": {
-    "defaultMessage": "加入 Discord 伺服器"
-  },
-  "project.about.links.donate.bmac": {
-    "defaultMessage": "Buy Me a Coffee"
-  },
-  "project.about.links.donate.generic": {
-    "defaultMessage": "贊助"
-  },
-  "project.about.links.donate.github": {
-    "defaultMessage": "GitHub Sponsors 贊助"
-  },
-  "project.about.links.donate.kofi": {
-    "defaultMessage": "Ko-fi 贊助"
-  },
-  "project.about.links.donate.patreon": {
-    "defaultMessage": "Patreon 贊助"
-  },
-  "project.about.links.donate.paypal": {
-    "defaultMessage": "PayPal 贊助"
-  },
-  "project.about.links.issues": {
-    "defaultMessage": "回報問題"
-  },
-  "project.about.links.site": {
-    "defaultMessage": "前往網站"
-  },
-  "project.about.links.source": {
-    "defaultMessage": "檢視原始碼"
-  },
-  "project.about.links.store": {
-    "defaultMessage": "前往商店頁面"
-  },
-  "project.about.links.title": {
-    "defaultMessage": "相關連結"
-  },
-  "project.about.links.wiki": {
-    "defaultMessage": "前往 wiki"
-  },
-  "project.about.server.address.tooltip": {
-    "defaultMessage": "複製 Java 伺服器位址"
-  },
-  "project.about.server.copied": {
-    "defaultMessage": "已複製！"
-  },
-  "project.about.server.copiedText": {
-    "defaultMessage": "已將伺服器位址複製到剪貼簿"
-  },
-  "project.about.server.downloadModpack": {
-    "defaultMessage": "下載模組包"
-  },
-  "project.about.server.languages": {
-    "defaultMessage": "語言"
-  },
-  "project.about.server.recommendedVersion": {
-    "defaultMessage": "（推薦）"
-  },
-  "project.about.server.region": {
-    "defaultMessage": "地區"
-  },
-  "project.about.server.requiredContent": {
-    "defaultMessage": "必需內容"
-  },
-  "project.about.server.title": {
-    "defaultMessage": "伺服器詳細資訊"
-  },
-  "project.about.tags.title": {
-    "defaultMessage": "標籤"
-  },
-  "project.download-count-tooltip": {
-    "defaultMessage": "{count, number} 次{count, plural, other {下載}}"
-  },
-  "project.follower-count-tooltip": {
-    "defaultMessage": "{count, number} 位{count, plural, other {追蹤者}}"
-  },
-  "project.online-player-count": {
-    "defaultMessage": "{count, number} 人在線上"
-  },
-  "project.online-player-count.tooltip": {
-    "defaultMessage": "{count} 位{countPlural, plural, other {玩家}}在線上"
-  },
-  "project.recent-plays": {
-    "defaultMessage": "{count} 次{countPlural, plural, other {近期遊玩}}"
-  },
-  "project.recent-plays.tooltip": {
-    "defaultMessage": "過去 2 週內來自 Modrinth 的 {count} 次{countPlural, plural, other {最近遊玩次數}}"
-  },
-  "project.server.customModpackTooltip": {
-    "defaultMessage": "這個專案使用了自訂模組包"
-  },
-  "project.server.language.af": {
-    "defaultMessage": "南非文"
-  },
-  "project.server.language.am": {
-    "defaultMessage": "阿姆哈拉文"
-  },
-  "project.server.language.ar": {
-    "defaultMessage": "阿拉伯文"
-  },
-  "project.server.language.az": {
-    "defaultMessage": "亞塞拜然文"
-  },
-  "project.server.language.be": {
-    "defaultMessage": "白俄羅斯文"
-  },
-  "project.server.language.bg": {
-    "defaultMessage": "保加利亞文"
-  },
-  "project.server.language.bn": {
-    "defaultMessage": "孟加拉文"
-  },
-  "project.server.language.bs": {
-    "defaultMessage": "波士尼亞文"
-  },
-  "project.server.language.ca": {
-    "defaultMessage": "加泰隆尼亞文"
-  },
-  "project.server.language.cs": {
-    "defaultMessage": "捷克文"
-  },
-  "project.server.language.da": {
-    "defaultMessage": "丹麥文"
-  },
-  "project.server.language.de": {
-    "defaultMessage": "德文"
-  },
-  "project.server.language.el": {
-    "defaultMessage": "希臘文"
-  },
-  "project.server.language.en": {
-    "defaultMessage": "英文"
-  },
-  "project.server.language.eo": {
-    "defaultMessage": "世界語"
-  },
-  "project.server.language.es": {
-    "defaultMessage": "西班牙文"
-  },
-  "project.server.language.et": {
-    "defaultMessage": "愛沙尼亞文"
-  },
-  "project.server.language.eu": {
-    "defaultMessage": "巴斯克文"
-  },
-  "project.server.language.fa": {
-    "defaultMessage": "波斯文"
-  },
-  "project.server.language.fi": {
-    "defaultMessage": "芬蘭文"
-  },
-  "project.server.language.fr": {
-    "defaultMessage": "法文"
-  },
-  "project.server.language.ga": {
-    "defaultMessage": "愛爾蘭文"
-  },
-  "project.server.language.gl": {
-    "defaultMessage": "加利西亞文"
-  },
-  "project.server.language.he": {
-    "defaultMessage": "希伯來文"
-  },
-  "project.server.language.hi": {
-    "defaultMessage": "印地文"
-  },
-  "project.server.language.hr": {
-    "defaultMessage": "克羅埃西亞文"
-  },
-  "project.server.language.hu": {
-    "defaultMessage": "匈牙利文"
-  },
-  "project.server.language.hy": {
-    "defaultMessage": "亞美尼亞文"
-  },
-  "project.server.language.id": {
-    "defaultMessage": "印尼文"
-  },
-  "project.server.language.is": {
-    "defaultMessage": "冰島文"
-  },
-  "project.server.language.it": {
-    "defaultMessage": "義大利文"
-  },
-  "project.server.language.ja": {
-    "defaultMessage": "日文"
-  },
-  "project.server.language.ka": {
-    "defaultMessage": "喬治亞文"
-  },
-  "project.server.language.kk": {
-    "defaultMessage": "哈薩克文"
-  },
-  "project.server.language.km": {
-    "defaultMessage": "高棉文"
-  },
-  "project.server.language.kn": {
-    "defaultMessage": "坎那達文"
-  },
-  "project.server.language.ko": {
-    "defaultMessage": "韓文"
-  },
-  "project.server.language.lo": {
-    "defaultMessage": "寮文"
-  },
-  "project.server.language.lt": {
-    "defaultMessage": "立陶宛文"
-  },
-  "project.server.language.lv": {
-    "defaultMessage": "拉脫維亞文"
-  },
-  "project.server.language.mk": {
-    "defaultMessage": "馬其頓文"
-  },
-  "project.server.language.ml": {
-    "defaultMessage": "馬來亞拉姆文"
-  },
-  "project.server.language.mn": {
-    "defaultMessage": "蒙古文"
-  },
-  "project.server.language.mr": {
-    "defaultMessage": "馬拉提文"
-  },
-  "project.server.language.ms": {
-    "defaultMessage": "馬來文"
-  },
-  "project.server.language.my": {
-    "defaultMessage": "緬甸文"
-  },
-  "project.server.language.ne": {
-    "defaultMessage": "尼泊爾文"
-  },
-  "project.server.language.nl": {
-    "defaultMessage": "荷蘭文"
-  },
-  "project.server.language.no": {
-    "defaultMessage": "挪威文"
-  },
-  "project.server.language.pa": {
-    "defaultMessage": "旁遮普文"
-  },
-  "project.server.language.pl": {
-    "defaultMessage": "波蘭文"
-  },
-  "project.server.language.pt": {
-    "defaultMessage": "葡萄牙文"
-  },
-  "project.server.language.ro": {
-    "defaultMessage": "羅馬尼亞文"
-  },
-  "project.server.language.ru": {
-    "defaultMessage": "俄文"
-  },
-  "project.server.language.si": {
-    "defaultMessage": "僧伽羅文"
-  },
-  "project.server.language.sk": {
-    "defaultMessage": "斯洛伐克文"
-  },
-  "project.server.language.sl": {
-    "defaultMessage": "斯洛維尼亞文"
-  },
-  "project.server.language.sq": {
-    "defaultMessage": "阿爾巴尼亞文"
-  },
-  "project.server.language.sr": {
-    "defaultMessage": "塞爾維亞文"
-  },
-  "project.server.language.sv": {
-    "defaultMessage": "瑞典文"
-  },
-  "project.server.language.sw": {
-    "defaultMessage": "斯瓦希里文"
-  },
-  "project.server.language.ta": {
-    "defaultMessage": "泰米爾文"
-  },
-  "project.server.language.te": {
-    "defaultMessage": "泰盧固文"
-  },
-  "project.server.language.th": {
-    "defaultMessage": "泰文"
-  },
-  "project.server.language.tl": {
-    "defaultMessage": "菲律賓文"
-  },
-  "project.server.language.tr": {
-    "defaultMessage": "土耳其文"
-  },
-  "project.server.language.uk": {
-    "defaultMessage": "烏克蘭文"
-  },
-  "project.server.language.ur": {
-    "defaultMessage": "烏爾都文"
-  },
-  "project.server.language.uz": {
-    "defaultMessage": "烏茲別克文"
-  },
-  "project.server.language.vi": {
-    "defaultMessage": "越南文"
-  },
-  "project.server.language.yo": {
-    "defaultMessage": "約魯巴文"
-  },
-  "project.server.language.zh": {
-    "defaultMessage": "中文"
-  },
-  "project.server.language.zu": {
-    "defaultMessage": "祖魯文"
-  },
-  "project.server.ping.ms": {
-    "defaultMessage": "{ping, number} 毫秒"
-  },
-  "project.server.region.asia": {
-    "defaultMessage": "亞洲"
-  },
-  "project.server.region.australia": {
-    "defaultMessage": "澳洲"
-  },
-  "project.server.region.europe": {
-    "defaultMessage": "歐洲"
-  },
-  "project.server.region.middle_east": {
-    "defaultMessage": "中東"
-  },
-  "project.server.region.russia": {
-    "defaultMessage": "俄羅斯"
-  },
-  "project.server.region.south_america": {
-    "defaultMessage": "南美洲"
-  },
-  "project.server.region.tooltip": {
-    "defaultMessage": "伺服器位於{regionName}"
-  },
-  "project.server.region.us_east": {
-    "defaultMessage": "美國東部"
-  },
-  "project.server.region.us_west": {
-    "defaultMessage": "美國西部"
-  },
-  "project.server.status.offline": {
-    "defaultMessage": "離線"
-  },
-  "project.server.status.offline.tooltip": {
-    "defaultMessage": "伺服器已離線"
-  },
-  "project.server.status.online": {
-    "defaultMessage": "線上"
-  },
-  "project.settings.analytics.title": {
-    "defaultMessage": "數據分析"
-  },
-  "project.settings.content.title": {
-    "defaultMessage": "內容"
-  },
-  "project.settings.description.title": {
-    "defaultMessage": "描述"
-  },
-  "project.settings.environment.title": {
-    "defaultMessage": "環境"
-  },
-  "project.settings.gallery.title": {
-    "defaultMessage": "圖庫"
-  },
-  "project.settings.general.title": {
-    "defaultMessage": "一般"
-  },
-  "project.settings.license.title": {
-    "defaultMessage": "授權條款"
-  },
-  "project.settings.links.title": {
-    "defaultMessage": "連結"
-  },
-  "project.settings.members.title": {
-    "defaultMessage": "成員"
-  },
-  "project.settings.notice.no-permission.description": {
-    "defaultMessage": "你沒有編輯這個設定的權限。"
-  },
-  "project.settings.notice.no-permission.title": {
-    "defaultMessage": "沒有權限"
-  },
-  "project.settings.server.title": {
-    "defaultMessage": "伺服器"
-  },
-  "project.settings.tags.title": {
-    "defaultMessage": "標籤"
-  },
-  "project.settings.upload.title": {
-    "defaultMessage": "上傳"
-  },
-  "project.settings.versions.permissions": {
-    "defaultMessage": "權限"
-  },
-  "project.settings.versions.title": {
-    "defaultMessage": "版本"
-  },
-  "project.settings.view.title": {
-    "defaultMessage": "檢視"
-  },
-  "project.versions.channel.alpha.symbol": {
-    "defaultMessage": "A"
-  },
-  "project.versions.channel.beta.symbol": {
-    "defaultMessage": "B"
-  },
-  "project.versions.channel.release.symbol": {
-    "defaultMessage": "R"
-  },
-  "project.versions.version.withheld": {
-    "defaultMessage": "保留"
-  },
-  "project.versions.version.withheld.tooltip": {
-    "defaultMessage": "版本由於缺少授權資訊而被保留"
-  },
-  "project.versions.withheld-versions-warning.resolve-button": {
-    "defaultMessage": "解決"
-  },
-  "project.visibility.archived": {
-    "defaultMessage": "已封存"
-  },
-  "project.visibility.draft": {
-    "defaultMessage": "草稿"
-  },
-  "project.visibility.private": {
-    "defaultMessage": "私人"
-  },
-  "project.visibility.public": {
-    "defaultMessage": "公開"
-  },
-  "project.visibility.rejected": {
-    "defaultMessage": "已拒絕"
-  },
-  "project.visibility.scheduled": {
-    "defaultMessage": "已排定"
-  },
-  "project.visibility.under-review": {
-    "defaultMessage": "審查中"
-  },
-  "project.visibility.unknown": {
-    "defaultMessage": "未知"
-  },
-  "project.visibility.unlisted": {
-    "defaultMessage": "不公開"
-  },
-  "project.visibility.unlisted-by-staff": {
-    "defaultMessage": "由工作人員設為不公開"
-  },
-  "report.item-type.content": {
-    "defaultMessage": "內容"
-  },
-  "report.item-type.project": {
-    "defaultMessage": "專案"
-  },
-  "report.item-type.user": {
-    "defaultMessage": "使用者"
-  },
-  "report.item-type.version": {
-    "defaultMessage": "版本"
-  },
-  "search.filter.locked.default": {
-    "defaultMessage": "篩選器已鎖定"
-  },
-  "search.filter.locked.default.description": {
-    "defaultMessage": "解鎖這個篩選器可能導致安裝不相容的內容。"
-  },
-  "search.filter.locked.default.sync": {
-    "defaultMessage": "同步篩選器"
-  },
-  "search.filter.locked.default.title": {
-    "defaultMessage": "{type} 已鎖定"
-  },
-  "search.filter.locked.default.unlock": {
-    "defaultMessage": "解鎖篩選器"
-  },
-  "search.filter.option.exclusion.add.tooltip": {
-    "defaultMessage": "排除"
-  },
-  "search.filter.option.search.clear.aria_label": {
-    "defaultMessage": "清除搜尋"
-  },
-  "search.filter.option.search.placeholder": {
-    "defaultMessage": "搜尋..."
-  },
-  "search.filter.option.show_fewer": {
-    "defaultMessage": "只顯示部分內容"
-  },
-  "search.filter.option.show_more": {
-    "defaultMessage": "顯示更多內容"
-  },
-  "search.filter_type.environment": {
-    "defaultMessage": "環境"
-  },
-  "search.filter_type.environment.client": {
-    "defaultMessage": "用戶端"
-  },
-  "search.filter_type.environment.server": {
-    "defaultMessage": "伺服器端"
-  },
-  "search.filter_type.game_version": {
-    "defaultMessage": "遊戲版本"
-  },
-  "search.filter_type.game_version.all_versions": {
-    "defaultMessage": "顯示所有版本"
-  },
-  "search.filter_type.license": {
-    "defaultMessage": "授權條款"
-  },
-  "search.filter_type.license.open_source": {
-    "defaultMessage": "開放原始碼"
-  },
-  "search.filter_type.mod_loader": {
-    "defaultMessage": "載入器"
-  },
-  "search.filter_type.modpack_loader": {
-    "defaultMessage": "載入器"
-  },
-  "search.filter_type.plugin_loader": {
-    "defaultMessage": "載入器"
-  },
-  "search.filter_type.plugin_platform": {
-    "defaultMessage": "平臺"
-  },
-  "search.filter_type.project_id": {
-    "defaultMessage": "專案 ID"
-  },
-  "search.filter_type.server_content_type": {
-    "defaultMessage": "類型"
-  },
-  "search.filter_type.server_language": {
-    "defaultMessage": "語言"
-  },
-  "search.filter_type.server_region": {
-    "defaultMessage": "地區"
-  },
-  "search.filter_type.server_status": {
-    "defaultMessage": "狀態"
-  },
-  "search.filter_type.shader_loader": {
-    "defaultMessage": "載入器"
-  },
-  "search.server_content_type.modpack": {
-    "defaultMessage": "模組支援"
-  },
-  "search.server_content_type.vanilla": {
-    "defaultMessage": "原版"
-  },
-  "servers.notice.dismiss": {
-    "defaultMessage": "撤銷"
-  },
-  "servers.notice.dismissable": {
-    "defaultMessage": "可撤銷"
-  },
-  "servers.notice.heading.attention": {
-    "defaultMessage": "注意"
-  },
-  "servers.notice.heading.info": {
-    "defaultMessage": "資訊"
-  },
-  "servers.notice.level.critical.name": {
-    "defaultMessage": "重要"
-  },
-  "servers.notice.level.info.name": {
-    "defaultMessage": "資訊"
-  },
-  "servers.notice.level.survey.name": {
-    "defaultMessage": "問卷"
-  },
-  "servers.notice.level.warn.name": {
-    "defaultMessage": "警告"
-  },
-  "servers.notice.undismissable": {
-    "defaultMessage": "不可撤銷"
-  },
-  "servers.region.australia": {
-    "defaultMessage": "澳洲"
-  },
-  "servers.region.central-europe": {
-    "defaultMessage": "中歐"
-  },
-  "servers.region.north-america-central": {
-    "defaultMessage": "北美中部"
-  },
-  "servers.region.north-america-east": {
-    "defaultMessage": "北美東部"
-  },
-  "servers.region.north-america-west": {
-    "defaultMessage": "北美西部"
-  },
-  "servers.region.southeast-asia": {
-    "defaultMessage": "東南亞"
-  },
-  "servers.region.western-europe": {
-    "defaultMessage": "西歐"
-  },
-  "servers.setup.upload-warning": {
-    "defaultMessage": "上傳時請勿關閉此頁面。"
-  },
-  "servers.setup.uploading-modpack.header": {
-    "defaultMessage": "正在上傳模組包"
-  },
-  "settings.account.title": {
-    "defaultMessage": "帳號和安全性"
-  },
-  "settings.appearance.title": {
-    "defaultMessage": "外觀"
-  },
-  "settings.applications.title": {
-    "defaultMessage": "你的應用程式"
-  },
-  "settings.authorized-apps.title": {
-    "defaultMessage": "已授權的應用程式"
-  },
-  "settings.display.theme.dark": {
-    "defaultMessage": "深色"
-  },
-  "settings.display.theme.description": {
-    "defaultMessage": "依照偏好，設定這部裝置的 Modrinth 主題顏色。"
-  },
-  "settings.display.theme.light": {
-    "defaultMessage": "淺色"
-  },
-  "settings.display.theme.oled": {
-    "defaultMessage": "OLED"
-  },
-  "settings.display.theme.preferred-dark-theme": {
-    "defaultMessage": "偏好深色主題"
-  },
-  "settings.display.theme.preferred-light-theme": {
-    "defaultMessage": "偏好淺色主題"
-  },
-  "settings.display.theme.retro": {
-    "defaultMessage": "復古"
-  },
-  "settings.display.theme.system": {
-    "defaultMessage": "與系統同步"
-  },
-  "settings.display.theme.title": {
-    "defaultMessage": "色彩主題"
-  },
-  "settings.feature-flags.title": {
-    "defaultMessage": "功能旗標"
-  },
-  "settings.language.categories.default": {
-    "defaultMessage": "標準語言"
-  },
-  "settings.language.categories.search-result": {
-    "defaultMessage": "搜尋結果"
-  },
-  "settings.language.description": {
-    "defaultMessage": "選擇你偏好的{platform}語言。翻譯由 <crowdin-link>Crowdin</crowdin-link> 上的志願者所貢獻。"
-  },
-  "settings.language.languages.search-field.placeholder": {
-    "defaultMessage": "搜尋語言..."
-  },
-  "settings.language.languages.search-results-announcement": {
-    "defaultMessage": "{matches, plural, =0 {未搜尋到相關語言} other {有 # 個語言符合搜尋字詞}}。"
-  },
-  "settings.language.languages.search.no-results": {
-    "defaultMessage": "沒有語言符合你的搜尋字詞。"
-  },
-  "settings.language.platform.app": {
-    "defaultMessage": "應用程式"
-  },
-  "settings.language.platform.site": {
-    "defaultMessage": "網站"
-  },
-  "settings.language.title": {
-    "defaultMessage": "語言"
-  },
-  "settings.language.warning": {
-    "defaultMessage": "變更{platform}的語言後，若部分內容尚未提供翻譯，則會以英文顯示。{platform}目前尚未完全翻譯，因此，在某些語言下，部分內容仍可能以英文顯示。"
-  },
-  "settings.pats.title": {
-    "defaultMessage": "個人存取權杖"
-  },
-  "settings.profile.title": {
-    "defaultMessage": "公開個人檔案"
-  },
-  "settings.sessions.title": {
-    "defaultMessage": "工作階段"
-  },
-  "tag.category.128x": {
-    "defaultMessage": "128x"
-  },
-  "tag.category.16x": {
-    "defaultMessage": "16x"
-  },
-  "tag.category.256x": {
-    "defaultMessage": "256x"
-  },
-  "tag.category.32x": {
-    "defaultMessage": "32x"
-  },
-  "tag.category.48x": {
-    "defaultMessage": "48x"
-  },
-  "tag.category.512x+": {
-    "defaultMessage": "512× 以上"
-  },
-  "tag.category.64x": {
-    "defaultMessage": "64x"
-  },
-  "tag.category.8x-": {
-    "defaultMessage": "8× 以下"
-  },
-  "tag.category.adventure": {
-    "defaultMessage": "冒險"
-  },
-  "tag.category.adventure-mode": {
-    "defaultMessage": "冒險模式"
-  },
-  "tag.category.anarchy": {
-    "defaultMessage": "無政府"
-  },
-  "tag.category.atmosphere": {
-    "defaultMessage": "大氣效果"
-  },
-  "tag.category.audio": {
-    "defaultMessage": "音效"
-  },
-  "tag.category.battle-royale": {
-    "defaultMessage": "大逃殺"
-  },
-  "tag.category.bedwars": {
-    "defaultMessage": "床戰"
-  },
-  "tag.category.blocks": {
-    "defaultMessage": "方塊"
-  },
-  "tag.category.bloom": {
-    "defaultMessage": "泛光"
-  },
-  "tag.category.bosses": {
-    "defaultMessage": "Boss"
-  },
-  "tag.category.cartoon": {
-    "defaultMessage": "卡通"
-  },
-  "tag.category.challenging": {
-    "defaultMessage": "挑戰"
-  },
-  "tag.category.classes": {
-    "defaultMessage": "職業"
-  },
-  "tag.category.colored-lighting": {
-    "defaultMessage": "彩色光照"
-  },
-  "tag.category.combat": {
-    "defaultMessage": "戰鬥"
-  },
-  "tag.category.competitive": {
-    "defaultMessage": "競技"
-  },
-  "tag.category.core-shaders": {
-    "defaultMessage": "核心著色器"
-  },
-  "tag.category.creative-mode": {
-    "defaultMessage": "創造模式"
-  },
-  "tag.category.creator-community": {
-    "defaultMessage": "創作者社群"
-  },
-  "tag.category.crossplay": {
-    "defaultMessage": "跨平臺"
-  },
-  "tag.category.cursed": {
-    "defaultMessage": "邪門"
-  },
-  "tag.category.custom-content": {
-    "defaultMessage": "自訂內容"
-  },
-  "tag.category.decoration": {
-    "defaultMessage": "裝飾"
-  },
-  "tag.category.dungeons": {
-    "defaultMessage": "副本"
-  },
-  "tag.category.economy": {
-    "defaultMessage": "經濟"
-  },
-  "tag.category.entities": {
-    "defaultMessage": "實體"
-  },
-  "tag.category.environment": {
-    "defaultMessage": "環境"
-  },
-  "tag.category.equipment": {
-    "defaultMessage": "裝備"
-  },
-  "tag.category.factions": {
-    "defaultMessage": "派系"
-  },
-  "tag.category.fantasy": {
-    "defaultMessage": "奇幻"
-  },
-  "tag.category.foliage": {
-    "defaultMessage": "植被"
-  },
-  "tag.category.fonts": {
-    "defaultMessage": "字型"
-  },
-  "tag.category.food": {
-    "defaultMessage": "食物"
-  },
-  "tag.category.game-mechanics": {
-    "defaultMessage": "遊戲機制"
-  },
-  "tag.category.gens": {
-    "defaultMessage": "生成器"
-  },
-  "tag.category.gui": {
-    "defaultMessage": "GUI"
-  },
-  "tag.category.hardcore-mode": {
-    "defaultMessage": "極限模式"
-  },
-  "tag.category.high": {
-    "defaultMessage": "高"
-  },
-  "tag.category.items": {
-    "defaultMessage": "物品"
-  },
-  "tag.category.keep-inventory": {
-    "defaultMessage": "保留物品欄"
-  },
-  "tag.category.kitchen-sink": {
-    "defaultMessage": "大雜燴"
-  },
-  "tag.category.kitpvp": {
-    "defaultMessage": "Kit PvP"
-  },
-  "tag.category.library": {
-    "defaultMessage": "程式庫"
-  },
-  "tag.category.lifesteal": {
-    "defaultMessage": "生命竊取"
-  },
-  "tag.category.lightweight": {
-    "defaultMessage": "輕量"
-  },
-  "tag.category.locale": {
-    "defaultMessage": "在地化"
-  },
-  "tag.category.low": {
-    "defaultMessage": "低"
-  },
-  "tag.category.magic": {
-    "defaultMessage": "魔法"
-  },
-  "tag.category.management": {
-    "defaultMessage": "管理"
-  },
-  "tag.category.media": {
-    "defaultMessage": "媒體"
-  },
-  "tag.category.medium": {
-    "defaultMessage": "中"
-  },
-  "tag.category.microgames": {
-    "defaultMessage": "微型遊戲"
-  },
-  "tag.category.minigame": {
-    "defaultMessage": "小遊戲"
-  },
-  "tag.category.minigames": {
-    "defaultMessage": "小遊戲"
-  },
-  "tag.category.mmo": {
-    "defaultMessage": "MMO"
-  },
-  "tag.category.mobs": {
-    "defaultMessage": "生物"
-  },
-  "tag.category.modded": {
-    "defaultMessage": "模組支援"
-  },
-  "tag.category.models": {
-    "defaultMessage": "模型"
-  },
-  "tag.category.multiplayer": {
-    "defaultMessage": "多人遊戲"
-  },
-  "tag.category.network": {
-    "defaultMessage": "群組伺服器"
-  },
-  "tag.category.offline-mode": {
-    "defaultMessage": "離線模式"
-  },
-  "tag.category.oneblock": {
-    "defaultMessage": "一格方塊"
-  },
-  "tag.category.op": {
-    "defaultMessage": "OP"
-  },
-  "tag.category.optimization": {
-    "defaultMessage": "最佳化"
-  },
-  "tag.category.parkour": {
-    "defaultMessage": "跑酷"
-  },
-  "tag.category.path-tracing": {
-    "defaultMessage": "光線追蹤"
-  },
-  "tag.category.pbr": {
-    "defaultMessage": "PBR"
-  },
-  "tag.category.personal-worlds": {
-    "defaultMessage": "個人世界"
-  },
-  "tag.category.plots": {
-    "defaultMessage": "地塊"
-  },
-  "tag.category.pokemon": {
-    "defaultMessage": "寶可夢"
-  },
-  "tag.category.potato": {
-    "defaultMessage": "馬鈴薯"
-  },
-  "tag.category.prison": {
-    "defaultMessage": "監獄"
-  },
-  "tag.category.pve": {
-    "defaultMessage": "PvE"
-  },
-  "tag.category.pvp": {
-    "defaultMessage": "PvP"
-  },
-  "tag.category.questing": {
-    "defaultMessage": "任務"
-  },
-  "tag.category.quests": {
-    "defaultMessage": "任務"
-  },
-  "tag.category.racing": {
-    "defaultMessage": "競速"
-  },
-  "tag.category.realistic": {
-    "defaultMessage": "寫實"
-  },
-  "tag.category.recording-smp": {
-    "defaultMessage": "錄影 SMP"
-  },
-  "tag.category.reflections": {
-    "defaultMessage": "折射"
-  },
-  "tag.category.roleplay": {
-    "defaultMessage": "角色扮演"
-  },
-  "tag.category.rpg": {
-    "defaultMessage": "RPG"
-  },
-  "tag.category.screenshot": {
-    "defaultMessage": "擷圖用"
-  },
-  "tag.category.semi-realistic": {
-    "defaultMessage": "半寫實"
-  },
-  "tag.category.shadows": {
-    "defaultMessage": "陰影"
-  },
-  "tag.category.simplistic": {
-    "defaultMessage": "簡約"
-  },
-  "tag.category.skyblock": {
-    "defaultMessage": "空島生存"
-  },
-  "tag.category.smp": {
-    "defaultMessage": "SMP"
-  },
-  "tag.category.social": {
-    "defaultMessage": "社交"
-  },
-  "tag.category.storage": {
-    "defaultMessage": "儲物管理"
-  },
-  "tag.category.survival-mode": {
-    "defaultMessage": "生存模式"
-  },
-  "tag.category.teams": {
-    "defaultMessage": "團隊"
-  },
-  "tag.category.technical": {
-    "defaultMessage": "技術性"
-  },
-  "tag.category.technology": {
-    "defaultMessage": "科技"
-  },
-  "tag.category.themed": {
-    "defaultMessage": "特定主題"
-  },
-  "tag.category.towns": {
-    "defaultMessage": "城鎮"
-  },
-  "tag.category.transportation": {
-    "defaultMessage": "交通"
-  },
-  "tag.category.tweaks": {
-    "defaultMessage": "微調"
-  },
-  "tag.category.utility": {
-    "defaultMessage": "工具"
-  },
-  "tag.category.vanilla-like": {
-    "defaultMessage": "類原版"
-  },
-  "tag.category.whitelisted": {
-    "defaultMessage": "白名單"
-  },
-  "tag.category.world-resets": {
-    "defaultMessage": "世界重設"
-  },
-  "tag.category.worldgen": {
-    "defaultMessage": "世界生成"
-  },
-  "tag.loader.babric": {
-    "defaultMessage": "Babric"
-  },
-  "tag.loader.bta-babric": {
-    "defaultMessage": "BTA（Babric）"
-  },
-  "tag.loader.bukkit": {
-    "defaultMessage": "Bukkit"
-  },
-  "tag.loader.bungeecord": {
-    "defaultMessage": "BungeeCord"
-  },
-  "tag.loader.canvas": {
-    "defaultMessage": "Canvas"
-  },
-  "tag.loader.datapack": {
-    "defaultMessage": "資料包"
-  },
-  "tag.loader.fabric": {
-    "defaultMessage": "Fabric"
-  },
-  "tag.loader.folia": {
-    "defaultMessage": "Folia"
-  },
-  "tag.loader.forge": {
-    "defaultMessage": "Forge"
-  },
-  "tag.loader.geyser": {
-    "defaultMessage": "Geyser 擴充"
-  },
-  "tag.loader.iris": {
-    "defaultMessage": "Iris"
-  },
-  "tag.loader.java-agent": {
-    "defaultMessage": "Java 代理"
-  },
-  "tag.loader.legacy-fabric": {
-    "defaultMessage": "Legacy Fabric"
-  },
-  "tag.loader.liteloader": {
-    "defaultMessage": "LiteLoader"
-  },
-  "tag.loader.minecraft": {
-    "defaultMessage": "資源包"
-  },
-  "tag.loader.modloader": {
-    "defaultMessage": "Risugami's ModLoader"
-  },
-  "tag.loader.mrpack": {
-    "defaultMessage": "模組包"
-  },
-  "tag.loader.neoforge": {
-    "defaultMessage": "NeoForge"
-  },
-  "tag.loader.nilloader": {
-    "defaultMessage": "NilLoader"
-  },
-  "tag.loader.optifine": {
-    "defaultMessage": "OptiFine"
-  },
-  "tag.loader.ornithe": {
-    "defaultMessage": "Ornithe"
-  },
-  "tag.loader.paper": {
-    "defaultMessage": "Paper"
-  },
-  "tag.loader.purpur": {
-    "defaultMessage": "Purpur"
-  },
-  "tag.loader.quilt": {
-    "defaultMessage": "Quilt"
-  },
-  "tag.loader.rift": {
-    "defaultMessage": "Rift"
-  },
-  "tag.loader.spigot": {
-    "defaultMessage": "Spigot"
-  },
-  "tag.loader.sponge": {
-    "defaultMessage": "Sponge"
-  },
-  "tag.loader.vanilla": {
-    "defaultMessage": "原版著色器"
-  },
-  "tag.loader.velocity": {
-    "defaultMessage": "Velocity"
-  },
-  "tag.loader.waterfall": {
-    "defaultMessage": "Waterfall"
-  },
-  "time-frame-picker.apply": {
-    "defaultMessage": "套用"
-  },
-  "time-frame-picker.cancel": {
-    "defaultMessage": "取消"
-  },
-  "time-frame-picker.clear-range": {
-    "defaultMessage": "清除"
-  },
-  "time-frame-picker.custom-range": {
-    "defaultMessage": "自訂日期範圍..."
-  },
-  "time-frame-picker.decrease-amount": {
-    "defaultMessage": "減少時間範圍時長"
-  },
-  "time-frame-picker.empty-range": {
-    "defaultMessage": "未選取日期範圍。"
-  },
-  "time-frame-picker.end-date": {
-    "defaultMessage": "結束日期"
-  },
-  "time-frame-picker.increase-amount": {
-    "defaultMessage": "增加時間範圍時長"
-  },
-  "time-frame-picker.last-timeframe": {
-    "defaultMessage": "在過去 {amount} {unit, select, hours {{amount, plural, other {小時}}} days {{amount, plural, other {天}}} weeks {{amount, plural, other {週}}} months {{amount, plural, other {月}}} other {天}}"
-  },
-  "time-frame-picker.last-timeframe-prefix": {
-    "defaultMessage": "在過去"
-  },
-  "time-frame-picker.option.all-time": {
-    "defaultMessage": "所有時間"
-  },
-  "time-frame-picker.option.last-14-days": {
-    "defaultMessage": "過去 14 天"
-  },
-  "time-frame-picker.option.last-180-days": {
-    "defaultMessage": "過去 180 天"
-  },
-  "time-frame-picker.option.last-30-days": {
-    "defaultMessage": "過去 30 天"
-  },
-  "time-frame-picker.option.last-7-days": {
-    "defaultMessage": "過去 7 天"
-  },
-  "time-frame-picker.option.last-90-days": {
-    "defaultMessage": "過去 90 天"
-  },
-  "time-frame-picker.option.today": {
-    "defaultMessage": "今天"
-  },
-  "time-frame-picker.option.year-to-date": {
-    "defaultMessage": "今年迄今"
-  },
-  "time-frame-picker.option.yesterday": {
-    "defaultMessage": "昨天"
-  },
-  "time-frame-picker.select-timeframe": {
-    "defaultMessage": "選取時間範圍"
-  },
-  "time-frame-picker.selected-range": {
-    "defaultMessage": "選取範圍"
-  },
-  "time-frame-picker.selecting-range": {
-    "defaultMessage": "選取中"
-  },
-  "time-frame-picker.start-date": {
-    "defaultMessage": "開始日期"
-  },
-  "time-frame-picker.timeframe-amount": {
-    "defaultMessage": "時間範圍時長"
-  },
-  "time-frame-picker.timeframe-unit": {
-    "defaultMessage": "時間範圍單位"
-  },
-  "time-frame-picker.unit.days": {
-    "defaultMessage": "天"
-  },
-  "time-frame-picker.unit.hours": {
-    "defaultMessage": "小時"
-  },
-  "time-frame-picker.unit.months": {
-    "defaultMessage": "月"
-  },
-  "time-frame-picker.unit.weeks": {
-    "defaultMessage": "週"
-  },
-  "ui.component.unsaved-changes-popup.body": {
-    "defaultMessage": "你的變更尚未儲存。"
-  },
-  "ui.confirm-leave-modal.body": {
-    "defaultMessage": "您有未儲存的變更，如果離開此頁面將會遺失"
-  },
-  "ui.confirm-leave-modal.header": {
-    "defaultMessage": "您有未儲存的變更"
-  },
-  "ui.confirm-leave-modal.leave": {
-    "defaultMessage": "離開頁面"
-  },
-  "ui.confirm-leave-modal.stay": {
-    "defaultMessage": "留在頁面"
-  },
-  "ui.confirm-leave-modal.title": {
-    "defaultMessage": "離開頁面？"
-  },
-  "ui.stacked-admonitions.alert-count": {
-    "defaultMessage": "{count, plural, other {# 個警示}}"
-  },
-  "ui.stacked-admonitions.dismiss-all": {
-    "defaultMessage": "忽略全部"
-  },
-  "version.content.name": {
-    "defaultMessage": "名稱"
-  },
-  "version.content.version": {
-    "defaultMessage": "版本"
-  },
-  "version.file-type.dev-jar": {
-    "defaultMessage": "開發用 jar"
-  },
-  "version.file-type.javadoc-jar": {
-    "defaultMessage": "Javadoc jar"
-  },
-  "version.file-type.optional-resource-pack": {
-    "defaultMessage": "可選資源包"
-  },
-  "version.file-type.primary": {
-    "defaultMessage": "主要"
-  },
-  "version.file-type.required-resource-pack": {
-    "defaultMessage": "所需資源包"
-  },
-  "version.file-type.signature": {
-    "defaultMessage": "簽署文件"
-  },
-  "version.file-type.sources-jar": {
-    "defaultMessage": "原始碼 jar"
-  },
-  "version.file-type.unknown": {
-    "defaultMessage": "其他"
-  },
-  "version.section.changes": {
-    "defaultMessage": "變更"
-  },
-  "version.section.compatibility": {
-    "defaultMessage": "相容性"
-  },
-  "version.section.content": {
-    "defaultMessage": "內容"
-  },
-  "version.section.content.search-placeholder": {
-    "defaultMessage": "搜尋內容..."
-  },
-  "version.section.dependencies.any-compatible-version": {
-    "defaultMessage": "任何相容的版本"
-  },
-  "version.section.dependencies.any-version": {
-    "defaultMessage": "任何版本"
-  },
-  "version.section.dependencies.unavailable-version": {
-    "defaultMessage": "不可用版本"
-  },
-  "version.section.dependencies.unavailable-version.description": {
-    "defaultMessage": "這個版本可能已被刪除，或正在由管理員審查。"
-  },
-  "version.section.dependencies.unavailable-version.description.required": {
-    "defaultMessage": "所需版本可能已被刪除，或正在由管理員審查。"
-  },
-  "version.section.files": {
-    "defaultMessage": "檔案"
-  },
-  "version.section.included-content": {
-    "defaultMessage": "包含的內容"
-  },
-  "version.section.known-incompatibilities": {
-    "defaultMessage": "已知不相容"
-  },
-  "version.section.no-changes": {
-    "defaultMessage": "未提供變更日誌。"
-  },
-  "version.section.no-modpack-mod-loader": {
-    "defaultMessage": "無模組載入器"
-  },
-  "version.section.optional-dependencies": {
-    "defaultMessage": "可選相依項"
-  },
-  "version.section.required-content": {
-    "defaultMessage": "所需內容"
-  },
-  "version.section.supplementary-resources": {
-    "defaultMessage": "補充資源"
-  },
-  "version.supplementary-resources.file": {
-    "defaultMessage": "檔案"
-  },
-  "version.supplementary-resources.size": {
-    "defaultMessage": "檔案大小"
-  },
-  "version.supplementary-resources.type": {
-    "defaultMessage": "類型"
-  },
-  "files.row.parent-folder": {
-    "message": "Parent folder"
-  },
-  "omorphia.component.loading-indicator.label": {
-    "message": "Loading"
-  },
-  "drop.confirm.title": {
-    "message": "你想以什麼類型匯入？"
-  },
-  "drop.confirm.cancel": {
-    "message": "取消"
-  },
-  "drop.confirm.help": {
-    "message": "我可以拖入什麼？"
-  },
-  "drop.confirm.as-mod": {
-    "message": "模組"
-  },
-  "drop.confirm.as-mod-desc": {
-    "message": "將模組 JAR 安裝到 Minecraft 實例"
-  },
-  "drop.confirm.as-instance": {
-    "message": "實例"
-  },
-  "drop.confirm.as-instance-desc": {
-    "message": "從其他啟動器匯入 Minecraft 實例"
-  },
-  "drop.confirm.as-modpack": {
-    "message": "整合包"
-  },
-  "drop.confirm.as-modpack-desc": {
-    "message": "從整合包建立新實例"
-  },
-  "drop.confirm.as-resource-pack": {
-    "message": "資源包"
-  },
-  "drop.confirm.as-resource-pack-desc": {
-    "message": "將資源包安裝到實例"
-  },
-  "drop.confirm.as-shader-pack": {
-    "message": "光影包"
-  },
-  "drop.confirm.as-shader-pack-desc": {
-    "message": "將光影包安裝到實例"
-  },
-  "drop.confirm.as-world": {
-    "message": "存檔"
-  },
-  "drop.confirm.as-world-desc": {
-    "message": "將存檔匯入到實例中"
-  },
-  "drop.confirm.as-schematic": {
-    "message": "投影"
-  },
-  "drop.confirm.as-schematic-desc": {
-    "message": "匯入 Litematic 投影檔案"
-  },
-  "drop.confirm.as-dot-minecraft": {
-    "message": ".minecraft"
-  },
-  "drop.confirm.as-dot-minecraft-desc": {
-    "message": "掃描 .minecraft 資料夾以建立實例"
-  },
-  "drop.confirm.as-launcher": {
-    "message": "啟動器"
-  },
-  "drop.confirm.as-hmcl-launcher": {
-    "message": "HMCL 啟動器"
-  },
-  "drop.generic_install.title": {
-    "message": "安裝 {type}"
-  },
-  "drop.generic_install.search": {
-    "message": "搜尋實例..."
-  },
-  "drop.generic_install.install": {
-    "message": "安裝"
-  },
-  "drop.generic_install.cancel": {
-    "message": "取消"
-  },
-  "drop.generic_install.create_new": {
-    "message": "建立新實例..."
-  },
-  "drop.generic_install.no_instances": {
-    "message": "找不到實例"
-  },
-  "drop.launcher_import.title": {
-    "message": "從 {launcherName} 匯入實例"
-  },
-  "drop.launcher_import.subtitle": {
-    "message": "在 {basePath} 中掃描到 {count} 個實例"
-  },
-  "drop.launcher_import.select_all": {
-    "message": "全選"
-  },
-  "drop.launcher_import.deselect_all": {
-    "message": "取消全選"
-  },
-  "drop.launcher_import.selected": {
-    "message": "已選 {n} 個"
-  },
-  "drop.launcher_import.cancel": {
-    "message": "取消"
-  },
-  "drop.launcher_import.import": {
-    "message": "匯入（{n}）"
-  },
-  "drop.launcher_import.no_instances": {
-    "message": "找不到實例"
-  },
-  "drop.symlink_method.title": {
-    "message": "選擇匯入方式"
-  },
-  "drop.symlink_method.subtitle": {
-    "message": "正在匯入 {n} 個實例"
-  },
-  "drop.symlink_method.copy_title": {
-    "message": "複製檔案"
-  },
-  "drop.symlink_method.copy_desc": {
-    "message": "複製到 Axolotl 目錄"
-  },
-  "drop.symlink_method.symlink_title": {
-    "message": "符號連結"
-  },
-  "drop.symlink_method.symlink_desc": {
-    "message": "引用原始位置"
-  },
-  "drop.symlink_method.requires_admin": {
-    "message": "建立連結時將要求一次系統管理員授權（UAC）"
-  },
-  "drop.symlink_method.unsupported_warning": {
-    "message": "此系統不支援符號連結"
-  },
-  "drop.symlink_method.cancel": {
-    "message": "取消"
-  },
-  "drop.symlink_method.confirm": {
-    "message": "確認"
-  },
-  "project.versions.filter.toggle-tooltip": {
-    "message": "Toggle filter for {filter}"
-  },
-  "project.versions.platform.modloader.short": {
-    "message": "ModLoader"
-  },
-  "skin.preview.drag-to-rotate": {
-    "message": "Drag to rotate"
-  },
-  "browse.sort.relevance": {
-    "message": "Relevance"
-  },
-  "browse.sort.downloads": {
-    "message": "Downloads"
-  },
-  "browse.sort.followers": {
-    "message": "Followers"
-  },
-  "browse.sort.date-published": {
-    "message": "Date published"
-  },
-  "browse.sort.date-updated": {
-    "message": "Date updated"
-  },
-  "browse.sort.verified-plays": {
-    "message": "Verified plays"
-  },
-  "browse.sort.players": {
-    "message": "Players"
-  },
-  "content.card.pending-manual-download": {
-    "message": "Manual download required"
-  },
-  "content.card.rollback-tooltip": {
-    "defaultMessage": "回滾到 {fileName}"
-  },
-  "app.symlink-warning.write.header": {
-    "message": "Shared instance"
-  },
-  "app.symlink-warning.write.body": {
-    "message": "This instance is linked to "
-  },
-  "instances.updater-modal.search-compat": {
-    "message": "尋找相容版本"
-  },
-  "files.delete-modal.bulk-header": {
-    "message": "Delete multiple items"
-  },
-  "files.delete-modal.deleting-multiple": {
-    "message": "Deleting {count} items"
-  },
-  "files.delete-modal.bulk-warning": {
-    "message": "The selected items will be permanently deleted. This action cannot be undone."
-  },
-  "files.delete-modal.symlink-warning-header": {
-    "message": "Shared instance"
-  },
-  "files.delete-modal.symlink-warning-body": {
-    "message": "You are modifying files in a shared instance linked to "
-  },
-  "button.open-in-browser": {
-    "message": "Open in browser"
-  },
-  "label.server-only": {
-    "message": "Server only"
-  },
-  "button.switch-to-version": {
-    "message": "Switch to version"
-  },
-  "project-type.schematic.category": {
-    "message": "投影"
-  },
-  "project-type.schematic.capital": {
-    "message": "{count, plural, one {投影} other {投影}}"
-  },
-  "project-type.schematic.lowercase": {
-    "message": "{count, plural, one {投影} other {投影}}"
-  },
-  "search.filter_type.advanced.exclude_mod": {
-    "message": "Exclude mods"
-  },
-  "search.filter_type.advanced.exclude_plugin": {
-    "message": "Exclude plugins"
-  },
-  "search.filter_type.advanced.exclude_datapack": {
-    "message": "Exclude data packs"
-  },
-  "search.filter_type.advanced": {
-    "message": "Advanced"
-  },
-  "header.category.cf-extra": {
-    "message": "More CurseForge categories"
-  },
-  "project.environment.tag.not-applicable": {
-    "defaultMessage": "不適用"
-  },
-  "project.environment.tag.unknown": {
-    "defaultMessage": "未知"
-  }
+	"action.no-permission": {
+		"defaultMessage": "你沒有權限。"
+	},
+	"app.symlink-warning.write.body": {
+		"message": "This instance is linked to "
+	},
+	"app.symlink-warning.write.header": {
+		"message": "Shared instance"
+	},
+	"badge.alpha": {
+		"defaultMessage": "Alpha 版"
+	},
+	"badge.beta": {
+		"defaultMessage": "Beta 版"
+	},
+	"badge.beta-release": {
+		"defaultMessage": "Beta 版發布"
+	},
+	"badge.new": {
+		"defaultMessage": "新功能"
+	},
+	"badge.release": {
+		"defaultMessage": "正式版"
+	},
+	"browse.filter-results": {
+		"defaultMessage": "篩選結果..."
+	},
+	"browse.no-results": {
+		"defaultMessage": "找不到符合你查詢的結果！"
+	},
+	"browse.offline": {
+		"defaultMessage": "你目前處於離線狀態，請連線至網路以瀏覽 Modrinth！"
+	},
+	"browse.search.placeholder": {
+		"defaultMessage": "搜尋{projectType}..."
+	},
+	"browse.selected-projects-floating-bar.aria-label": {
+		"defaultMessage": "已選取專案"
+	},
+	"browse.selected-projects-floating-bar.hide-projects": {
+		"defaultMessage": "隐藏已选项目"
+	},
+	"browse.selected-projects-floating-bar.install": {
+		"defaultMessage": "安裝 {count, plural, other {# 個專案}}"
+	},
+	"browse.selected-projects-floating-bar.selected-count": {
+		"defaultMessage": "{count, plural, other {已選取 # 個專案}}"
+	},
+	"browse.selected-projects-floating-bar.show-projects": {
+		"defaultMessage": "显示{count, plural, other {#个已选项目}}"
+	},
+	"browse.selected-projects-leave-modal.admonition-body": {
+		"defaultMessage": "你已選取 {count, plural, other {# 個專案}}來安裝。立即安裝專案，或返回而不安裝。"
+	},
+	"browse.selected-projects-leave-modal.admonition-header": {
+		"defaultMessage": "你選取的專案尚未安裝"
+	},
+	"browse.selected-projects-leave-modal.discard": {
+		"defaultMessage": "捨棄"
+	},
+	"browse.selected-projects-leave-modal.header": {
+		"defaultMessage": "你選取的專案尚未安裝"
+	},
+	"browse.sort.date-published": {
+		"message": "Date published"
+	},
+	"browse.sort.date-updated": {
+		"message": "Date updated"
+	},
+	"browse.sort.downloads": {
+		"message": "Downloads"
+	},
+	"browse.sort.followers": {
+		"message": "Followers"
+	},
+	"browse.sort.players": {
+		"message": "Players"
+	},
+	"browse.sort.relevance": {
+		"message": "Relevance"
+	},
+	"browse.sort.verified-plays": {
+		"message": "Verified plays"
+	},
+	"browse.view-prefix": {
+		"defaultMessage": "檢視模式："
+	},
+	"button.accept": {
+		"defaultMessage": "接受"
+	},
+	"button.add-server-to-instance": {
+		"defaultMessage": "將伺服器新增至實例"
+	},
+	"button.affiliate-links": {
+		"defaultMessage": "聯盟連結"
+	},
+	"button.analytics": {
+		"defaultMessage": "數據分析"
+	},
+	"button.back": {
+		"defaultMessage": "返回"
+	},
+	"button.cancel": {
+		"defaultMessage": "取消"
+	},
+	"button.change-version": {
+		"defaultMessage": "變更版本"
+	},
+	"button.clear": {
+		"defaultMessage": "清除"
+	},
+	"button.close": {
+		"defaultMessage": "關閉"
+	},
+	"button.continue": {
+		"defaultMessage": "繼續"
+	},
+	"button.copy-filename": {
+		"defaultMessage": "複製檔案名稱"
+	},
+	"button.copy-full-path": {
+		"defaultMessage": "複製完整路徑"
+	},
+	"button.copy-id": {
+		"defaultMessage": "複製 ID"
+	},
+	"button.copy-link": {
+		"defaultMessage": "複製連結"
+	},
+	"button.copy-permalink": {
+		"defaultMessage": "複製永久連結"
+	},
+	"button.create-a-project": {
+		"defaultMessage": "建立專案"
+	},
+	"button.decline": {
+		"defaultMessage": "拒絕"
+	},
+	"button.disable": {
+		"defaultMessage": "停用"
+	},
+	"button.download": {
+		"defaultMessage": "下載"
+	},
+	"button.downloading": {
+		"defaultMessage": "下載中"
+	},
+	"button.edit": {
+		"defaultMessage": "編輯"
+	},
+	"button.enable": {
+		"defaultMessage": "啟用"
+	},
+	"button.extract": {
+		"defaultMessage": "解壓縮"
+	},
+	"button.follow": {
+		"defaultMessage": "追蹤"
+	},
+	"button.hide-snapshots": {
+		"defaultMessage": "隱藏快照版本"
+	},
+	"button.install": {
+		"defaultMessage": "安裝"
+	},
+	"button.max": {
+		"defaultMessage": "最大值"
+	},
+	"button.more-options": {
+		"defaultMessage": "更多選項"
+	},
+	"button.move": {
+		"defaultMessage": "移動"
+	},
+	"button.next": {
+		"defaultMessage": "下一步"
+	},
+	"button.open-folder": {
+		"defaultMessage": "開啟資料夾"
+	},
+	"button.open-in-browser": {
+		"message": "Open in browser"
+	},
+	"button.open-in-folder": {
+		"defaultMessage": "在資料夾中開啟"
+	},
+	"button.open-in-modrinth": {
+		"defaultMessage": "在 Modrinth 中開啟"
+	},
+	"button.play": {
+		"defaultMessage": "遊玩"
+	},
+	"button.refresh": {
+		"defaultMessage": "重新整理"
+	},
+	"button.reinstall-modpack": {
+		"defaultMessage": "重新安裝模組包"
+	},
+	"button.remove": {
+		"defaultMessage": "刪除通行金鑰"
+	},
+	"button.remove-image": {
+		"defaultMessage": "移除圖片"
+	},
+	"button.rename": {
+		"defaultMessage": "重新命名"
+	},
+	"button.repair": {
+		"defaultMessage": "修復"
+	},
+	"button.repairing": {
+		"defaultMessage": "修復中..."
+	},
+	"button.report": {
+		"defaultMessage": "檢舉"
+	},
+	"button.reset": {
+		"defaultMessage": "重設"
+	},
+	"button.reset-server": {
+		"defaultMessage": "重設伺服器"
+	},
+	"button.retry": {
+		"defaultMessage": "重試"
+	},
+	"button.save": {
+		"defaultMessage": "儲存"
+	},
+	"button.save-changes": {
+		"defaultMessage": "儲存變更"
+	},
+	"button.saving": {
+		"defaultMessage": "儲存中"
+	},
+	"button.show-all-versions": {
+		"defaultMessage": "顯示所有版本"
+	},
+	"button.show-file": {
+		"defaultMessage": "顯示檔案"
+	},
+	"button.sign-in": {
+		"defaultMessage": "登入"
+	},
+	"button.sign-out": {
+		"defaultMessage": "登出"
+	},
+	"button.sign-up": {
+		"defaultMessage": "註冊"
+	},
+	"button.stop": {
+		"defaultMessage": "停止"
+	},
+	"button.switch-to-version": {
+		"message": "Switch to version"
+	},
+	"button.switch-version": {
+		"defaultMessage": "切換版本"
+	},
+	"button.unfollow": {
+		"defaultMessage": "取消追蹤"
+	},
+	"button.unlink-modpack": {
+		"defaultMessage": "取消連結模組包"
+	},
+	"button.update": {
+		"defaultMessage": "更新"
+	},
+	"button.upload-image": {
+		"defaultMessage": "上傳圖片"
+	},
+	"collections.label.private": {
+		"defaultMessage": "私人"
+	},
+	"console.action.collapse": {
+		"defaultMessage": "收合"
+	},
+	"console.action.expand": {
+		"defaultMessage": "展開"
+	},
+	"console.action.share": {
+		"defaultMessage": "分享"
+	},
+	"console.command.disabled-placeholder": {
+		"defaultMessage": "指令輸入已停用"
+	},
+	"console.command.server-not-running-placeholder": {
+		"defaultMessage": "伺服器未執行"
+	},
+	"console.crash.export-context": {
+		"defaultMessage": "匯出崩潰內容"
+	},
+	"console.crash.finding.amd-driver.action": {
+		"defaultMessage": "全新安裝最新版 AMD 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
+	},
+	"console.crash.finding.amd-driver.title": {
+		"defaultMessage": "AMD 顯示卡驅動程式崩潰"
+	},
+	"console.crash.finding.content-verification.action": {
+		"defaultMessage": "從可信來源重新安裝證據中指出的檔案。"
+	},
+	"console.crash.finding.content-verification.title": {
+		"defaultMessage": "jar 簽章驗證失敗"
+	},
+	"console.crash.finding.definite-mod-fabric.action": {
+		"defaultMessage": "更新或暫時移除 Fabric 載入器證據中指出的模組。"
+	},
+	"console.crash.finding.definite-mod-fabric.title": {
+		"defaultMessage": "Fabric 發現特定模組故障"
+	},
+	"console.crash.finding.definite-mod.action": {
+		"defaultMessage": "更新、修復或暫時移除證據和相符 jar 中指出的模組。"
+	},
+	"console.crash.finding.definite-mod.title": {
+		"defaultMessage": "特定模組導致崩潰"
+	},
+	"console.crash.finding.duplicate-mod.action": {
+		"defaultMessage": "在 mods 資料夾中，每個模組只保留一個相容版本。"
+	},
+	"console.crash.finding.duplicate-mod.title": {
+		"defaultMessage": "安裝了重複模組"
+	},
+	"console.crash.finding.extracted-mod.action": {
+		"defaultMessage": "從 mods 資料夾移除解壓縮後的目錄，並安裝原始 jar 檔案。"
+	},
+	"console.crash.finding.extracted-mod.title": {
+		"defaultMessage": "發現已解壓縮的模組"
+	},
+	"console.crash.finding.fabric-solution.action": {
+		"defaultMessage": "依證據中列出的相依性變更處理後再啟動。"
+	},
+	"console.crash.finding.fabric-solution.title": {
+		"defaultMessage": "Fabric 發現不相容模組或缺少相依性"
+	},
+	"console.crash.finding.fallback-action": {
+		"defaultMessage": "檢視下方證據和本機實例中相符的模組。"
+	},
+	"console.crash.finding.fallback-title": {
+		"defaultMessage": "未知診斷：{finding}"
+	},
+	"console.crash.finding.forge-error.action": {
+		"defaultMessage": "檢視 Forge 故障證據，並在撤銷近期變更後測試指出的模組。"
+	},
+	"console.crash.finding.forge-error.title": {
+		"defaultMessage": "Forge 回報了遊戲錯誤"
+	},
+	"console.crash.finding.forge-incomplete.action": {
+		"defaultMessage": "修復或重新安裝此實例的 Forge 載入器。"
+	},
+	"console.crash.finding.forge-incomplete.title": {
+		"defaultMessage": "Forge 安裝不完整"
+	},
+	"console.crash.finding.forge-java-incompatible.action": {
+		"defaultMessage": "使用此 Forge 版本所需的 Java 版本，或更新 Forge。"
+	},
+	"console.crash.finding.forge-java-incompatible.title": {
+		"defaultMessage": "此 Forge 版本與所選 Java 執行環境不相容"
+	},
+	"console.crash.finding.incompatible-mods.action": {
+		"defaultMessage": "依證據中的相容性詳情更新、移除或替換衝突模組。"
+	},
+	"console.crash.finding.incompatible-mods.title": {
+		"defaultMessage": "已安裝的模組互不相容"
+	},
+	"console.crash.finding.intel-driver.action": {
+		"defaultMessage": "安裝最新版 Intel 顯示卡驅動程式，或改用其他可用 GPU 執行 Minecraft。"
+	},
+	"console.crash.finding.intel-driver.title": {
+		"defaultMessage": "Intel 顯示卡驅動程式崩潰"
+	},
+	"console.crash.finding.java-11-required.action": {
+		"defaultMessage": "選擇 Java 11，或安裝與所選 Java 版本相容的模組版本。"
+	},
+	"console.crash.finding.java-11-required.title": {
+		"defaultMessage": "模組需要 Java 11"
+	},
+	"console.crash.finding.java-32bit.action": {
+		"defaultMessage": "安裝並選擇 64 位元 Java 執行環境，然後重試啟動。"
+	},
+	"console.crash.finding.java-32bit.title": {
+		"defaultMessage": "32 位元 Java 執行環境無法配置所需記憶體"
+	},
+	"console.crash.finding.java-incompatible.action": {
+		"defaultMessage": "使用相容的 Java 執行環境，或安裝適用於此 Java 版本的模組版本。"
+	},
+	"console.crash.finding.java-incompatible.title": {
+		"defaultMessage": "模組需要其他 Java 版本"
+	},
+	"console.crash.finding.java-too-new.action": {
+		"defaultMessage": "選擇此 Minecraft 和模組載入器版本所需的 Java 主要版本。"
+	},
+	"console.crash.finding.java-too-new.title": {
+		"defaultMessage": "Java 執行環境版本對此實例過新"
+	},
+	"console.crash.finding.jdk-runtime.action": {
+		"defaultMessage": "為此 Minecraft 版本選擇標準 HotSpot Java 執行環境。"
+	},
+	"console.crash.finding.jdk-runtime.title": {
+		"defaultMessage": "選擇了 JDK 而不是 JRE"
+	},
+	"console.crash.finding.jvm-arguments.action": {
+		"defaultMessage": "移除報告中指出的自訂 JVM 參數，然後重新啟動實例。"
+	},
+	"console.crash.finding.jvm-arguments.title": {
+		"defaultMessage": "JVM 參數無效"
+	},
+	"console.crash.finding.large-resource-pack.action": {
+		"defaultMessage": "停用該資源包，或改用解析度較低的版本。"
+	},
+	"console.crash.finding.large-resource-pack.title": {
+		"defaultMessage": "目前資源包對圖形設定而言過大"
+	},
+	"console.crash.finding.manual-debug-crash.action": {
+		"defaultMessage": "重新啟動，並避免長按手動偵錯崩潰快速鍵。"
+	},
+	"console.crash.finding.manual-debug-crash.title": {
+		"defaultMessage": "觸發了偵錯崩潰快速鍵"
+	},
+	"console.crash.finding.matched-mod": {
+		"defaultMessage": "相符模組：{identity}{modId} - {fileName}"
+	},
+	"console.crash.finding.missing-dependency.action": {
+		"defaultMessage": "安裝所需的相依性版本，或使用與此 Minecraft 版本相符的模組版本。"
+	},
+	"console.crash.finding.missing-dependency.title": {
+		"defaultMessage": "模組相依性缺少或不受支援"
+	},
+	"console.crash.finding.mixin-bootstrap.action": {
+		"defaultMessage": "修復模組載入器安裝，並確認所有模組均適用於已安裝的載入器。"
+	},
+	"console.crash.finding.mixin-bootstrap.title": {
+		"defaultMessage": "缺少 Mixin 啟動程序"
+	},
+	"console.crash.finding.mixin-failure.action": {
+		"defaultMessage": "更新或移除相符的模組，並檢查其 Minecraft 和載入器版本是否相容。"
+	},
+	"console.crash.finding.mixin-failure.title": {
+		"defaultMessage": "模組 Mixin 套用失敗"
+	},
+	"console.crash.finding.mod-config.action": {
+		"defaultMessage": "備份並移除指出的設定檔，讓模組重新產生它。"
+	},
+	"console.crash.finding.mod-config.title": {
+		"defaultMessage": "無法讀取模組設定檔"
+	},
+	"console.crash.finding.mod-filename.action": {
+		"defaultMessage": "使用簡單的拉丁字母檔名重新命名或安裝模組 jar。"
+	},
+	"console.crash.finding.mod-filename.title": {
+		"defaultMessage": "模組檔名包含不支援的字元"
+	},
+	"console.crash.finding.mod-id-limit.action": {
+		"defaultMessage": "移除未使用的模組，或將安裝內容拆分為較小的相容設定檔。"
+	},
+	"console.crash.finding.mod-id-limit.title": {
+		"defaultMessage": "模組過多，超出 ID 限制"
+	},
+	"console.crash.finding.mod-initialization.action": {
+		"defaultMessage": "更新指出的模組，並確認其所需相依性均已安裝。"
+	},
+	"console.crash.finding.mod-initialization.title": {
+		"defaultMessage": "模組初始化失敗"
+	},
+	"console.crash.finding.mod-loader-error.action": {
+		"defaultMessage": "修復載入器安裝，並確認列出的模組檔案與此遊戲版本相符。"
+	},
+	"console.crash.finding.mod-loader-error.title": {
+		"defaultMessage": "模組載入器回報了故障"
+	},
+	"console.crash.finding.mod-loader-failure.action": {
+		"defaultMessage": "修復載入器安裝，並依證據中顯示的故障訊息處理。"
+	},
+	"console.crash.finding.mod-loader-failure.title": {
+		"defaultMessage": "模組載入器在識別模組檔案前失敗"
+	},
+	"console.crash.finding.multiple-forge-versions.action": {
+		"defaultMessage": "修復實例，使其版本設定檔中只包含一個 Forge 安裝。"
+	},
+	"console.crash.finding.multiple-forge-versions.title": {
+		"defaultMessage": "版本設定檔中包含多個 Forge 版本"
+	},
+	"console.crash.finding.nightconfig-bug.action": {
+		"defaultMessage": "備份 config 資料夾，移除損壞設定，讓模組重新產生它。"
+	},
+	"console.crash.finding.nightconfig-bug.title": {
+		"defaultMessage": "NightConfig 無法讀取設定檔"
+	},
+	"console.crash.finding.nvidia-driver.action": {
+		"defaultMessage": "全新安裝最新版 NVIDIA 顯示卡驅動程式，並關閉圖形覆蓋層後重試。"
+	},
+	"console.crash.finding.nvidia-driver.title": {
+		"defaultMessage": "NVIDIA 顯示卡驅動程式崩潰"
+	},
+	"console.crash.finding.opengl-unsupported.action": {
+		"defaultMessage": "安裝 GPU 製造商提供的顯示卡驅動程式，並確認 Minecraft 使用預期的 GPU。"
+	},
+	"console.crash.finding.opengl-unsupported.title": {
+		"defaultMessage": "目前顯示卡驅動程式不支援 OpenGL"
+	},
+	"console.crash.finding.openj9.action": {
+		"defaultMessage": "選擇以 HotSpot 為基礎的 Java 執行環境，例如 Eclipse Temurin 或內建 Minecraft 執行環境。"
+	},
+	"console.crash.finding.openj9.title": {
+		"defaultMessage": "所選 OpenJ9 執行環境不相容"
+	},
+	"console.crash.finding.optifine-incompatible.action": {
+		"defaultMessage": "安裝相容的 OptiFine 版本，或移除 OptiFine 和衝突的光影模組。"
+	},
+	"console.crash.finding.optifine-incompatible.title": {
+		"defaultMessage": "OptiFine 與已安裝的載入器或模組衝突"
+	},
+	"console.crash.finding.optifine-world.action": {
+		"defaultMessage": "移除 OptiFine，或安裝與此 Minecraft 和 Forge 版本相容的版本。"
+	},
+	"console.crash.finding.optifine-world.title": {
+		"defaultMessage": "OptiFine 阻止世界載入"
+	},
+	"console.crash.finding.out-of-memory.action": {
+		"defaultMessage": "增加實例記憶體配置，或移除占用大量記憶體的模組和資源包。"
+	},
+	"console.crash.finding.out-of-memory.title": {
+		"defaultMessage": "Minecraft 記憶體不足"
+	},
+	"console.crash.finding.pixel-format.action": {
+		"defaultMessage": "更新或重新安裝顯示卡驅動程式，停用衝突的覆蓋層後重試。"
+	},
+	"console.crash.finding.pixel-format.title": {
+		"defaultMessage": "顯示卡驅動程式無法設定像素格式"
+	},
+	"console.crash.finding.resource-pack.action": {
+		"defaultMessage": "停用目前光影和資源包，再逐一重新啟用。"
+	},
+	"console.crash.finding.resource-pack.title": {
+		"defaultMessage": "光影或資源包觸發圖形錯誤"
+	},
+	"console.crash.finding.shaders-optifine.action": {
+		"defaultMessage": "移除單獨的光影模組，因為 OptiFine 已提供光影支援。"
+	},
+	"console.crash.finding.shaders-optifine.title": {
+		"defaultMessage": "同時安裝了光影模組和 OptiFine"
+	},
+	"console.crash.finding.short-output.action": {
+		"defaultMessage": "重試一次，然後檢查 Java、載入器安裝和啟動器輸出中較早出現的錯誤。"
+	},
+	"console.crash.finding.short-output.title": {
+		"defaultMessage": "遊戲在產生有效日誌前停止"
+	},
+	"console.crash.finding.specific-block.action": {
+		"defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的方塊。"
+	},
+	"console.crash.finding.specific-block.title": {
+		"defaultMessage": "特定方塊導致崩潰"
+	},
+	"console.crash.finding.specific-entity.action": {
+		"defaultMessage": "使用世界備份或世界編輯器，移除證據所示座標處的實體。"
+	},
+	"console.crash.finding.specific-entity.title": {
+		"defaultMessage": "特定實體導致崩潰"
+	},
+	"console.crash.finding.stack-analysis.action": {
+		"defaultMessage": "更新或暫時移除相符的模組，然後重新測試實例。"
+	},
+	"console.crash.finding.stack-analysis.title": {
+		"defaultMessage": "堆疊追蹤指向已安裝的模組"
+	},
+	"console.crash.finding.suspected-mod.action": {
+		"defaultMessage": "更新或暫時移除報告懷疑且本機相符的模組，然後重試。"
+	},
+	"console.crash.finding.suspected-mod.title": {
+		"defaultMessage": "崩潰報告懷疑一個或多個模組"
+	},
+	"console.crash.local-header": {
+		"defaultMessage": "{findings, plural, other {# 項本機診斷結果}}，來自 {sources, plural, other {# 個相關檔案}}"
+	},
+	"console.crash.problems-detected": {
+		"defaultMessage": "偵測到 {count, plural, other {# 個問題}}"
+	},
+	"console.delete-modal.confirmation": {
+		"defaultMessage": "刪除後無法復原此日誌檔案。確定要繼續嗎？"
+	},
+	"console.delete-modal.irreversible-title": {
+		"defaultMessage": "此操作無法復原"
+	},
+	"console.delete-modal.title": {
+		"defaultMessage": "刪除日誌檔案"
+	},
+	"console.filter.error": {
+		"defaultMessage": "錯誤"
+	},
+	"console.filter.info": {
+		"defaultMessage": "資訊"
+	},
+	"console.filter.warn": {
+		"defaultMessage": "警告"
+	},
+	"console.notification.delete-failed": {
+		"defaultMessage": "刪除日誌檔案失敗"
+	},
+	"console.notification.share-failed": {
+		"defaultMessage": "分享日誌失敗"
+	},
+	"console.notification.share-truncated": {
+		"defaultMessage": "日志过大，已自动截取最后 9MB 上传。"
+	},
+	"console.notification.unknown-error": {
+		"defaultMessage": "未知錯誤。"
+	},
+	"console.log.toggle-wrap": {
+		"defaultMessage": "切换换行"
+	},
+	"console.log.wrap-label": {
+		"defaultMessage": "换行"
+	},
+	"console.empty.instance-title": {
+		"defaultMessage": "暂无日志"
+	},
+	"console.empty.instance-description": {
+		"defaultMessage": "点击右上角「开始游戏」即可接收实时日志"
+	},
+	"console.empty.server-title": {
+		"defaultMessage": "欢迎使用 Modrinth 服务器！"
+	},
+	"console.empty.server-description": {
+		"defaultMessage": "点击启动按钮即可启动服务器！"
+	},
+	"console.search.placeholder": {
+		"defaultMessage": "搜尋日誌"
+	},
+	"console.share-modal.title": {
+		"defaultMessage": "分享日誌"
+	},
+	"content-type.content.lowercase": {
+		"defaultMessage": "內容"
+	},
+	"content-type.item.lowercase": {
+		"defaultMessage": "{count, plural, other {項目}}"
+	},
+	"content.card.dependency-badge": {
+		"defaultMessage": "前置"
+	},
+	"content.card.duplicate-mod": {
+		"defaultMessage": "此模组已安装 {count, number} 次。"
+	},
+	"content.card.group.hardcore": {
+		"defaultMessage": "硬核模式"
+	},
+	"content.card.group.not-played-yet": {
+		"defaultMessage": "尚未游玩"
+	},
+	"content.card.orphaned-dependency-badge": {
+		"defaultMessage": "孤立前置"
+	},
+	"content.card.pending-manual-download": {
+		"message": "Manual download required"
+	},
+	"content.card.rollback-tooltip": {
+		"defaultMessage": "回滾到 {fileName}"
+	},
+	"content.card.select-project": {
+		"defaultMessage": "選取「{project}」"
+	},
+	"content.confirm-bulk-update.admonition-body": {
+		"defaultMessage": "確定要將這 {count, plural, other {# 個專案}}更新至最新的相容版本嗎？建議你逐一進行更新。"
+	},
+	"content.confirm-bulk-update.admonition-header": {
+		"defaultMessage": "更新警告"
+	},
+	"content.confirm-bulk-update.header": {
+		"defaultMessage": "更新專案"
+	},
+	"content.confirm-bulk-update.update-button": {
+		"defaultMessage": "更新 {count, plural, other {# 個專案}}"
+	},
+	"content.confirm-deletion.admonition-body": {
+		"defaultMessage": "刪除模組可能會對你的世界造成永久性影響，並在重新載入時導致內容遺失或發生非預期的問題。"
+	},
+	"content.confirm-deletion.admonition-header": {
+		"defaultMessage": "刪除警告"
+	},
+	"content.confirm-deletion.delete-button": {
+		"defaultMessage": "刪除 {count, number} 個{itemType}"
+	},
+	"content.confirm-deletion.header": {
+		"defaultMessage": "刪除{itemType}"
+	},
+	"content.confirm-modpack-update.admonition-body": {
+		"defaultMessage": "{action, select, downgrade {降級} other {更新}}可能會導致相容性問題。你額外新增至模組包的模組或內容將保留，但可能與新版本不相容。"
+	},
+	"content.confirm-modpack-update.admonition-header": {
+		"defaultMessage": "{action, select, downgrade {降級} other {更新}}警告"
+	},
+	"content.confirm-modpack-update.confirm-button": {
+		"defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
+	},
+	"content.confirm-modpack-update.header": {
+		"defaultMessage": "{action, select, downgrade {降級} other {更新}}模組包"
+	},
+	"content.confirm-unlink.admonition-body": {
+		"defaultMessage": "模組與內容將與你額外新增至模組包的內容合併，且將不再接收更新。"
+	},
+	"content.confirm-unlink.admonition-header": {
+		"defaultMessage": "取消連結模組包"
+	},
+	"content.confirm-unlink.header": {
+		"defaultMessage": "取消連結模組包"
+	},
+	"content.confirm-unlink.unlink-button": {
+		"defaultMessage": "取消連結"
+	},
+	"content.dependency-warning.admonition-header": {
+		"defaultMessage": "其他內容需要此內容"
+	},
+	"content.dependency-warning.affected-dependents-label": {
+		"defaultMessage": "受影響{count, plural, other {專案}}"
+	},
+	"content.dependency-warning.bulk-admonition-body": {
+		"defaultMessage": "部分所選的專案已作為相依項安裝。刪除這些專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
+	},
+	"content.dependency-warning.context.instance": {
+		"defaultMessage": "實例"
+	},
+	"content.dependency-warning.context.server": {
+		"defaultMessage": "伺服器"
+	},
+	"content.dependency-warning.delete-anyway-button": {
+		"defaultMessage": "仍要刪除"
+	},
+	"content.dependency-warning.delete-many-anyway-button": {
+		"defaultMessage": "仍要刪除 {count, number} 個{itemType}"
+	},
+	"content.dependency-warning.deleting-label": {
+		"defaultMessage": "刪除"
+	},
+	"content.dependency-warning.disable-dependents-label": {
+		"defaultMessage": "刪除後停用依賴項"
+	},
+	"content.dependency-warning.effect-dependent-content": {
+		"defaultMessage": "依賴項內容可能會無法載入，或自主停用"
+	},
+	"content.dependency-warning.effect-instance": {
+		"defaultMessage": "你的{context}可能會崩潰、無法啟動，或出現異常行為"
+	},
+	"content.dependency-warning.header": {
+		"defaultMessage": "相依項警告"
+	},
+	"content.dependency-warning.single-admonition-body": {
+		"defaultMessage": "{project} 已作為相依項安裝。刪除這個專案可能會導致你的{context}無法運作，或使依賴項的內容無法正確載入。"
+	},
+	"content.dependency-warning.what-happens-label": {
+		"defaultMessage": "會發生什麼事？"
+	},
+	"content.diff-modal.added-count": {
+		"defaultMessage": "已新增 {count} 個"
+	},
+	"content.diff-modal.diff-type.added": {
+		"defaultMessage": "已新增（相依項）"
+	},
+	"content.diff-modal.diff-type.removed": {
+		"defaultMessage": "已停用"
+	},
+	"content.diff-modal.diff-type.updated": {
+		"defaultMessage": "已更新"
+	},
+	"content.diff-modal.removed-count": {
+		"defaultMessage": "已移除 {count} 個"
+	},
+	"content.diff-modal.unknown-content-body": {
+		"defaultMessage": "你伺服器上的部分內容無法進行分析，且可能會受到這項變更的影響。"
+	},
+	"content.diff-modal.updated-count": {
+		"defaultMessage": "已更新 {count} 個"
+	},
+	"content.filter.disabled": {
+		"defaultMessage": "停用"
+	},
+	"content.filter.duplicates": {
+		"defaultMessage": "重复"
+	},
+	"content.filter.enabled": {
+		"defaultMessage": "啟用"
+	},
+	"content.filter.updates": {
+		"defaultMessage": "更新"
+	},
+	"content.filter.warnings": {
+		"defaultMessage": "警告"
+	},
+	"content.metadata-filter.author": {
+		"defaultMessage": "作者"
+	},
+	"content.metadata-filter.clear": {
+		"defaultMessage": "清除"
+	},
+	"content.metadata-filter.environment": {
+		"defaultMessage": "环境"
+	},
+	"content.metadata-filter.environment.client": {
+		"defaultMessage": "客户端"
+	},
+	"content.metadata-filter.environment.client-and-server": {
+		"defaultMessage": "客户端和服务端"
+	},
+	"content.metadata-filter.environment.server": {
+		"defaultMessage": "服务端"
+	},
+	"content.metadata-filter.environment.singleplayer": {
+		"defaultMessage": "单人游戏"
+	},
+	"content.metadata-filter.external": {
+		"defaultMessage": "外部文件"
+	},
+	"content.metadata-filter.external.external": {
+		"defaultMessage": "外部文件"
+	},
+	"content.metadata-filter.external.linked": {
+		"defaultMessage": "在线项目"
+	},
+	"content.metadata-filter.loader": {
+		"defaultMessage": "加载器"
+	},
+	"content.metadata-filter.loader.fabric": {
+		"defaultMessage": "Fabric"
+	},
+	"content.metadata-filter.loader.forge": {
+		"defaultMessage": "Forge"
+	},
+	"content.metadata-filter.loader.neoforge": {
+		"defaultMessage": "NeoForge"
+	},
+	"content.metadata-filter.loader.other": {
+		"defaultMessage": "其他"
+	},
+	"content.metadata-filter.loader.quilt": {
+		"defaultMessage": "Quilt"
+	},
+	"content.metadata-filter.long-press-reset": {
+		"defaultMessage": "长按重置筛选"
+	},
+	"content.metadata-filter.open-source": {
+		"defaultMessage": "开源"
+	},
+	"content.metadata-filter.open-source.closed": {
+		"defaultMessage": "非开源"
+	},
+	"content.metadata-filter.open-source.open": {
+		"defaultMessage": "开源"
+	},
+	"content.metadata-filter.search": {
+		"defaultMessage": "搜索..."
+	},
+	"content.metadata-filter.select-all": {
+		"defaultMessage": "全选"
+	},
+	"content.metadata-filter.source": {
+		"defaultMessage": "来源"
+	},
+	"content.metadata-filter.source.curseforge": {
+		"defaultMessage": "CurseForge"
+	},
+	"content.metadata-filter.source.imported-modpack": {
+		"defaultMessage": "导入整合包"
+	},
+	"content.metadata-filter.source.local": {
+		"defaultMessage": "本地"
+	},
+	"content.metadata-filter.source.modrinth-modpack": {
+		"defaultMessage": "Modrinth 整合包"
+	},
+	"content.metadata-filter.source.server-project": {
+		"defaultMessage": "服务器项目"
+	},
+	"content.metadata-filter.source.shared-instance": {
+		"defaultMessage": "共享实例"
+	},
+	"content.metadata-filter.state": {
+		"defaultMessage": "状态"
+	},
+	"content.metadata-filter.state.disabled": {
+		"defaultMessage": "已禁用"
+	},
+	"content.metadata-filter.state.enabled": {
+		"defaultMessage": "已启用"
+	},
+	"content.metadata-filter.toggle": {
+		"defaultMessage": "筛选"
+	},
+	"content.metadata-filter.toggle-active": {
+		"defaultMessage": "筛选（已启用 {count, number} 项）"
+	},
+	"content.metadata-filter.unknown": {
+		"defaultMessage": "未知"
+	},
+	"content.metadata-filter.update.available": {
+		"defaultMessage": "可更新"
+	},
+	"content.metadata-filter.update.up-to-date": {
+		"defaultMessage": "已是最新"
+	},
+	"content.metadata-filter.updates": {
+		"defaultMessage": "更新"
+	},
+	"content.page-layout.browse-content": {
+		"defaultMessage": "瀏覽內容"
+	},
+	"content.page-layout.empty.hint": {
+		"defaultMessage": "瀏覽或上傳{contentType}即可開始"
+	},
+	"content.page-layout.empty.no-content-installed": {
+		"defaultMessage": "未安裝內容"
+	},
+	"content.page-layout.failed-to-load": {
+		"defaultMessage": "無法載入內容"
+	},
+	"content.page-layout.no-content-found": {
+		"defaultMessage": "找不到內容。"
+	},
+	"content.page-layout.search-placeholder": {
+		"defaultMessage": "搜尋 {count, number} 個{contentType}..."
+	},
+	"content.page-layout.share.file-names": {
+		"defaultMessage": "檔案名稱"
+	},
+	"content.page-layout.share.label": {
+		"defaultMessage": "分享"
+	},
+	"content.page-layout.share.markdown-links": {
+		"defaultMessage": "Markdown 連結"
+	},
+	"content.page-layout.share.project-links": {
+		"defaultMessage": "專案連結"
+	},
+	"content.page-layout.share.project-names": {
+		"defaultMessage": "專案名稱"
+	},
+	"content.page-layout.sort.alphabetical": {
+		"defaultMessage": "字母順序"
+	},
+	"content.page-layout.sort.file-name-ascending": {
+		"defaultMessage": "文件名 A-Z"
+	},
+	"content.page-layout.sort.file-name-descending": {
+		"defaultMessage": "文件名 Z-A"
+	},
+	"content.page-layout.sort.date-added-newest": {
+		"defaultMessage": "最新在前"
+	},
+	"content.page-layout.sort.date-added-oldest": {
+		"defaultMessage": "最舊在前"
+	},
+	"content.page-layout.sort.label": {
+		"defaultMessage": "排序依據：{mode}"
+	},
+	"content.page-layout.sort.project-name-ascending": {
+		"defaultMessage": "项目名称 A-Z"
+	},
+	"content.page-layout.sort.project-name-descending": {
+		"defaultMessage": "项目名称 Z-A"
+	},
+	"content.page-layout.pin-view": {
+		"defaultMessage": "固定当前视图"
+	},
+	"content.page-layout.reset-view": {
+		"defaultMessage": "重置视图"
+	},
+	"content.page-layout.unpin-view": {
+		"defaultMessage": "取消固定当前视图"
+	},
+	"content.page-layout.update-all": {
+		"defaultMessage": "更新全部"
+	},
+	"content.page-layout.view-options": {
+		"defaultMessage": "视图选项"
+	},
+	"content.selection-bar.all-already-disabled": {
+		"defaultMessage": "所有已選擇的內容已經停用"
+	},
+	"content.selection-bar.all-already-enabled": {
+		"defaultMessage": "所有已選擇的內容已經啟用"
+	},
+	"content.selection-bar.bulk.deleting": {
+		"defaultMessage": "正在刪除 {progress}/{total} {contentType}..."
+	},
+	"content.selection-bar.bulk.deleting-count": {
+		"defaultMessage": "正在刪除 {count, number} 個{contentType}"
+	},
+	"content.selection-bar.bulk.deleting-waiting": {
+		"defaultMessage": "正在刪除{contentType}..."
+	},
+	"content.selection-bar.bulk.disabling": {
+		"defaultMessage": "正在停用 {progress}/{total} {contentType}..."
+	},
+	"content.selection-bar.bulk.disabling-count": {
+		"defaultMessage": "正在停用 {count, number} 個{contentType}"
+	},
+	"content.selection-bar.bulk.disabling-waiting": {
+		"defaultMessage": "正在停用{contentType}..."
+	},
+	"content.selection-bar.bulk.enabling": {
+		"defaultMessage": "正在啟用 {progress}/{total} {contentType}..."
+	},
+	"content.selection-bar.bulk.enabling-count": {
+		"defaultMessage": "正在啟用 {count, number} 個{contentType}"
+	},
+	"content.selection-bar.bulk.enabling-waiting": {
+		"defaultMessage": "正在啟用{contentType}..."
+	},
+	"content.selection-bar.bulk.updating": {
+		"defaultMessage": "正在更新 {progress}/{total} {contentType}..."
+	},
+	"content.selection-bar.bulk.updating-count": {
+		"defaultMessage": "正在更新 {count, number} 個{contentType}"
+	},
+	"content.selection-bar.bulk.updating-waiting": {
+		"defaultMessage": "正在更新{contentType}..."
+	},
+	"content.selection-bar.selected-count": {
+		"defaultMessage": "已選取 {count, number} 個{contentType}"
+	},
+	"content.selection-bar.selected-count-simple": {
+		"defaultMessage": "已選取 {count, number} 個項目"
+	},
+	"creation-flow.button.create-instance": {
+		"defaultMessage": "建立實例"
+	},
+	"creation-flow.button.create-world": {
+		"defaultMessage": "建立世界"
+	},
+	"creation-flow.button.finish": {
+		"defaultMessage": "完成"
+	},
+	"creation-flow.button.import": {
+		"defaultMessage": "匯入"
+	},
+	"creation-flow.button.import-instances": {
+		"defaultMessage": "匯入 {count, plural, other {# 個實例}}"
+	},
+	"creation-flow.button.setup-server": {
+		"defaultMessage": "設定伺服器"
+	},
+	"creation-flow.modal.custom-setup.adjunct.hint": {
+		"defaultMessage": "下载前会自动选择兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.checking-compatibility": {
+		"defaultMessage": "正在检查兼容性……"
+	},
+	"creation-flow.modal.custom-setup.adjunct.compatibility-load-failed": {
+		"defaultMessage": "无法验证 {loader} 的兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.label": {
+		"defaultMessage": "附加加载器"
+	},
+	"creation-flow.modal.custom-setup.adjunct.optifabric-load-failed": {
+		"defaultMessage": "无法验证 OptiFabric 兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.optifabric-unsupported": {
+		"defaultMessage": "OptiFine 需要 OptiFabric，但当前游戏版本没有兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.primary-unsupported": {
+		"defaultMessage": "所选主加载器不支持当前游戏版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.select-game-version": {
+		"defaultMessage": "请先选择游戏版本以检查兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.unsupported": {
+		"defaultMessage": "{loader} 没有支持当前游戏版本的兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.build-number.label": {
+		"defaultMessage": "組建編號"
+	},
+	"creation-flow.modal.custom-setup.build-number.placeholder": {
+		"defaultMessage": "選擇組建編號"
+	},
+	"creation-flow.modal.custom-setup.build-number.search-placeholder": {
+		"defaultMessage": "搜尋組建編號..."
+	},
+	"creation-flow.modal.custom-setup.content-loader.label": {
+		"defaultMessage": "內容載入器"
+	},
+	"creation-flow.modal.custom-setup.game-version.load-failed": {
+		"defaultMessage": "遊戲版本載入失敗"
+	},
+	"creation-flow.modal.custom-setup.game-version.no-supported-versions": {
+		"defaultMessage": "沒有遊戲版本支援此載入器"
+	},
+	"creation-flow.modal.custom-setup.game-version.placeholder": {
+		"defaultMessage": "選擇遊戲版本"
+	},
+	"creation-flow.modal.custom-setup.game-version.search-placeholder": {
+		"defaultMessage": "搜尋遊戲版本..."
+	},
+	"creation-flow.modal.custom-setup.game-version-type.alpha": {
+		"defaultMessage": "愚人節版"
+	},
+	"creation-flow.modal.custom-setup.game-version-type.release": {
+		"defaultMessage": "正式版"
+	},
+	"creation-flow.modal.custom-setup.game-version-type.snapshot": {
+		"defaultMessage": "快照版"
+	},
+	"creation-flow.modal.custom-setup.icon.remove": {
+		"defaultMessage": "移除圖示"
+	},
+	"creation-flow.modal.custom-setup.icon.select": {
+		"defaultMessage": "選擇圖示"
+	},
+	"creation-flow.modal.custom-setup.loader-version-type.latest": {
+		"defaultMessage": "最新版"
+	},
+	"creation-flow.modal.custom-setup.loader-version-type.other": {
+		"defaultMessage": "其他"
+	},
+	"creation-flow.modal.custom-setup.loader-version-type.stable": {
+		"defaultMessage": "穩定版"
+	},
+	"creation-flow.modal.custom-setup.loader-version.label": {
+		"defaultMessage": "載入器版本"
+	},
+	"creation-flow.modal.custom-setup.loader-version.placeholder": {
+		"defaultMessage": "選擇載入器版本"
+	},
+	"creation-flow.modal.custom-setup.loader-version.search-placeholder": {
+		"defaultMessage": "搜尋載入器版本..."
+	},
+	"creation-flow.modal.custom-setup.loader.compatibility-load-failed": {
+		"defaultMessage": "无法验证加载器兼容性"
+	},
+	"creation-flow.modal.custom-setup.loader.label": {
+		"defaultMessage": "載入器"
+	},
+	"creation-flow.modal.custom-setup.loader.no-such-versions-available": {
+		"defaultMessage": "無此版本"
+	},
+	"creation-flow.modal.custom-setup.loader.unsupported-tooltip": {
+		"defaultMessage": "此載入器不支援所選遊戲版本"
+	},
+	"creation-flow.modal.custom-setup.name.label": {
+		"defaultMessage": "名稱"
+	},
+	"creation-flow.modal.custom-setup.name.placeholder": {
+		"defaultMessage": "輸入實例名稱"
+	},
+	"creation-flow.modal.custom-setup.options.no-versions-available": {
+		"defaultMessage": "沒有可用的版本"
+	},
+	"creation-flow.modal.custom-setup.will-install-loader-version": {
+		"defaultMessage": "將會安裝：{loader} {version}"
+	},
+	"creation-flow.modal.import-instance.import-prompt": {
+		"defaultMessage": "拖拽启动器文件夹、整合包文件或 .minecraft 文件夹即可一键导入实例"
+	},
+	"creation-flow.modal.import-instance.select-file": {
+		"defaultMessage": "选择要导入的文件"
+	},
+	"creation-flow.modal.setup-type.instance.description": {
+		"defaultMessage": "實例是指具有特定載入器、版本及模組的 Minecraft 設定。"
+	},
+	"creation-flow.modal.setup-type.option.custom-setup.description": {
+		"defaultMessage": "從頭開始，先選擇載入器與遊戲版本。"
+	},
+	"creation-flow.modal.setup-type.option.custom-setup.title": {
+		"defaultMessage": "自訂設定"
+	},
+	"creation-flow.modal.setup-type.option.import-instance.description": {
+		"defaultMessage": "從 Prism、CurseForge 或類似啟動器匯入實例。"
+	},
+	"creation-flow.modal.setup-type.option.import-instance.title": {
+		"defaultMessage": "匯入實例"
+	},
+	"creation-flow.modal.setup-type.option.modpack-base.description": {
+		"defaultMessage": "在 Modrinth 上瀏覽模組包，或從檔案匯入。"
+	},
+	"creation-flow.modal.setup-type.option.modpack-base.title": {
+		"defaultMessage": "安裝模組包"
+	},
+	"creation-flow.modal.setup-type.option.vanilla-minecraft.description": {
+		"defaultMessage": "不含任何模組或插件的經典 Minecraft。"
+	},
+	"creation-flow.modal.setup-type.option.vanilla-minecraft.title": {
+		"defaultMessage": "原版 Minecraft"
+	},
+	"creation-flow.modal.setup-type.title.installation": {
+		"defaultMessage": "選擇安裝類型"
+	},
+	"creation-flow.modal.setup-type.title.instance": {
+		"defaultMessage": "選擇實例類型"
+	},
+	"creation-flow.modal.setup-type.title.world": {
+		"defaultMessage": "選擇世界類型"
+	},
+	"creation-flow.title.choose-modpack": {
+		"defaultMessage": "選擇模組包"
+	},
+	"creation-flow.title.create-instance": {
+		"defaultMessage": "建立實例"
+	},
+	"creation-flow.title.create-world": {
+		"defaultMessage": "建立世界"
+	},
+	"creation-flow.title.import-instance": {
+		"defaultMessage": "匯入實例"
+	},
+	"creation-flow.title.reset-server": {
+		"defaultMessage": "重設伺服器"
+	},
+	"creation-flow.title.set-up-server": {
+		"defaultMessage": "設定伺服器"
+	},
+	"external-project-license-status.no": {
+		"defaultMessage": "否"
+	},
+	"external-project-license-status.permanent-no": {
+		"defaultMessage": "永久禁止"
+	},
+	"external-project-license-status.unidentified": {
+		"defaultMessage": "未識別"
+	},
+	"external-project-license-status.with-attribution": {
+		"defaultMessage": "附帶引用標註"
+	},
+	"external-project-license-status.with-attribution-and-source": {
+		"defaultMessage": "附帶引用標註與來源"
+	},
+	"external-project-license-status.yes": {
+		"defaultMessage": "是"
+	},
+	"files.conflict-modal.header": {
+		"defaultMessage": "解壓縮摘要"
+	},
+	"files.conflict-modal.overwrite-button": {
+		"defaultMessage": "覆寫"
+	},
+	"files.conflict-modal.overwrite-file-label": {
+		"defaultMessage": "將覆寫 <file-path>{path}</file-path>"
+	},
+	"files.conflict-modal.overwrite-many-warning": {
+		"defaultMessage": "若你繼續執行解壓縮，將有超過 100 個檔案被覆寫；以下列出部分檔案。"
+	},
+	"files.conflict-modal.overwrite-warning": {
+		"defaultMessage": "下列 {count} 個檔案已存在於你的伺服器上，若你繼續執行解壓縮，這些檔案將被覆寫。"
+	},
+	"files.conflict-modal.overwritten-count": {
+		"defaultMessage": "將覆寫 {count} 個檔案"
+	},
+	"files.conflict-modal.warning-header": {
+		"defaultMessage": "檔案將被覆寫"
+	},
+	"files.create-modal.create-button": {
+		"defaultMessage": "建立 {type}"
+	},
+	"files.create-modal.header": {
+		"defaultMessage": "建立一個 {type}"
+	},
+	"files.create-modal.placeholder-directory": {
+		"defaultMessage": "例如：my-folder"
+	},
+	"files.create-modal.placeholder-file": {
+		"defaultMessage": "例如：config.yml"
+	},
+	"files.delete-modal.deleting-name": {
+		"defaultMessage": "正在刪除「{name}」"
+	},
+	"files.delete-modal.deleting-multiple": {
+		"message": "Deleting {count} items"
+	},
+	"files.delete-modal.bulk-header": {
+		"message": "Delete multiple items"
+	},
+	"files.delete-modal.bulk-warning": {
+		"message": "The selected items will be permanently deleted. This action cannot be undone."
+	},
+	"files.delete-modal.symlink-warning-header": {
+		"message": "Shared instance"
+	},
+	"files.delete-modal.symlink-warning-body": {
+		"message": "You are modifying files in a shared instance linked to "
+	},
+	"files.delete-modal.header": {
+		"defaultMessage": "刪除檔案"
+	},
+	"files.delete-modal.warning.file": {
+		"defaultMessage": "此檔案將永久刪除。此操作無法撤銷。"
+	},
+	"files.delete-modal.warning.folder": {
+		"defaultMessage": "此資料夾及其所有內容將永久刪除。此操作無法撤銷。"
+	},
+	"files.editor.failed-to-open-text": {
+		"defaultMessage": "無法載入檔案內容。"
+	},
+	"files.editor.failed-to-open-title": {
+		"defaultMessage": "無法開啟檔案"
+	},
+	"files.editor.failed-to-share-text": {
+		"defaultMessage": "無法上傳至 mclo.gs。"
+	},
+	"files.editor.failed-to-share-title": {
+		"defaultMessage": "無法分享檔案"
+	},
+	"files.editor.file-saved-text": {
+		"defaultMessage": "你的檔案已儲存。"
+	},
+	"files.editor.file-saved-title": {
+		"defaultMessage": "已儲存檔案"
+	},
+	"files.editor.find-close": {
+		"defaultMessage": "關閉"
+	},
+	"files.editor.find-in-file": {
+		"defaultMessage": "尋找"
+	},
+	"files.editor.find-match-count": {
+		"defaultMessage": "{current}/{total}"
+	},
+	"files.editor.find-next-match": {
+		"defaultMessage": "下一個相符項"
+	},
+	"files.editor.find-no-results": {
+		"defaultMessage": "沒有結果"
+	},
+	"files.editor.find-previous-match": {
+		"defaultMessage": "上一個相符項"
+	},
+	"files.editor.find-toggle-replace": {
+		"defaultMessage": "切換取代功能"
+	},
+	"files.editor.log-url-copied-text": {
+		"defaultMessage": "你的記錄檔網址已複製到剪貼簿。"
+	},
+	"files.editor.log-url-copied-title": {
+		"defaultMessage": "記錄檔網址已複製"
+	},
+	"files.editor.replace": {
+		"defaultMessage": "取代"
+	},
+	"files.editor.replace-all": {
+		"defaultMessage": "取代全部"
+	},
+	"files.editor.replace-in-file": {
+		"defaultMessage": "取代"
+	},
+	"files.editor.save-failed-text": {
+		"defaultMessage": "無法儲存檔案。"
+	},
+	"files.editor.save-failed-title": {
+		"defaultMessage": "儲存失敗"
+	},
+	"files.editor.share-truncated-warning": {
+		"defaultMessage": "日志文件过大，已自动截取最后 9MB 上传。"
+	},
+	"files.error.go-to-home": {
+		"defaultMessage": "前往家資料夾"
+	},
+	"files.error.try-again": {
+		"defaultMessage": "再試一次"
+	},
+	"files.image_viewer.image_too_large": {
+		"defaultMessage": "圖片過大無法預覽 (最大 {maxDimension}x{maxDimension} 像素)"
+	},
+	"files.image_viewer.invalid_image": {
+		"defaultMessage": "圖片檔案無效或內容為空。"
+	},
+	"files.image_viewer.load_failed": {
+		"defaultMessage": "無法載入圖片"
+	},
+	"files.image_viewer.reset_zoom": {
+		"defaultMessage": "重設縮放"
+	},
+	"files.image_viewer.viewed_image_alt": {
+		"defaultMessage": "已檢視圖片"
+	},
+	"files.image_viewer.zoom_in": {
+		"defaultMessage": "放大"
+	},
+	"files.image_viewer.zoom_out": {
+		"defaultMessage": "縮小"
+	},
+	"files.item-type.file": {
+		"defaultMessage": "檔案"
+	},
+	"files.item-type.files": {
+		"defaultMessage": "檔案"
+	},
+	"files.item-type.folder": {
+		"defaultMessage": "資料夾"
+	},
+	"files.item-type.folders": {
+		"defaultMessage": "資料夾"
+	},
+	"files.layout.dry-run-failed-text": {
+		"defaultMessage": "執行模擬測試時發生錯誤"
+	},
+	"files.layout.dry-run-failed-title": {
+		"defaultMessage": "模擬測試失敗"
+	},
+	"files.layout.empty-folder-description": {
+		"defaultMessage": "沒有任何檔案或資料夾"
+	},
+	"files.layout.empty-folder-title": {
+		"defaultMessage": "此資料夾是空的"
+	},
+	"files.layout.error-message": {
+		"defaultMessage": "該資料夾可能不存在"
+	},
+	"files.layout.error-title": {
+		"defaultMessage": "無法載入檔案"
+	},
+	"files.layout.extraction-started-title": {
+		"defaultMessage": "解壓縮已開始"
+	},
+	"files.layout.selected-count": {
+		"defaultMessage": "已選擇 {count} 個"
+	},
+	"files.layout.unsaved-changes": {
+		"defaultMessage": "您有未儲存的變更"
+	},
+	"files.move-modal.current-location": {
+		"defaultMessage": "目前位置"
+	},
+	"files.move-modal.destination-path": {
+		"defaultMessage": "目標路徑"
+	},
+	"files.move-modal.destination-placeholder": {
+		"defaultMessage": "例如：/my-folder"
+	},
+	"files.move-modal.header": {
+		"defaultMessage": "移動{type}"
+	},
+	"files.navbar.back-to-home": {
+		"defaultMessage": "回到首頁"
+	},
+	"files.navbar.breadcrumb-navigation": {
+		"defaultMessage": "麵包屑導覽"
+	},
+	"files.navbar.create-new": {
+		"defaultMessage": "建立新的..."
+	},
+	"files.navbar.file-navigation": {
+		"defaultMessage": "檔案導覽"
+	},
+	"files.navbar.find-in-file": {
+		"defaultMessage": "在檔案中尋找"
+	},
+	"files.navbar.home": {
+		"defaultMessage": "首頁"
+	},
+	"files.navbar.install-curseforge-pack": {
+		"defaultMessage": "安裝 CurseForge 整合包"
+	},
+	"files.navbar.new-file": {
+		"defaultMessage": "新增檔案"
+	},
+	"files.navbar.new-folder": {
+		"defaultMessage": "新增資料夾"
+	},
+	"files.navbar.search-files": {
+		"defaultMessage": "搜尋檔案"
+	},
+	"files.navbar.share-log": {
+		"defaultMessage": "分享日志"
+	},
+	"files.navbar.upload-from-zip": {
+		"defaultMessage": "從 .zip 檔案上傳"
+	},
+	"files.navbar.upload-from-zip-url": {
+		"defaultMessage": "從 .zip 網址上傳"
+	},
+	"files.rename-modal.header": {
+		"defaultMessage": "重新命名 {name}"
+	},
+	"files.rename-modal.new-name-label": {
+		"defaultMessage": "新名稱"
+	},
+	"files.row.item-count": {
+		"defaultMessage": "{count, plural, other {# 個項目}}"
+	},
+	"files.row.parent-folder": {
+		"message": "Parent folder"
+	},
+	"files.table-header.created": {
+		"defaultMessage": "建立時間"
+	},
+	"files.table-header.modified": {
+		"defaultMessage": "修改時間"
+	},
+	"files.table-header.name": {
+		"defaultMessage": "名稱"
+	},
+	"files.table-header.size": {
+		"defaultMessage": "大小"
+	},
+	"files.unsaved-changes-modal.body": {
+		"defaultMessage": "您有未儲存的變更，如果離開將會遺失。離開前要儲存嗎？"
+	},
+	"files.unsaved-changes-modal.discard": {
+		"defaultMessage": "捨棄"
+	},
+	"files.unsaved-changes-modal.header": {
+		"defaultMessage": "未儲存的變更"
+	},
+	"files.validation.name-invalid-directory": {
+		"defaultMessage": "名稱只能包含英數字、破折號、底線或空格"
+	},
+	"files.validation.name-invalid-file": {
+		"defaultMessage": "名稱只能包含英數字、破折號、底線、點或空格"
+	},
+	"files.validation.name-label": {
+		"defaultMessage": "名稱"
+	},
+	"files.validation.name-required": {
+		"defaultMessage": "名稱為必填項目"
+	},
+	"files.zip-url-modal.cf-header": {
+		"defaultMessage": "安裝 CurseForge 整合包"
+	},
+	"files.zip-url-modal.cf-not-found-text": {
+		"defaultMessage": "在該網址找不到 CurseForge 整合包"
+	},
+	"files.zip-url-modal.cf-not-found-title": {
+		"defaultMessage": "找不到 CurseForge 整合包"
+	},
+	"files.zip-url-modal.enter-link": {
+		"defaultMessage": "輸入連結"
+	},
+	"files.zip-url-modal.error-cf-url": {
+		"defaultMessage": "網址必須是 CurseForge 整合包版本網址"
+	},
+	"files.zip-url-modal.error-url-invalid": {
+		"defaultMessage": "網址必須有效"
+	},
+	"files.zip-url-modal.error-url-required": {
+		"defaultMessage": "網址為必填項目"
+	},
+	"files.zip-url-modal.install-button": {
+		"defaultMessage": "安裝"
+	},
+	"files.zip-url-modal.install-failed-title": {
+		"defaultMessage": "安裝失敗"
+	},
+	"files.zip-url-modal.step-copy-description": {
+		"defaultMessage": "複製版本頁面網址並貼到下方"
+	},
+	"files.zip-url-modal.step-copy-title": {
+		"defaultMessage": "複製網址"
+	},
+	"files.zip-url-modal.step-find-description": {
+		"defaultMessage": "瀏覽 CurseForge 並找到您想要的整合包"
+	},
+	"files.zip-url-modal.step-find-title": {
+		"defaultMessage": "尋找整合包"
+	},
+	"files.zip-url-modal.step-select-description": {
+		"defaultMessage": "前往「檔案」分頁並選擇要安裝的版本"
+	},
+	"files.zip-url-modal.step-select-title": {
+		"defaultMessage": "選擇版本"
+	},
+	"files.zip-url-modal.unknown-error": {
+		"defaultMessage": "發生未知錯誤"
+	},
+	"files.zip-url-modal.zip-description": {
+		"defaultMessage": "複製並貼上 .zip 檔案的直接下載網址"
+	},
+	"files.zip-url-modal.zip-header": {
+		"defaultMessage": "正在從網址上傳 .zip 內容"
+	},
+	"form.label.address-line": {
+		"defaultMessage": "地址行 1"
+	},
+	"form.label.address-line-2": {
+		"defaultMessage": "地址行 2（可選）"
+	},
+	"form.label.amount": {
+		"defaultMessage": "金額"
+	},
+	"form.label.bank-name": {
+		"defaultMessage": "銀行名稱"
+	},
+	"form.label.business-name": {
+		"defaultMessage": "企業名稱"
+	},
+	"form.label.city": {
+		"defaultMessage": "城市"
+	},
+	"form.label.country": {
+		"defaultMessage": "國家或地區"
+	},
+	"form.label.date-of-birth": {
+		"defaultMessage": "出生日期"
+	},
+	"form.label.email": {
+		"defaultMessage": "電子郵件"
+	},
+	"form.label.first-name": {
+		"defaultMessage": "名字"
+	},
+	"form.label.last-name": {
+		"defaultMessage": "姓氏"
+	},
+	"form.label.postal-code": {
+		"defaultMessage": "郵遞區號"
+	},
+	"form.label.state-province": {
+		"defaultMessage": "縣市／省／州"
+	},
+	"form.placeholder.address": {
+		"defaultMessage": "輸入地址"
+	},
+	"form.placeholder.address-2": {
+		"defaultMessage": "公寓、套房等"
+	},
+	"form.placeholder.amount": {
+		"defaultMessage": "輸入金額"
+	},
+	"form.placeholder.bank-name": {
+		"defaultMessage": "輸入銀行名稱"
+	},
+	"form.placeholder.bank-name-dropdown": {
+		"defaultMessage": "選擇銀行名稱"
+	},
+	"form.placeholder.business-name": {
+		"defaultMessage": "輸入企業名稱"
+	},
+	"form.placeholder.city": {
+		"defaultMessage": "輸入城市"
+	},
+	"form.placeholder.country": {
+		"defaultMessage": "選擇國家或地區"
+	},
+	"form.placeholder.email": {
+		"defaultMessage": "輸入電子郵件地址"
+	},
+	"form.placeholder.first-name": {
+		"defaultMessage": "輸入名字"
+	},
+	"form.placeholder.last-name": {
+		"defaultMessage": "輸入姓氏"
+	},
+	"form.placeholder.postal-code": {
+		"defaultMessage": "輸入郵遞區號"
+	},
+	"form.placeholder.state": {
+		"defaultMessage": "輸入縣市／省／州"
+	},
+	"format.bytes.0": {
+		"defaultMessage": "{count, plural, other {# 位元組}}"
+	},
+	"format.bytes.1": {
+		"defaultMessage": "{count, number} KiB"
+	},
+	"format.bytes.2": {
+		"defaultMessage": "{count, number} MiB"
+	},
+	"format.bytes.3": {
+		"defaultMessage": "{count, number} GiB"
+	},
+	"format.bytes.4": {
+		"defaultMessage": "{count, number} TiB"
+	},
+	"header.category.category": {
+		"defaultMessage": "類別"
+	},
+	"header.category.cf-extra": {
+		"message": "More CurseForge categories"
+	},
+	"header.category.feature": {
+		"defaultMessage": "功能"
+	},
+	"header.category.minecraft-server-community": {
+		"defaultMessage": "社群"
+	},
+	"header.category.minecraft-server-features": {
+		"defaultMessage": "特色"
+	},
+	"header.category.minecraft-server-gameplay": {
+		"defaultMessage": "遊戲玩法"
+	},
+	"header.category.minecraft-server-meta": {
+		"defaultMessage": "設定與機制"
+	},
+	"header.category.performance-impact": {
+		"defaultMessage": "效能影響"
+	},
+	"header.category.resolutions": {
+		"defaultMessage": "解析度"
+	},
+	"icon-select.edit": {
+		"defaultMessage": "編輯圖示"
+	},
+	"icon-select.remove": {
+		"defaultMessage": "移除圖示"
+	},
+	"icon-select.replace": {
+		"defaultMessage": "取代圖示"
+	},
+	"icon-select.select": {
+		"defaultMessage": "選擇圖示"
+	},
+	"input.search-version.placeholder": {
+		"defaultMessage": "搜尋版本..."
+	},
+	"input.search.placeholder": {
+		"defaultMessage": "搜尋..."
+	},
+	"input.select-version.placeholder": {
+		"defaultMessage": "選擇版本"
+	},
+	"input.view.gallery": {
+		"defaultMessage": "圖庫檢視"
+	},
+	"input.view.grid": {
+		"defaultMessage": "格狀檢視"
+	},
+	"input.view.list": {
+		"defaultMessage": "清單檢視"
+	},
+	"installation-settings.aria.select-game-version": {
+		"defaultMessage": "選擇遊戲版本"
+	},
+	"installation-settings.aria.select-loader-version": {
+		"defaultMessage": "選擇 {loader} 版本"
+	},
+	"installation-settings.aria.select-platform": {
+		"defaultMessage": "選擇平臺"
+	},
+	"installation-settings.confirm-version-change": {
+		"defaultMessage": "確定"
+	},
+	"installation-settings.confirm-version-change-description": {
+		"defaultMessage": "變更為 {gameVersion} 將會修改你伺服器上的下列內容。"
+	},
+	"installation-settings.confirm-version-change-header": {
+		"defaultMessage": "檢視內容變更"
+	},
+	"installation-settings.edit-installation.title": {
+		"defaultMessage": "編輯安裝"
+	},
+	"installation-settings.edit.warning-instance": {
+		"defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你仍想修改，請務必謹慎，因為這可能會導致問題。"
+	},
+	"installation-settings.edit.warning-server": {
+		"defaultMessage": "我們不建議在安裝內容後修改安裝設定。若你想進行變更，請重設你的伺服器。"
+	},
+	"installation-settings.incompatible-content.auto-fix-button": {
+		"defaultMessage": "自動修復"
+	},
+	"installation-settings.incompatible-content.change-loader-button": {
+		"defaultMessage": "變更載入器"
+	},
+	"installation-settings.incompatible-content.disable-conflicts-button": {
+		"defaultMessage": "停用衝突項目"
+	},
+	"installation-settings.incompatible-content.game-version-warning-body": {
+		"defaultMessage": "變更遊戲版本時，我們可以停用不相容的已安裝內容，或是嘗試解決相容性問題。"
+	},
+	"installation-settings.incompatible-content.game-version-warning-title": {
+		"defaultMessage": "不相容警告"
+	},
+	"installation-settings.incompatible-content.header": {
+		"defaultMessage": "安裝了不相容的內容"
+	},
+	"installation-settings.incompatible-content.loader-change-body": {
+		"defaultMessage": "變更載入器時，所有已安裝的內容都將被停用。我們建議改為重設你的伺服器。"
+	},
+	"installation-settings.incompatible-content.loader-change-title": {
+		"defaultMessage": "變更載入器具有破壞性"
+	},
+	"installation-settings.linked-instance.title": {
+		"defaultMessage": "已連接{projectType}"
+	},
+	"installation-settings.linked.modpack": {
+		"defaultMessage": "模組包"
+	},
+	"installation-settings.linked.server-project": {
+		"defaultMessage": "伺服器專案"
+	},
+	"installation-settings.loader-version": {
+		"defaultMessage": "{loader} 版本"
+	},
+	"installation-settings.loader-version.error": {
+		"defaultMessage": "加载加载器版本数据失败"
+	},
+	"installation-settings.loader-version.unsupported": {
+		"defaultMessage": "此加载器不支持所选游戏版本"
+	},
+	"installation-settings.platform-lock-tooltip": {
+		"defaultMessage": "你需要重設伺服器才能切換載入器。"
+	},
+	"installation-settings.reinstall-modpack.description": {
+		"defaultMessage": "重新安裝模組包會將{type}內容重設為原始狀態，你新增的所有模組或內容都將被移除。"
+	},
+	"installation-settings.reinstall-modpack.title": {
+		"defaultMessage": "重新安裝模組包"
+	},
+	"installation-settings.reinstalling-modpack": {
+		"defaultMessage": "正在重新安裝模組包"
+	},
+	"installation-settings.removed-incompatible": {
+		"defaultMessage": "已移除（不相容）"
+	},
+	"installation-settings.repair.instance-description": {
+		"defaultMessage": "重新安裝 Minecraft 的必要元件並檢查檔案是否損毀。這或許能修復你的遊戲因啟動器出錯而打不開的問題。"
+	},
+	"installation-settings.repair.instance-title": {
+		"defaultMessage": "修復實例"
+	},
+	"installation-settings.repair.server-description": {
+		"defaultMessage": "在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的必要元件。這或許能修復你伺服器無法正常啟動的問題。"
+	},
+	"installation-settings.repair.server-title": {
+		"defaultMessage": "修復伺服器"
+	},
+	"installation-settings.saving": {
+		"defaultMessage": "儲存中..."
+	},
+	"installation-settings.search-game-version": {
+		"defaultMessage": "搜尋遊戲版本..."
+	},
+	"installation-settings.type.instance": {
+		"defaultMessage": "實例"
+	},
+	"installation-settings.type.instance-possessive": {
+		"defaultMessage": "實例"
+	},
+	"installation-settings.type.server": {
+		"defaultMessage": "伺服器"
+	},
+	"installation-settings.type.server-possessive": {
+		"defaultMessage": "伺服器"
+	},
+	"installation-settings.unlink": {
+		"defaultMessage": "取消連結"
+	},
+	"installation-settings.unlink.description": {
+		"defaultMessage": "取消連結將會永久中斷這個{type}與{projectType}的連結。這讓你可以變更載入器與 Minecraft 版本，但你將無法收到未來的更新。"
+	},
+	"installation-settings.verifying": {
+		"defaultMessage": "驗證中..."
+	},
+	"instance.confirm-reinstall.admonition-body": {
+		"defaultMessage": "重新安裝將會把所有已安裝或修改過的內容，重設回模組包原始的狀態。這將會移除所有你在原始安裝上額外添加的模組或內容。"
+	},
+	"instance.confirm-reinstall.admonition-header": {
+		"defaultMessage": "重新安裝警告"
+	},
+	"instance.confirm-reinstall.header": {
+		"defaultMessage": "重新安裝模組包"
+	},
+	"instance.confirm-reinstall.reinstall-button": {
+		"defaultMessage": "重新安裝模組包"
+	},
+	"instance.confirm-repair.body.instance": {
+		"defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復遊戲因啟動器出錯而無法啟動的問題。"
+	},
+	"instance.confirm-repair.body.server": {
+		"defaultMessage": "修復功能會在保留遊戲內容的情況下，重新安裝載入器與 Minecraft 的相依檔案。這或許能修復伺服器無法正常啟動的問題。"
+	},
+	"instance.confirm-repair.header": {
+		"defaultMessage": "修復{type}"
+	},
+	"instance.confirm-repair.instance-label": {
+		"defaultMessage": "實例"
+	},
+	"instance.confirm-repair.repair-button": {
+		"defaultMessage": "修復"
+	},
+	"instance.confirm-repair.server-label": {
+		"defaultMessage": "伺服器"
+	},
+	"instance.worlds.game_mode.adventure": {
+		"defaultMessage": "冒險模式"
+	},
+	"instance.worlds.game_mode.creative": {
+		"defaultMessage": "創造模式"
+	},
+	"instance.worlds.game_mode.spectator": {
+		"defaultMessage": "旁觀者模式"
+	},
+	"instance.worlds.game_mode.survival": {
+		"defaultMessage": "生存模式"
+	},
+	"instance.worlds.game_mode.unknown": {
+		"defaultMessage": "未知的遊戲模式"
+	},
+	"instances.content-install.compatible-count": {
+		"defaultMessage": "{count} 個相容{count, plural, other {實例}}"
+	},
+	"instances.content-install.existing-tab": {
+		"defaultMessage": "已有實例"
+	},
+	"instances.content-install.game-version-placeholder": {
+		"defaultMessage": "選擇遊戲版本"
+	},
+	"instances.content-install.header": {
+		"defaultMessage": "安裝專案"
+	},
+	"instances.content-install.incompatible-tooltip": {
+		"defaultMessage": "這個專案支援的載入器或遊戲版本與這個實例所使用的不同。"
+	},
+	"instances.content-install.install-button": {
+		"defaultMessage": "安裝"
+	},
+	"instances.content-install.installed-badge": {
+		"defaultMessage": "已安裝"
+	},
+	"instances.content-install.instance-type": {
+		"defaultMessage": "實例類型"
+	},
+	"instances.content-install.loader-label": {
+		"defaultMessage": "載入器"
+	},
+	"instances.content-install.name-label": {
+		"defaultMessage": "名稱"
+	},
+	"instances.content-install.name-placeholder": {
+		"defaultMessage": "輸入實例名稱"
+	},
+	"instances.content-install.new-tab": {
+		"defaultMessage": "新的實例"
+	},
+	"instances.content-install.no-instances": {
+		"defaultMessage": "找不到相容的實例"
+	},
+	"instances.content-install.remove-icon": {
+		"defaultMessage": "移除圖示"
+	},
+	"instances.content-install.search-placeholder": {
+		"defaultMessage": "搜尋實例"
+	},
+	"instances.content-install.select-icon": {
+		"defaultMessage": "選擇圖示"
+	},
+	"instances.modpack-content-modal.empty-description": {
+		"defaultMessage": "這個模組包不包含任何額外內容。"
+	},
+	"instances.modpack-content-modal.empty-title": {
+		"defaultMessage": "找不到內容"
+	},
+	"instances.modpack-content-modal.header": {
+		"defaultMessage": "模組包內容"
+	},
+	"instances.modpack-content-modal.loading": {
+		"defaultMessage": "正在載入內容..."
+	},
+	"instances.modpack-content-modal.no-results": {
+		"defaultMessage": "沒有專案符合你的搜尋字詞。"
+	},
+	"instances.modpack-content-modal.search-placeholder": {
+		"defaultMessage": "搜尋 {count, number} {count, plural, other {個專案}}"
+	},
+	"instances.updater-modal.badge.current": {
+		"defaultMessage": "目前"
+	},
+	"instances.updater-modal.badge.incompatible": {
+		"defaultMessage": "不相容"
+	},
+	"instances.updater-modal.downgrade-to": {
+		"defaultMessage": "降級到 {version}"
+	},
+	"instances.updater-modal.header": {
+		"defaultMessage": "更新版本"
+	},
+	"instances.updater-modal.header-modpack": {
+		"defaultMessage": "切換模組包版本"
+	},
+	"instances.updater-modal.header-switch": {
+		"defaultMessage": "切換版本"
+	},
+	"instances.updater-modal.hide-incompatible": {
+		"defaultMessage": "隱藏不相容項目"
+	},
+	"instances.updater-modal.incompatibility-warning": {
+		"defaultMessage": "這個版本與這個實例不相容。相依項將不會自動安裝。"
+	},
+	"instances.updater-modal.incompatibility-warning-header": {
+		"defaultMessage": "選擇版本"
+	},
+	"instances.updater-modal.incompatible-update.description": {
+		"defaultMessage": "{version} 與此實例不相容。它可能無法啟動或運行異常。"
+	},
+	"instances.updater-modal.incompatible-update.header": {
+		"defaultMessage": "更新到不相容版本？"
+	},
+	"instances.updater-modal.incompatible-update.proceed": {
+		"defaultMessage": "仍要更新"
+	},
+	"instances.updater-modal.install-anyway": {
+		"defaultMessage": "仍要安裝"
+	},
+	"instances.updater-modal.loading-changelog": {
+		"defaultMessage": "正在載入更新日誌..."
+	},
+	"instances.updater-modal.loading-versions": {
+		"defaultMessage": "正在載入版本..."
+	},
+	"instances.updater-modal.no-changelog": {
+		"defaultMessage": "這個版本沒有提供更新日誌。"
+	},
+	"instances.updater-modal.no-versions": {
+		"defaultMessage": "找不到版本"
+	},
+	"instances.updater-modal.search-placeholder": {
+		"defaultMessage": "搜尋版本..."
+	},
+	"instances.updater-modal.select-version": {
+		"defaultMessage": "選擇版本以查看更新日誌"
+	},
+	"instances.updater-modal.show-incompatible": {
+		"defaultMessage": "顯示不相容項目"
+	},
+	"instances.updater-modal.switch-to": {
+		"defaultMessage": "切換到 {version}"
+	},
+	"instances.updater-modal.update-to": {
+		"defaultMessage": "更新到 {version}"
+	},
+	"instances.updater-modal.warning-app": {
+		"defaultMessage": "更新可能會導致實例損壞。請先查看版本更新日誌並備份。"
+	},
+	"instances.updater-modal.warning-web": {
+		"defaultMessage": "更新可能會導致世界損壞。請先查看版本更新日誌並備份。"
+	},
+	"label.actions": {
+		"defaultMessage": "動作"
+	},
+	"label.available": {
+		"defaultMessage": "可用餘額 {amount}。"
+	},
+	"label.changelog": {
+		"defaultMessage": "更新日誌"
+	},
+	"label.changes-saved": {
+		"defaultMessage": "變更已儲存"
+	},
+	"label.client-depends-warning": {
+		"defaultMessage": "此模組依賴客戶端模組，啟動伺服器時可能會造成問題"
+	},
+	"label.client-only-warning": {
+		"defaultMessage": "此為用戶端模組，啟動伺服器時可能會導致問題"
+	},
+	"label.client-retained-warning": {
+		"defaultMessage": "這是一個作為依賴項安裝的客戶端模組，啟動伺服器時可能會造成問題"
+	},
+	"label.collections": {
+		"defaultMessage": "收藏"
+	},
+	"label.confirm-password": {
+		"defaultMessage": "確認密碼"
+	},
+	"label.content": {
+		"defaultMessage": "內容"
+	},
+	"label.copied-filename": {
+		"defaultMessage": "已複製檔案名稱"
+	},
+	"label.copied-path": {
+		"defaultMessage": "已複製路徑"
+	},
+	"label.create-failed": {
+		"defaultMessage": "建立失敗"
+	},
+	"label.created-ago": {
+		"defaultMessage": "建立時間：{ago}"
+	},
+	"label.dashboard": {
+		"defaultMessage": "資訊主頁"
+	},
+	"label.delete": {
+		"defaultMessage": "刪除"
+	},
+	"label.delete-failed": {
+		"defaultMessage": "刪除失敗"
+	},
+	"label.delete-immediately": {
+		"defaultMessage": "立即刪除"
+	},
+	"label.description": {
+		"defaultMessage": "描述"
+	},
+	"label.details": {
+		"defaultMessage": "詳細資訊"
+	},
+	"label.done": {
+		"defaultMessage": "完成"
+	},
+	"label.download-failed": {
+		"defaultMessage": "下載失敗"
+	},
+	"label.email": {
+		"defaultMessage": "電子郵件地址"
+	},
+	"label.email-username": {
+		"defaultMessage": "電子郵件地址或使用者名稱"
+	},
+	"label.error": {
+		"defaultMessage": "錯誤"
+	},
+	"label.extract-failed": {
+		"defaultMessage": "解壓縮失敗"
+	},
+	"label.filter-by": {
+		"defaultMessage": "篩選依據"
+	},
+	"label.filters": {
+		"defaultMessage": "篩選器"
+	},
+	"label.followed-projects": {
+		"defaultMessage": "追蹤的專案"
+	},
+	"label.game-version": {
+		"defaultMessage": "遊戲版本"
+	},
+	"label.hide-installed-content": {
+		"defaultMessage": "隱藏已安裝的內容"
+	},
+	"label.hide-selected-content": {
+		"defaultMessage": "隱藏已選取的內容"
+	},
+	"label.installation-info": {
+		"defaultMessage": "安裝資訊"
+	},
+	"label.installed": {
+		"defaultMessage": "已安裝"
+	},
+	"label.installed-modpack": {
+		"defaultMessage": "已安裝模組包"
+	},
+	"label.installing": {
+		"defaultMessage": "安裝中..."
+	},
+	"label.installing-content": {
+		"defaultMessage": "正在安裝內容"
+	},
+	"label.loading": {
+		"defaultMessage": "載入中..."
+	},
+	"label.moderation": {
+		"defaultMessage": "管理"
+	},
+	"label.modpack": {
+		"defaultMessage": "模組包"
+	},
+	"label.move-failed": {
+		"defaultMessage": "移動失敗"
+	},
+	"label.no": {
+		"defaultMessage": "否"
+	},
+	"label.no-items": {
+		"defaultMessage": "沒有項目"
+	},
+	"label.notifications": {
+		"defaultMessage": "通知"
+	},
+	"label.or": {
+		"defaultMessage": "或"
+	},
+	"label.password": {
+		"defaultMessage": "密碼"
+	},
+	"label.plan-custom": {
+		"defaultMessage": "自訂"
+	},
+	"label.plan-large": {
+		"defaultMessage": "大型"
+	},
+	"label.plan-medium": {
+		"defaultMessage": "中型"
+	},
+	"label.plan-small": {
+		"defaultMessage": "小型"
+	},
+	"label.plan-unknown": {
+		"defaultMessage": "未知"
+	},
+	"label.platform": {
+		"defaultMessage": "平臺"
+	},
+	"label.played": {
+		"defaultMessage": "上次遊玩時間：{ago}"
+	},
+	"label.project": {
+		"defaultMessage": "專案"
+	},
+	"label.public": {
+		"defaultMessage": "公開"
+	},
+	"label.rejected": {
+		"defaultMessage": "已拒絕"
+	},
+	"label.rename-failed": {
+		"defaultMessage": "重新命名失敗"
+	},
+	"label.rewards-program-terms-agreement": {
+		"defaultMessage": "我同意《<terms-link>獎勵計畫條款</terms-link>》"
+	},
+	"label.saved": {
+		"defaultMessage": "已儲存"
+	},
+	"label.scopes": {
+		"defaultMessage": "權限範圍"
+	},
+	"label.search": {
+		"defaultMessage": "搜尋"
+	},
+	"label.select-all": {
+		"defaultMessage": "選擇全部"
+	},
+	"label.selected": {
+		"defaultMessage": "已選取"
+	},
+	"label.selection-actions": {
+		"defaultMessage": "選擇動作"
+	},
+	"label.server": {
+		"defaultMessage": "伺服器"
+	},
+	"label.server-only": {
+		"message": "Server only"
+	},
+	"label.servers": {
+		"defaultMessage": "伺服器"
+	},
+	"label.settings": {
+		"defaultMessage": "設定"
+	},
+	"label.singleplayer": {
+		"defaultMessage": "單人遊戲"
+	},
+	"label.sort-by": {
+		"defaultMessage": "排序依據："
+	},
+	"label.success": {
+		"defaultMessage": "成功"
+	},
+	"label.title": {
+		"defaultMessage": "標題"
+	},
+	"label.unknown": {
+		"defaultMessage": "未知"
+	},
+	"label.unlisted": {
+		"defaultMessage": "不公開"
+	},
+	"label.update-available": {
+		"defaultMessage": "有可用的更新"
+	},
+	"label.updating": {
+		"defaultMessage": "更新中..."
+	},
+	"label.upload-failed": {
+		"defaultMessage": "上傳失敗"
+	},
+	"label.username": {
+		"defaultMessage": "使用者名稱"
+	},
+	"label.validating": {
+		"defaultMessage": "驗證中"
+	},
+	"label.version": {
+		"defaultMessage": "版本"
+	},
+	"label.view": {
+		"defaultMessage": "檢視方式"
+	},
+	"label.visibility": {
+		"defaultMessage": "瀏覽權限"
+	},
+	"label.visit-your-profile": {
+		"defaultMessage": "瀏覽個人檔案"
+	},
+	"label.yes": {
+		"defaultMessage": "是"
+	},
+	"locale.cs-CZ": {
+		"defaultMessage": "捷克文"
+	},
+	"locale.da-DK": {
+		"defaultMessage": "丹麥文"
+	},
+	"locale.de-CH": {
+		"defaultMessage": "德文（瑞士）"
+	},
+	"locale.de-DE": {
+		"defaultMessage": "德文（德國）"
+	},
+	"locale.en-US": {
+		"defaultMessage": "英文（美國）"
+	},
+	"locale.es-419": {
+		"defaultMessage": "西班牙文（拉丁美洲）"
+	},
+	"locale.es-ES": {
+		"defaultMessage": "西班牙文（西班牙）"
+	},
+	"locale.fi-FI": {
+		"defaultMessage": "芬蘭文"
+	},
+	"locale.fil-PH": {
+		"defaultMessage": "菲律賓文"
+	},
+	"locale.fr-FR": {
+		"defaultMessage": "法文"
+	},
+	"locale.he-IL": {
+		"defaultMessage": "希伯來文"
+	},
+	"locale.hu-HU": {
+		"defaultMessage": "匈牙利文"
+	},
+	"locale.id-ID": {
+		"defaultMessage": "印尼文"
+	},
+	"locale.it-IT": {
+		"defaultMessage": "義大利文（義大利）"
+	},
+	"locale.ja-JP": {
+		"defaultMessage": "日文"
+	},
+	"locale.ko-KR": {
+		"defaultMessage": "韓文"
+	},
+	"locale.ms-MY": {
+		"defaultMessage": "馬來文"
+	},
+	"locale.nl-NL": {
+		"defaultMessage": "荷蘭文"
+	},
+	"locale.no-NO": {
+		"defaultMessage": "書面挪威文"
+	},
+	"locale.pl-PL": {
+		"defaultMessage": "波蘭文"
+	},
+	"locale.pt-BR": {
+		"defaultMessage": "葡萄牙文（巴西）"
+	},
+	"locale.pt-PT": {
+		"defaultMessage": "葡萄牙文（葡萄牙）"
+	},
+	"locale.ro-RO": {
+		"defaultMessage": "羅馬尼亞文"
+	},
+	"locale.ru-RU": {
+		"defaultMessage": "俄文"
+	},
+	"locale.sr-CS": {
+		"defaultMessage": "塞爾維亞文（拉丁）"
+	},
+	"locale.sv-SE": {
+		"defaultMessage": "瑞典文"
+	},
+	"locale.th-TH": {
+		"defaultMessage": "泰文"
+	},
+	"locale.tr-TR": {
+		"defaultMessage": "土耳其文"
+	},
+	"locale.uk-UA": {
+		"defaultMessage": "烏克蘭文"
+	},
+	"locale.vi-VN": {
+		"defaultMessage": "越南文"
+	},
+	"locale.zh-CN": {
+		"defaultMessage": "簡體中文"
+	},
+	"locale.zh-TW": {
+		"defaultMessage": "正體中文"
+	},
+	"markdown-editor.default-image-alt-text": {
+		"defaultMessage": "請將此內容替換為描述"
+	},
+	"markdown-editor.error-label": {
+		"defaultMessage": "錯誤"
+	},
+	"markdown-editor.image-modal.description-field.description": {
+		"defaultMessage": "請盡可能詳細描述這張圖片，如同對一位看不見這張圖片的人說明一般。"
+	},
+	"markdown-editor.image-modal.description-field.placeholder": {
+		"defaultMessage": "描述這張圖片..."
+	},
+	"markdown-editor.image-modal.description-field.title": {
+		"defaultMessage": "描述（替代文字）"
+	},
+	"markdown-editor.image-modal.header": {
+		"defaultMessage": "插入圖片"
+	},
+	"markdown-editor.image-modal.upload-mode.label": {
+		"defaultMessage": "圖片來源"
+	},
+	"markdown-editor.image-modal.upload-mode.link": {
+		"defaultMessage": "連結"
+	},
+	"markdown-editor.image-modal.upload-mode.upload": {
+		"defaultMessage": "上傳"
+	},
+	"markdown-editor.image-modal.upload.prompt": {
+		"defaultMessage": "拖曳檔案以上傳或點擊選擇檔案"
+	},
+	"markdown-editor.image-modal.url-field.placeholder": {
+		"defaultMessage": "輸入圖片網址..."
+	},
+	"markdown-editor.insert-button": {
+		"defaultMessage": "插入"
+	},
+	"markdown-editor.link-modal.header": {
+		"defaultMessage": "插入連結"
+	},
+	"markdown-editor.link-modal.label-field.placeholder": {
+		"defaultMessage": "輸入標籤..."
+	},
+	"markdown-editor.link-modal.label-field.title": {
+		"defaultMessage": "標籤"
+	},
+	"markdown-editor.link-modal.url-field.placeholder": {
+		"defaultMessage": "輸入連結網址..."
+	},
+	"markdown-editor.markdown-formatting-support": {
+		"defaultMessage": "這個編輯器支援 <markdown-link>Markdown 格式</markdown-link>。"
+	},
+	"markdown-editor.max-length.label": {
+		"defaultMessage": "長度限制："
+	},
+	"markdown-editor.max-length.unlimited": {
+		"defaultMessage": "無限制"
+	},
+	"markdown-editor.max-length.value": {
+		"defaultMessage": "{currentLength}/{maxLength}"
+	},
+	"markdown-editor.placeholder": {
+		"defaultMessage": "寫點什麼..."
+	},
+	"markdown-editor.preview-label": {
+		"defaultMessage": "預覽"
+	},
+	"markdown-editor.preview-toggle.label": {
+		"defaultMessage": "預覽"
+	},
+	"markdown-editor.toolbar.bold": {
+		"defaultMessage": "粗體"
+	},
+	"markdown-editor.toolbar.bulleted-list": {
+		"defaultMessage": "項目符號清單"
+	},
+	"markdown-editor.toolbar.code": {
+		"defaultMessage": "程式碼"
+	},
+	"markdown-editor.toolbar.heading-1": {
+		"defaultMessage": "標題 1"
+	},
+	"markdown-editor.toolbar.heading-2": {
+		"defaultMessage": "標題 2"
+	},
+	"markdown-editor.toolbar.heading-3": {
+		"defaultMessage": "標題 3"
+	},
+	"markdown-editor.toolbar.image": {
+		"defaultMessage": "圖片"
+	},
+	"markdown-editor.toolbar.italic": {
+		"defaultMessage": "斜體"
+	},
+	"markdown-editor.toolbar.link": {
+		"defaultMessage": "連結"
+	},
+	"markdown-editor.toolbar.ordered-list": {
+		"defaultMessage": "排序清單"
+	},
+	"markdown-editor.toolbar.quote": {
+		"defaultMessage": "引用"
+	},
+	"markdown-editor.toolbar.spoiler": {
+		"defaultMessage": "暴雷內容"
+	},
+	"markdown-editor.toolbar.strikethrough": {
+		"defaultMessage": "刪除線"
+	},
+	"markdown-editor.toolbar.video": {
+		"defaultMessage": "影片"
+	},
+	"markdown-editor.upload-error.no-file": {
+		"defaultMessage": "未提供檔案"
+	},
+	"markdown-editor.upload-error.no-handler": {
+		"defaultMessage": "未提供圖片上傳處理常式"
+	},
+	"markdown-editor.url-label": {
+		"defaultMessage": "網址"
+	},
+	"markdown-editor.url-validation-error.blocked-domain": {
+		"defaultMessage": "無效的網址。不允許這個網域。"
+	},
+	"markdown-editor.url-validation-error.malformed": {
+		"defaultMessage": "無效的網址。請確保網址格式正確。"
+	},
+	"markdown-editor.url-validation-error.unsupported-protocol": {
+		"defaultMessage": "不支援的協定。請使用 http 或 https。"
+	},
+	"markdown-editor.video-embed.title": {
+		"defaultMessage": "YouTube 影片播放器"
+	},
+	"markdown-editor.video-modal.header": {
+		"defaultMessage": "插入 YouTube 影片"
+	},
+	"markdown-editor.video-modal.url-field.description": {
+		"defaultMessage": "請輸入有效的 YouTube 影片連結。"
+	},
+	"markdown-editor.video-modal.url-field.placeholder": {
+		"defaultMessage": "輸入 YouTube 影片網址"
+	},
+	"markdown-editor.video-modal.url-field.title": {
+		"defaultMessage": "YouTube 影片網址"
+	},
+	"modal.open-in-app.benefit.install": {
+		"defaultMessage": "自動安裝所需內容"
+	},
+	"modal.open-in-app.benefit.launch": {
+		"defaultMessage": "直接啟動遊戲並加入伺服器"
+	},
+	"modal.open-in-app.benefit.update": {
+		"defaultMessage": "當伺服器變動時，維持檔案為最新狀態"
+	},
+	"modal.open-in-app.get-app": {
+		"defaultMessage": "取得 Modrinth App"
+	},
+	"modal.open-in-app.opening-automatically": {
+		"defaultMessage": "Modrinth App 將自動開啟..."
+	},
+	"modal.open-in-app.title": {
+		"defaultMessage": "正在開啟 Modrinth App"
+	},
+	"modal.open-in-app.why-use": {
+		"defaultMessage": "為何使用 Modrinth App"
+	},
+	"multiselect.selection-actions.label": {
+		"defaultMessage": "已选 {count, number} 项"
+	},
+	"notification.error.title": {
+		"defaultMessage": "發生錯誤"
+	},
+	"omorphia.component.badge.label.accepted": {
+		"defaultMessage": "已接受"
+	},
+	"omorphia.component.badge.label.approved": {
+		"defaultMessage": "已核准"
+	},
+	"omorphia.component.badge.label.archived": {
+		"defaultMessage": "已封存"
+	},
+	"omorphia.component.badge.label.closed": {
+		"defaultMessage": "已關閉"
+	},
+	"omorphia.component.badge.label.creator": {
+		"defaultMessage": "創作者"
+	},
+	"omorphia.component.badge.label.draft": {
+		"defaultMessage": "草稿"
+	},
+	"omorphia.component.badge.label.failed": {
+		"defaultMessage": "失敗"
+	},
+	"omorphia.component.badge.label.listed": {
+		"defaultMessage": "公開"
+	},
+	"omorphia.component.badge.label.moderator": {
+		"defaultMessage": "管理員"
+	},
+	"omorphia.component.badge.label.modrinth-team": {
+		"defaultMessage": "Modrinth 團隊"
+	},
+	"omorphia.component.badge.label.pending": {
+		"defaultMessage": "待處理"
+	},
+	"omorphia.component.badge.label.private": {
+		"defaultMessage": "私人"
+	},
+	"omorphia.component.badge.label.processed": {
+		"defaultMessage": "已處理"
+	},
+	"omorphia.component.badge.label.rejected": {
+		"defaultMessage": "已拒絕"
+	},
+	"omorphia.component.badge.label.returned": {
+		"defaultMessage": "已退回"
+	},
+	"omorphia.component.badge.label.safe": {
+		"defaultMessage": "通過"
+	},
+	"omorphia.component.badge.label.scheduled": {
+		"defaultMessage": "已排定"
+	},
+	"omorphia.component.badge.label.under-review": {
+		"defaultMessage": "審查中"
+	},
+	"omorphia.component.badge.label.unlisted": {
+		"defaultMessage": "不公開"
+	},
+	"omorphia.component.badge.label.unsafe": {
+		"defaultMessage": "不通過"
+	},
+	"omorphia.component.badge.label.withheld": {
+		"defaultMessage": "由工作人員設為不公開"
+	},
+	"omorphia.component.copy.action.copy": {
+		"defaultMessage": "將程式碼複製到剪貼簿"
+	},
+	"omorphia.component.environment-indicator.label.client": {
+		"defaultMessage": "用戶端"
+	},
+	"omorphia.component.environment-indicator.label.client-and-server": {
+		"defaultMessage": "用戶端與伺服器端"
+	},
+	"omorphia.component.environment-indicator.label.client-or-server": {
+		"defaultMessage": "用戶端或伺服器端"
+	},
+	"omorphia.component.environment-indicator.label.server": {
+		"defaultMessage": "伺服器端"
+	},
+	"omorphia.component.environment-indicator.label.type": {
+		"defaultMessage": "{type}"
+	},
+	"omorphia.component.environment-indicator.label.unsupported": {
+		"defaultMessage": "不支援"
+	},
+	"omorphia.component.loading-indicator.label": {
+		"message": "Loading"
+	},
+	"payment-method.amazon_pay": {
+		"defaultMessage": "Amazon Pay"
+	},
+	"payment-method.amex": {
+		"defaultMessage": "美國運通"
+	},
+	"payment-method.card_display": {
+		"defaultMessage": "{card_brand}（末四碼 {last_four}）"
+	},
+	"payment-method.cashapp": {
+		"defaultMessage": "Cash App"
+	},
+	"payment-method.charity": {
+		"defaultMessage": "慈善機構"
+	},
+	"payment-method.charity-plural": {
+		"defaultMessage": "慈善機構"
+	},
+	"payment-method.diners": {
+		"defaultMessage": "大來卡"
+	},
+	"payment-method.discover": {
+		"defaultMessage": "Discover"
+	},
+	"payment-method.eftpos": {
+		"defaultMessage": "EFTPOS"
+	},
+	"payment-method.gift-card": {
+		"defaultMessage": "禮品卡"
+	},
+	"payment-method.gift-card-plural": {
+		"defaultMessage": "禮品卡"
+	},
+	"payment-method.jcb": {
+		"defaultMessage": "JCB"
+	},
+	"payment-method.mastercard": {
+		"defaultMessage": "萬事達卡"
+	},
+	"payment-method.paypal": {
+		"defaultMessage": "PayPal"
+	},
+	"payment-method.paypal_international": {
+		"defaultMessage": "PayPal 國際"
+	},
+	"payment-method.unionpay": {
+		"defaultMessage": "銀聯"
+	},
+	"payment-method.unknown": {
+		"defaultMessage": "未知的付款方式"
+	},
+	"payment-method.venmo": {
+		"defaultMessage": "Venmo"
+	},
+	"payment-method.virtual-visa": {
+		"defaultMessage": "虛擬 Visa 卡"
+	},
+	"payment-method.virtual-visa-plural": {
+		"defaultMessage": "虛擬 Visa 卡"
+	},
+	"payment-method.visa": {
+		"defaultMessage": "Visa"
+	},
+	"project-card.date.published.tooltip": {
+		"defaultMessage": "發布時間：{date}"
+	},
+	"project-card.date.updated.tooltip": {
+		"defaultMessage": "更新時間：{date}"
+	},
+	"project-card.environment.client": {
+		"defaultMessage": "用戶端"
+	},
+	"project-card.environment.client-and-server": {
+		"defaultMessage": "用戶端與伺服器端"
+	},
+	"project-card.environment.client-or-server": {
+		"defaultMessage": "用戶端或伺服器端"
+	},
+	"project-card.environment.server": {
+		"defaultMessage": "伺服器"
+	},
+	"project-type.all": {
+		"defaultMessage": "全部"
+	},
+	"project-type.datapack.capital": {
+		"defaultMessage": "{count, plural, other {資料包}}"
+	},
+	"project-type.datapack.category": {
+		"defaultMessage": "資料包"
+	},
+	"project-type.datapack.lowercase": {
+		"defaultMessage": "{count, plural, other {資料包}}"
+	},
+	"project-type.mod.capital": {
+		"defaultMessage": "{count, plural, other {模組}}"
+	},
+	"project-type.mod.category": {
+		"defaultMessage": "模組"
+	},
+	"project-type.mod.lowercase": {
+		"defaultMessage": "{count, plural, other {模組}}"
+	},
+	"project-type.modpack.capital": {
+		"defaultMessage": "{count, plural, other {模組包}}"
+	},
+	"project-type.modpack.category": {
+		"defaultMessage": "模組包"
+	},
+	"project-type.modpack.lowercase": {
+		"defaultMessage": "{count, plural, other {模組包}}"
+	},
+	"project-type.plugin.capital": {
+		"defaultMessage": "{count, plural, other {插件}}"
+	},
+	"project-type.plugin.category": {
+		"defaultMessage": "插件"
+	},
+	"project-type.plugin.lowercase": {
+		"defaultMessage": "{count, plural, other {插件}}"
+	},
+	"project-type.project.capital": {
+		"defaultMessage": "{count, plural, other {專案}}"
+	},
+	"project-type.project.category": {
+		"defaultMessage": "專案"
+	},
+	"project-type.project.lowercase": {
+		"defaultMessage": "{count, plural, other {專案}}"
+	},
+	"project-type.resourcepack.capital": {
+		"defaultMessage": "{count, plural, other {資源包}}"
+	},
+	"project-type.resourcepack.category": {
+		"defaultMessage": "資源包"
+	},
+	"project-type.resourcepack.lowercase": {
+		"defaultMessage": "{count, plural, other {資源包}}"
+	},
+	"project-type.server.capital": {
+		"defaultMessage": "{count, plural, one {伺服器} other {伺服器}}"
+	},
+	"project-type.server.category": {
+		"defaultMessage": "伺服器"
+	},
+	"project-type.server.lowercase": {
+		"defaultMessage": "{count, plural, other {伺服器}}"
+	},
+	"project-type.shader.capital": {
+		"defaultMessage": "{count, plural, other {光影包}}"
+	},
+	"project-type.shader.category": {
+		"defaultMessage": "光影包"
+	},
+	"project-type.shader.lowercase": {
+		"defaultMessage": "{count, plural, other {光影包}}"
+	},
+	"project.about.compatibility.environments": {
+		"defaultMessage": "支援環境"
+	},
+	"project.about.compatibility.environments.client-and-server": {
+		"defaultMessage": "用戶端與伺服器端"
+	},
+	"project.about.compatibility.environments.client-side": {
+		"defaultMessage": "用戶端"
+	},
+	"project.about.compatibility.environments.dedicated-servers-only": {
+		"defaultMessage": "僅限專用伺服器"
+	},
+	"project.about.compatibility.environments.server-side": {
+		"defaultMessage": "伺服器端"
+	},
+	"project.about.compatibility.environments.singleplayer": {
+		"defaultMessage": "單人遊戲"
+	},
+	"project.about.compatibility.environments.singleplayer-only": {
+		"defaultMessage": "僅限單人遊戲"
+	},
+	"project.about.compatibility.game.minecraftJava": {
+		"defaultMessage": "Minecraft Java 版"
+	},
+	"project.about.compatibility.platforms": {
+		"defaultMessage": "平臺"
+	},
+	"project.about.compatibility.platforms-plural": {
+		"defaultMessage": "{count, plural, other {平臺}}"
+	},
+	"project.about.compatibility.title": {
+		"defaultMessage": "相容性"
+	},
+	"project.about.creators.organization": {
+		"defaultMessage": "組織"
+	},
+	"project.about.creators.owner": {
+		"defaultMessage": "專案擁有者"
+	},
+	"project.about.creators.title": {
+		"defaultMessage": "創作者"
+	},
+	"project.about.details.created": {
+		"defaultMessage": "建立時間：{date}"
+	},
+	"project.about.details.licensed": {
+		"defaultMessage": "授權條款：{license}"
+	},
+	"project.about.details.published": {
+		"defaultMessage": "發布時間：{date}"
+	},
+	"project.about.details.submitted": {
+		"defaultMessage": "提交時間：{date}"
+	},
+	"project.about.details.updated": {
+		"defaultMessage": "更新時間：{date}"
+	},
+	"project.about.links.discord": {
+		"defaultMessage": "加入 Discord 伺服器"
+	},
+	"project.about.links.donate.bmac": {
+		"defaultMessage": "Buy Me a Coffee"
+	},
+	"project.about.links.donate.generic": {
+		"defaultMessage": "贊助"
+	},
+	"project.about.links.donate.github": {
+		"defaultMessage": "GitHub Sponsors 贊助"
+	},
+	"project.about.links.donate.kofi": {
+		"defaultMessage": "Ko-fi 贊助"
+	},
+	"project.about.links.donate.patreon": {
+		"defaultMessage": "Patreon 贊助"
+	},
+	"project.about.links.donate.paypal": {
+		"defaultMessage": "PayPal 贊助"
+	},
+	"project.about.links.issues": {
+		"defaultMessage": "回報問題"
+	},
+	"project.about.links.mcmod": {
+		"defaultMessage": "MC Mod"
+	},
+	"project.about.links.site": {
+		"defaultMessage": "前往網站"
+	},
+	"project.about.links.source": {
+		"defaultMessage": "檢視原始碼"
+	},
+	"project.about.links.store": {
+		"defaultMessage": "前往商店頁面"
+	},
+	"project.about.links.title": {
+		"defaultMessage": "相關連結"
+	},
+	"project.about.links.wiki": {
+		"defaultMessage": "前往 wiki"
+	},
+	"project.about.server.address.tooltip": {
+		"defaultMessage": "複製 Java 伺服器位址"
+	},
+	"project.about.server.copied": {
+		"defaultMessage": "已複製！"
+	},
+	"project.about.server.copiedText": {
+		"defaultMessage": "已將伺服器位址複製到剪貼簿"
+	},
+	"project.about.server.downloadModpack": {
+		"defaultMessage": "下載模組包"
+	},
+	"project.about.server.languages": {
+		"defaultMessage": "語言"
+	},
+	"project.about.server.recommendedVersion": {
+		"defaultMessage": "（推薦）"
+	},
+	"project.about.server.region": {
+		"defaultMessage": "地區"
+	},
+	"project.about.server.requiredContent": {
+		"defaultMessage": "必需內容"
+	},
+	"project.about.server.title": {
+		"defaultMessage": "伺服器詳細資訊"
+	},
+	"project.about.tags.title": {
+		"defaultMessage": "標籤"
+	},
+	"project.download-count-tooltip": {
+		"defaultMessage": "{count, number} 次{count, plural, other {下載}}"
+	},
+	"project.follower-count-tooltip": {
+		"defaultMessage": "{count, number} 位{count, plural, other {追蹤者}}"
+	},
+	"project.online-player-count": {
+		"defaultMessage": "{count, number} 人在線上"
+	},
+	"project.online-player-count.tooltip": {
+		"defaultMessage": "{count} 位{countPlural, plural, other {玩家}}在線上"
+	},
+	"project.recent-plays": {
+		"defaultMessage": "{count} 次{countPlural, plural, other {近期遊玩}}"
+	},
+	"project.recent-plays.tooltip": {
+		"defaultMessage": "過去 2 週內來自 Modrinth 的 {count} 次{countPlural, plural, other {最近遊玩次數}}"
+	},
+	"project.environment.tag.not-applicable": {
+		"defaultMessage": "不適用"
+	},
+	"project.environment.tag.unknown": {
+		"defaultMessage": "未知"
+	},
+	"project.server.customModpackTooltip": {
+		"defaultMessage": "這個專案使用了自訂模組包"
+	},
+	"project.server.language.af": {
+		"defaultMessage": "南非文"
+	},
+	"project.server.language.am": {
+		"defaultMessage": "阿姆哈拉文"
+	},
+	"project.server.language.ar": {
+		"defaultMessage": "阿拉伯文"
+	},
+	"project.server.language.az": {
+		"defaultMessage": "亞塞拜然文"
+	},
+	"project.server.language.be": {
+		"defaultMessage": "白俄羅斯文"
+	},
+	"project.server.language.bg": {
+		"defaultMessage": "保加利亞文"
+	},
+	"project.server.language.bn": {
+		"defaultMessage": "孟加拉文"
+	},
+	"project.server.language.bs": {
+		"defaultMessage": "波士尼亞文"
+	},
+	"project.server.language.ca": {
+		"defaultMessage": "加泰隆尼亞文"
+	},
+	"project.server.language.cs": {
+		"defaultMessage": "捷克文"
+	},
+	"project.server.language.da": {
+		"defaultMessage": "丹麥文"
+	},
+	"project.server.language.de": {
+		"defaultMessage": "德文"
+	},
+	"project.server.language.el": {
+		"defaultMessage": "希臘文"
+	},
+	"project.server.language.en": {
+		"defaultMessage": "英文"
+	},
+	"project.server.language.eo": {
+		"defaultMessage": "世界語"
+	},
+	"project.server.language.es": {
+		"defaultMessage": "西班牙文"
+	},
+	"project.server.language.et": {
+		"defaultMessage": "愛沙尼亞文"
+	},
+	"project.server.language.eu": {
+		"defaultMessage": "巴斯克文"
+	},
+	"project.server.language.fa": {
+		"defaultMessage": "波斯文"
+	},
+	"project.server.language.fi": {
+		"defaultMessage": "芬蘭文"
+	},
+	"project.server.language.fr": {
+		"defaultMessage": "法文"
+	},
+	"project.server.language.ga": {
+		"defaultMessage": "愛爾蘭文"
+	},
+	"project.server.language.gl": {
+		"defaultMessage": "加利西亞文"
+	},
+	"project.server.language.he": {
+		"defaultMessage": "希伯來文"
+	},
+	"project.server.language.hi": {
+		"defaultMessage": "印地文"
+	},
+	"project.server.language.hr": {
+		"defaultMessage": "克羅埃西亞文"
+	},
+	"project.server.language.hu": {
+		"defaultMessage": "匈牙利文"
+	},
+	"project.server.language.hy": {
+		"defaultMessage": "亞美尼亞文"
+	},
+	"project.server.language.id": {
+		"defaultMessage": "印尼文"
+	},
+	"project.server.language.is": {
+		"defaultMessage": "冰島文"
+	},
+	"project.server.language.it": {
+		"defaultMessage": "義大利文"
+	},
+	"project.server.language.ja": {
+		"defaultMessage": "日文"
+	},
+	"project.server.language.ka": {
+		"defaultMessage": "喬治亞文"
+	},
+	"project.server.language.kk": {
+		"defaultMessage": "哈薩克文"
+	},
+	"project.server.language.km": {
+		"defaultMessage": "高棉文"
+	},
+	"project.server.language.kn": {
+		"defaultMessage": "坎那達文"
+	},
+	"project.server.language.ko": {
+		"defaultMessage": "韓文"
+	},
+	"project.server.language.lo": {
+		"defaultMessage": "寮文"
+	},
+	"project.server.language.lt": {
+		"defaultMessage": "立陶宛文"
+	},
+	"project.server.language.lv": {
+		"defaultMessage": "拉脫維亞文"
+	},
+	"project.server.language.mk": {
+		"defaultMessage": "馬其頓文"
+	},
+	"project.server.language.ml": {
+		"defaultMessage": "馬來亞拉姆文"
+	},
+	"project.server.language.mn": {
+		"defaultMessage": "蒙古文"
+	},
+	"project.server.language.mr": {
+		"defaultMessage": "馬拉提文"
+	},
+	"project.server.language.ms": {
+		"defaultMessage": "馬來文"
+	},
+	"project.server.language.my": {
+		"defaultMessage": "緬甸文"
+	},
+	"project.server.language.ne": {
+		"defaultMessage": "尼泊爾文"
+	},
+	"project.server.language.nl": {
+		"defaultMessage": "荷蘭文"
+	},
+	"project.server.language.no": {
+		"defaultMessage": "挪威文"
+	},
+	"project.server.language.pa": {
+		"defaultMessage": "旁遮普文"
+	},
+	"project.server.language.pl": {
+		"defaultMessage": "波蘭文"
+	},
+	"project.server.language.pt": {
+		"defaultMessage": "葡萄牙文"
+	},
+	"project.server.language.ro": {
+		"defaultMessage": "羅馬尼亞文"
+	},
+	"project.server.language.ru": {
+		"defaultMessage": "俄文"
+	},
+	"project.server.language.si": {
+		"defaultMessage": "僧伽羅文"
+	},
+	"project.server.language.sk": {
+		"defaultMessage": "斯洛伐克文"
+	},
+	"project.server.language.sl": {
+		"defaultMessage": "斯洛維尼亞文"
+	},
+	"project.server.language.sq": {
+		"defaultMessage": "阿爾巴尼亞文"
+	},
+	"project.server.language.sr": {
+		"defaultMessage": "塞爾維亞文"
+	},
+	"project.server.language.sv": {
+		"defaultMessage": "瑞典文"
+	},
+	"project.server.language.sw": {
+		"defaultMessage": "斯瓦希里文"
+	},
+	"project.server.language.ta": {
+		"defaultMessage": "泰米爾文"
+	},
+	"project.server.language.te": {
+		"defaultMessage": "泰盧固文"
+	},
+	"project.server.language.th": {
+		"defaultMessage": "泰文"
+	},
+	"project.server.language.tl": {
+		"defaultMessage": "菲律賓文"
+	},
+	"project.server.language.tr": {
+		"defaultMessage": "土耳其文"
+	},
+	"project.server.language.uk": {
+		"defaultMessage": "烏克蘭文"
+	},
+	"project.server.language.ur": {
+		"defaultMessage": "烏爾都文"
+	},
+	"project.server.language.uz": {
+		"defaultMessage": "烏茲別克文"
+	},
+	"project.server.language.vi": {
+		"defaultMessage": "越南文"
+	},
+	"project.server.language.yo": {
+		"defaultMessage": "約魯巴文"
+	},
+	"project.server.language.zh": {
+		"defaultMessage": "中文"
+	},
+	"project.server.language.zu": {
+		"defaultMessage": "祖魯文"
+	},
+	"project.server.ping.ms": {
+		"defaultMessage": "{ping, number} 毫秒"
+	},
+	"project.server.region.asia": {
+		"defaultMessage": "亞洲"
+	},
+	"project.server.region.australia": {
+		"defaultMessage": "澳洲"
+	},
+	"project.server.region.europe": {
+		"defaultMessage": "歐洲"
+	},
+	"project.server.region.middle_east": {
+		"defaultMessage": "中東"
+	},
+	"project.server.region.russia": {
+		"defaultMessage": "俄羅斯"
+	},
+	"project.server.region.south_america": {
+		"defaultMessage": "南美洲"
+	},
+	"project.server.region.tooltip": {
+		"defaultMessage": "伺服器位於{regionName}"
+	},
+	"project.server.region.us_east": {
+		"defaultMessage": "美國東部"
+	},
+	"project.server.region.us_west": {
+		"defaultMessage": "美國西部"
+	},
+	"project.server.status.offline": {
+		"defaultMessage": "離線"
+	},
+	"project.server.status.offline.tooltip": {
+		"defaultMessage": "伺服器已離線"
+	},
+	"project.server.status.online": {
+		"defaultMessage": "線上"
+	},
+	"project.settings.analytics.title": {
+		"defaultMessage": "數據分析"
+	},
+	"project.settings.content.title": {
+		"defaultMessage": "內容"
+	},
+	"project.settings.description.title": {
+		"defaultMessage": "描述"
+	},
+	"project.settings.environment.title": {
+		"defaultMessage": "環境"
+	},
+	"project.settings.gallery.title": {
+		"defaultMessage": "圖庫"
+	},
+	"project.settings.general.title": {
+		"defaultMessage": "一般"
+	},
+	"project.settings.license.title": {
+		"defaultMessage": "授權條款"
+	},
+	"project.settings.links.title": {
+		"defaultMessage": "連結"
+	},
+	"project.settings.members.title": {
+		"defaultMessage": "成員"
+	},
+	"project.settings.notice.no-permission.description": {
+		"defaultMessage": "你沒有編輯這個設定的權限。"
+	},
+	"project.settings.notice.no-permission.title": {
+		"defaultMessage": "沒有權限"
+	},
+	"project.settings.server.title": {
+		"defaultMessage": "伺服器"
+	},
+	"project.settings.tags.title": {
+		"defaultMessage": "標籤"
+	},
+	"project.settings.upload.title": {
+		"defaultMessage": "上傳"
+	},
+	"project.settings.versions.permissions": {
+		"defaultMessage": "權限"
+	},
+	"project.settings.versions.title": {
+		"defaultMessage": "版本"
+	},
+	"project.settings.view.title": {
+		"defaultMessage": "檢視"
+	},
+	"project.versions.channel.alpha.symbol": {
+		"defaultMessage": "A"
+	},
+	"project.versions.channel.beta.symbol": {
+		"defaultMessage": "B"
+	},
+	"project.versions.channel.release.symbol": {
+		"defaultMessage": "R"
+	},
+	"project.versions.filter.toggle-tooltip": {
+		"message": "Toggle filter for {filter}"
+	},
+	"project.versions.platform.modloader.short": {
+		"message": "ModLoader"
+	},
+	"project.versions.table.downloads": {
+		"defaultMessage": "下载量"
+	},
+	"project.versions.table.environment": {
+		"defaultMessage": "运行环境"
+	},
+	"project.versions.table.game-version": {
+		"defaultMessage": "游戏版本"
+	},
+	"project.versions.table.platform": {
+		"defaultMessage": "平台"
+	},
+	"project.versions.table.published": {
+		"defaultMessage": "发布时间"
+	},
+	"project.versions.table.version": {
+		"defaultMessage": "版本"
+	},
+	"project.versions.version.withheld": {
+		"defaultMessage": "保留"
+	},
+	"project.versions.version.withheld.tooltip": {
+		"defaultMessage": "版本由於缺少授權資訊而被保留"
+	},
+	"project.versions.filter.projectChannels": {
+		"defaultMessage": "更新通道"
+	},
+	"project.versions.withheld-versions-warning.resolve-button": {
+		"defaultMessage": "解決"
+	},
+	"project.versions.filter.gameVersions": {
+		"defaultMessage": "游戏版本"
+	},
+	"project.visibility.archived": {
+		"defaultMessage": "已封存"
+	},
+	"project.visibility.draft": {
+		"defaultMessage": "草稿"
+	},
+	"project.visibility.private": {
+		"defaultMessage": "私人"
+	},
+	"project.visibility.public": {
+		"defaultMessage": "公開"
+	},
+	"project.visibility.rejected": {
+		"defaultMessage": "已拒絕"
+	},
+	"project.visibility.scheduled": {
+		"defaultMessage": "已排定"
+	},
+	"project.visibility.under-review": {
+		"defaultMessage": "審查中"
+	},
+	"project.visibility.unknown": {
+		"defaultMessage": "未知"
+	},
+	"project.visibility.unlisted": {
+		"defaultMessage": "不公開"
+	},
+	"project.visibility.unlisted-by-staff": {
+		"defaultMessage": "由工作人員設為不公開"
+	},
+	"report.item-type.content": {
+		"defaultMessage": "內容"
+	},
+	"report.item-type.project": {
+		"defaultMessage": "專案"
+	},
+	"report.item-type.user": {
+		"defaultMessage": "使用者"
+	},
+	"report.item-type.version": {
+		"defaultMessage": "版本"
+	},
+	"search.filter.locked.default": {
+		"defaultMessage": "篩選器已鎖定"
+	},
+	"search.filter.locked.default.description": {
+		"defaultMessage": "解鎖這個篩選器可能導致安裝不相容的內容。"
+	},
+	"search.filter.locked.default.sync": {
+		"defaultMessage": "同步篩選器"
+	},
+	"search.filter.locked.default.title": {
+		"defaultMessage": "{type} 已鎖定"
+	},
+	"search.filter.locked.default.unlock": {
+		"defaultMessage": "解鎖篩選器"
+	},
+	"search.filter.option.exclusion.add.tooltip": {
+		"defaultMessage": "排除"
+	},
+	"search.filter.option.search.clear.aria_label": {
+		"defaultMessage": "清除搜尋"
+	},
+	"search.filter.option.search.placeholder": {
+		"defaultMessage": "搜尋..."
+	},
+	"search.filter.option.show_fewer": {
+		"defaultMessage": "只顯示部分內容"
+	},
+	"search.filter.option.show_more": {
+		"defaultMessage": "顯示更多內容"
+	},
+	"search.filter_type.advanced": {
+		"message": "Advanced"
+	},
+	"search.filter_type.advanced.exclude_datapack": {
+		"message": "Exclude data packs"
+	},
+	"search.filter_type.advanced.exclude_mod": {
+		"message": "Exclude mods"
+	},
+	"search.filter_type.advanced.exclude_plugin": {
+		"message": "Exclude plugins"
+	},
+	"search.filter_type.environment": {
+		"defaultMessage": "環境"
+	},
+	"search.filter_type.environment.client": {
+		"defaultMessage": "用戶端"
+	},
+	"search.filter_type.environment.server": {
+		"defaultMessage": "伺服器端"
+	},
+	"search.filter_type.game_version": {
+		"defaultMessage": "遊戲版本"
+	},
+	"search.filter_type.game_version.all_versions": {
+		"defaultMessage": "顯示所有版本"
+	},
+	"search.filter_type.license": {
+		"defaultMessage": "授權條款"
+	},
+	"search.filter_type.license.open_source": {
+		"defaultMessage": "開放原始碼"
+	},
+	"search.filter_type.mod_loader": {
+		"defaultMessage": "載入器"
+	},
+	"search.filter_type.modpack_loader": {
+		"defaultMessage": "載入器"
+	},
+	"search.filter_type.plugin_loader": {
+		"defaultMessage": "載入器"
+	},
+	"search.filter_type.plugin_platform": {
+		"defaultMessage": "平臺"
+	},
+	"search.filter_type.project_id": {
+		"defaultMessage": "專案 ID"
+	},
+	"search.filter_type.server_content_type": {
+		"defaultMessage": "類型"
+	},
+	"search.filter_type.server_language": {
+		"defaultMessage": "語言"
+	},
+	"search.filter_type.server_region": {
+		"defaultMessage": "地區"
+	},
+	"search.filter_type.server_status": {
+		"defaultMessage": "狀態"
+	},
+	"search.filter_type.shader_loader": {
+		"defaultMessage": "載入器"
+	},
+	"search.server_content_type.modpack": {
+		"defaultMessage": "模組支援"
+	},
+	"search.server_content_type.vanilla": {
+		"defaultMessage": "原版"
+	},
+	"servers.notice.dismiss": {
+		"defaultMessage": "撤銷"
+	},
+	"servers.notice.dismissable": {
+		"defaultMessage": "可撤銷"
+	},
+	"servers.notice.heading.attention": {
+		"defaultMessage": "注意"
+	},
+	"servers.notice.heading.info": {
+		"defaultMessage": "資訊"
+	},
+	"servers.notice.level.critical.name": {
+		"defaultMessage": "重要"
+	},
+	"servers.notice.level.info.name": {
+		"defaultMessage": "資訊"
+	},
+	"servers.notice.level.survey.name": {
+		"defaultMessage": "問卷"
+	},
+	"servers.notice.level.warn.name": {
+		"defaultMessage": "警告"
+	},
+	"servers.notice.undismissable": {
+		"defaultMessage": "不可撤銷"
+	},
+	"servers.region.australia": {
+		"defaultMessage": "澳洲"
+	},
+	"servers.region.central-europe": {
+		"defaultMessage": "中歐"
+	},
+	"servers.region.north-america-central": {
+		"defaultMessage": "北美中部"
+	},
+	"servers.region.north-america-east": {
+		"defaultMessage": "北美東部"
+	},
+	"servers.region.north-america-west": {
+		"defaultMessage": "北美西部"
+	},
+	"servers.region.southeast-asia": {
+		"defaultMessage": "東南亞"
+	},
+	"servers.region.western-europe": {
+		"defaultMessage": "西歐"
+	},
+	"servers.setup.upload-warning": {
+		"defaultMessage": "上傳時請勿關閉此頁面。"
+	},
+	"servers.setup.uploading-modpack.header": {
+		"defaultMessage": "正在上傳模組包"
+	},
+	"settings.account.title": {
+		"defaultMessage": "帳號和安全性"
+	},
+	"settings.appearance.title": {
+		"defaultMessage": "外觀"
+	},
+	"settings.applications.title": {
+		"defaultMessage": "你的應用程式"
+	},
+	"settings.authorized-apps.title": {
+		"defaultMessage": "已授權的應用程式"
+	},
+	"settings.display.theme.dark": {
+		"defaultMessage": "深色"
+	},
+	"settings.display.theme.description": {
+		"defaultMessage": "依照偏好，設定這部裝置的 Modrinth 主題顏色。"
+	},
+	"settings.display.theme.light": {
+		"defaultMessage": "淺色"
+	},
+	"settings.display.theme.oled": {
+		"defaultMessage": "OLED"
+	},
+	"settings.display.theme.preferred-dark-theme": {
+		"defaultMessage": "偏好深色主題"
+	},
+	"settings.display.theme.preferred-light-theme": {
+		"defaultMessage": "偏好淺色主題"
+	},
+	"settings.display.theme.retro": {
+		"defaultMessage": "復古"
+	},
+	"settings.display.theme.system": {
+		"defaultMessage": "與系統同步"
+	},
+	"settings.display.theme.title": {
+		"defaultMessage": "色彩主題"
+	},
+	"settings.feature-flags.title": {
+		"defaultMessage": "功能旗標"
+	},
+	"settings.language.categories.default": {
+		"defaultMessage": "標準語言"
+	},
+	"settings.language.categories.search-result": {
+		"defaultMessage": "搜尋結果"
+	},
+	"settings.language.description": {
+		"defaultMessage": "選擇你偏好的{platform}語言。翻譯由 <crowdin-link>Crowdin</crowdin-link> 上的志願者所貢獻。"
+	},
+	"settings.language.languages.search-field.placeholder": {
+		"defaultMessage": "搜尋語言..."
+	},
+	"settings.language.languages.search-results-announcement": {
+		"defaultMessage": "{matches, plural, =0 {未搜尋到相關語言} other {有 # 個語言符合搜尋字詞}}。"
+	},
+	"settings.language.languages.search.no-results": {
+		"defaultMessage": "沒有語言符合你的搜尋字詞。"
+	},
+	"settings.language.platform.app": {
+		"defaultMessage": "應用程式"
+	},
+	"settings.language.platform.site": {
+		"defaultMessage": "網站"
+	},
+	"settings.language.title": {
+		"defaultMessage": "語言"
+	},
+	"settings.language.warning": {
+		"defaultMessage": "變更{platform}的語言後，若部分內容尚未提供翻譯，則會以英文顯示。{platform}目前尚未完全翻譯，因此，在某些語言下，部分內容仍可能以英文顯示。"
+	},
+	"settings.pats.title": {
+		"defaultMessage": "個人存取權杖"
+	},
+	"settings.profile.title": {
+		"defaultMessage": "公開個人檔案"
+	},
+	"settings.sessions.title": {
+		"defaultMessage": "工作階段"
+	},
+	"skin.preview.drag-to-rotate": {
+		"message": "Drag to rotate"
+	},
+	"tag.category.128x": {
+		"defaultMessage": "128x"
+	},
+	"tag.category.16x": {
+		"defaultMessage": "16x"
+	},
+	"tag.category.256x": {
+		"defaultMessage": "256x"
+	},
+	"tag.category.32x": {
+		"defaultMessage": "32x"
+	},
+	"tag.category.48x": {
+		"defaultMessage": "48x"
+	},
+	"tag.category.512x+": {
+		"defaultMessage": "512× 以上"
+	},
+	"tag.category.64x": {
+		"defaultMessage": "64x"
+	},
+	"tag.category.8x-": {
+		"defaultMessage": "8× 以下"
+	},
+	"tag.category.adventure": {
+		"defaultMessage": "冒險"
+	},
+	"tag.category.adventure-mode": {
+		"defaultMessage": "冒險模式"
+	},
+	"tag.category.anarchy": {
+		"defaultMessage": "無政府"
+	},
+	"tag.category.atmosphere": {
+		"defaultMessage": "大氣效果"
+	},
+	"tag.category.audio": {
+		"defaultMessage": "音效"
+	},
+	"tag.category.battle-royale": {
+		"defaultMessage": "大逃殺"
+	},
+	"tag.category.bedwars": {
+		"defaultMessage": "床戰"
+	},
+	"tag.category.blocks": {
+		"defaultMessage": "方塊"
+	},
+	"tag.category.bloom": {
+		"defaultMessage": "泛光"
+	},
+	"tag.category.bosses": {
+		"defaultMessage": "Boss"
+	},
+	"tag.category.cartoon": {
+		"defaultMessage": "卡通"
+	},
+	"tag.category.challenging": {
+		"defaultMessage": "挑戰"
+	},
+	"tag.category.classes": {
+		"defaultMessage": "職業"
+	},
+	"tag.category.colored-lighting": {
+		"defaultMessage": "彩色光照"
+	},
+	"tag.category.combat": {
+		"defaultMessage": "戰鬥"
+	},
+	"tag.category.competitive": {
+		"defaultMessage": "競技"
+	},
+	"tag.category.core-shaders": {
+		"defaultMessage": "核心著色器"
+	},
+	"tag.category.creative-mode": {
+		"defaultMessage": "創造模式"
+	},
+	"tag.category.creator-community": {
+		"defaultMessage": "創作者社群"
+	},
+	"tag.category.crossplay": {
+		"defaultMessage": "跨平臺"
+	},
+	"tag.category.cursed": {
+		"defaultMessage": "邪門"
+	},
+	"tag.category.custom-content": {
+		"defaultMessage": "自訂內容"
+	},
+	"tag.category.decoration": {
+		"defaultMessage": "裝飾"
+	},
+	"tag.category.dungeons": {
+		"defaultMessage": "副本"
+	},
+	"tag.category.economy": {
+		"defaultMessage": "經濟"
+	},
+	"tag.category.entities": {
+		"defaultMessage": "實體"
+	},
+	"tag.category.environment": {
+		"defaultMessage": "環境"
+	},
+	"tag.category.equipment": {
+		"defaultMessage": "裝備"
+	},
+	"tag.category.factions": {
+		"defaultMessage": "派系"
+	},
+	"tag.category.fantasy": {
+		"defaultMessage": "奇幻"
+	},
+	"tag.category.foliage": {
+		"defaultMessage": "植被"
+	},
+	"tag.category.fonts": {
+		"defaultMessage": "字型"
+	},
+	"tag.category.food": {
+		"defaultMessage": "食物"
+	},
+	"tag.category.game-mechanics": {
+		"defaultMessage": "遊戲機制"
+	},
+	"tag.category.gens": {
+		"defaultMessage": "生成器"
+	},
+	"tag.category.gui": {
+		"defaultMessage": "GUI"
+	},
+	"tag.category.hardcore-mode": {
+		"defaultMessage": "極限模式"
+	},
+	"tag.category.high": {
+		"defaultMessage": "高"
+	},
+	"tag.category.items": {
+		"defaultMessage": "物品"
+	},
+	"tag.category.keep-inventory": {
+		"defaultMessage": "保留物品欄"
+	},
+	"tag.category.kitchen-sink": {
+		"defaultMessage": "大雜燴"
+	},
+	"tag.category.kitpvp": {
+		"defaultMessage": "Kit PvP"
+	},
+	"tag.category.library": {
+		"defaultMessage": "程式庫"
+	},
+	"tag.category.lifesteal": {
+		"defaultMessage": "生命竊取"
+	},
+	"tag.category.lightweight": {
+		"defaultMessage": "輕量"
+	},
+	"tag.category.locale": {
+		"defaultMessage": "在地化"
+	},
+	"tag.category.low": {
+		"defaultMessage": "低"
+	},
+	"tag.category.magic": {
+		"defaultMessage": "魔法"
+	},
+	"tag.category.management": {
+		"defaultMessage": "管理"
+	},
+	"tag.category.media": {
+		"defaultMessage": "媒體"
+	},
+	"tag.category.medium": {
+		"defaultMessage": "中"
+	},
+	"tag.category.microgames": {
+		"defaultMessage": "微型遊戲"
+	},
+	"tag.category.minigame": {
+		"defaultMessage": "小遊戲"
+	},
+	"tag.category.minigames": {
+		"defaultMessage": "小遊戲"
+	},
+	"tag.category.mmo": {
+		"defaultMessage": "MMO"
+	},
+	"tag.category.mobs": {
+		"defaultMessage": "生物"
+	},
+	"tag.category.modded": {
+		"defaultMessage": "模組支援"
+	},
+	"tag.category.models": {
+		"defaultMessage": "模型"
+	},
+	"tag.category.multiplayer": {
+		"defaultMessage": "多人遊戲"
+	},
+	"tag.category.network": {
+		"defaultMessage": "群組伺服器"
+	},
+	"tag.category.offline-mode": {
+		"defaultMessage": "離線模式"
+	},
+	"tag.category.oneblock": {
+		"defaultMessage": "一格方塊"
+	},
+	"tag.category.op": {
+		"defaultMessage": "OP"
+	},
+	"tag.category.optimization": {
+		"defaultMessage": "最佳化"
+	},
+	"tag.category.parkour": {
+		"defaultMessage": "跑酷"
+	},
+	"tag.category.path-tracing": {
+		"defaultMessage": "光線追蹤"
+	},
+	"tag.category.pbr": {
+		"defaultMessage": "PBR"
+	},
+	"tag.category.personal-worlds": {
+		"defaultMessage": "個人世界"
+	},
+	"tag.category.plots": {
+		"defaultMessage": "地塊"
+	},
+	"tag.category.pokemon": {
+		"defaultMessage": "寶可夢"
+	},
+	"tag.category.potato": {
+		"defaultMessage": "馬鈴薯"
+	},
+	"tag.category.prison": {
+		"defaultMessage": "監獄"
+	},
+	"tag.category.pve": {
+		"defaultMessage": "PvE"
+	},
+	"tag.category.pvp": {
+		"defaultMessage": "PvP"
+	},
+	"tag.category.questing": {
+		"defaultMessage": "任務"
+	},
+	"tag.category.quests": {
+		"defaultMessage": "任務"
+	},
+	"tag.category.racing": {
+		"defaultMessage": "競速"
+	},
+	"tag.category.realistic": {
+		"defaultMessage": "寫實"
+	},
+	"tag.category.recording-smp": {
+		"defaultMessage": "錄影 SMP"
+	},
+	"tag.category.reflections": {
+		"defaultMessage": "折射"
+	},
+	"tag.category.roleplay": {
+		"defaultMessage": "角色扮演"
+	},
+	"tag.category.rpg": {
+		"defaultMessage": "RPG"
+	},
+	"tag.category.screenshot": {
+		"defaultMessage": "擷圖用"
+	},
+	"tag.category.semi-realistic": {
+		"defaultMessage": "半寫實"
+	},
+	"tag.category.shadows": {
+		"defaultMessage": "陰影"
+	},
+	"tag.category.simplistic": {
+		"defaultMessage": "簡約"
+	},
+	"tag.category.skyblock": {
+		"defaultMessage": "空島生存"
+	},
+	"tag.category.smp": {
+		"defaultMessage": "SMP"
+	},
+	"tag.category.social": {
+		"defaultMessage": "社交"
+	},
+	"tag.category.storage": {
+		"defaultMessage": "儲物管理"
+	},
+	"tag.category.survival-mode": {
+		"defaultMessage": "生存模式"
+	},
+	"tag.category.teams": {
+		"defaultMessage": "團隊"
+	},
+	"tag.category.technical": {
+		"defaultMessage": "技術性"
+	},
+	"tag.category.technology": {
+		"defaultMessage": "科技"
+	},
+	"tag.category.themed": {
+		"defaultMessage": "特定主題"
+	},
+	"tag.category.towns": {
+		"defaultMessage": "城鎮"
+	},
+	"tag.category.transportation": {
+		"defaultMessage": "交通"
+	},
+	"tag.category.tweaks": {
+		"defaultMessage": "微調"
+	},
+	"tag.category.utility": {
+		"defaultMessage": "工具"
+	},
+	"tag.category.vanilla-like": {
+		"defaultMessage": "類原版"
+	},
+	"tag.category.whitelisted": {
+		"defaultMessage": "白名單"
+	},
+	"tag.category.world-resets": {
+		"defaultMessage": "世界重設"
+	},
+	"tag.category.worldgen": {
+		"defaultMessage": "世界生成"
+	},
+	"tag.loader.babric": {
+		"defaultMessage": "Babric"
+	},
+	"tag.loader.bta-babric": {
+		"defaultMessage": "BTA（Babric）"
+	},
+	"tag.loader.bukkit": {
+		"defaultMessage": "Bukkit"
+	},
+	"tag.loader.bungeecord": {
+		"defaultMessage": "BungeeCord"
+	},
+	"tag.loader.canvas": {
+		"defaultMessage": "Canvas"
+	},
+	"tag.loader.datapack": {
+		"defaultMessage": "資料包"
+	},
+	"tag.loader.fabric": {
+		"defaultMessage": "Fabric"
+	},
+	"tag.loader.folia": {
+		"defaultMessage": "Folia"
+	},
+	"tag.loader.forge": {
+		"defaultMessage": "Forge"
+	},
+	"tag.loader.geyser": {
+		"defaultMessage": "Geyser 擴充"
+	},
+	"tag.loader.iris": {
+		"defaultMessage": "Iris"
+	},
+	"tag.loader.java-agent": {
+		"defaultMessage": "Java 代理"
+	},
+	"tag.loader.legacy-fabric": {
+		"defaultMessage": "Legacy Fabric"
+	},
+	"tag.loader.liteloader": {
+		"defaultMessage": "LiteLoader"
+	},
+	"tag.loader.minecraft": {
+		"defaultMessage": "資源包"
+	},
+	"tag.loader.modloader": {
+		"defaultMessage": "Risugami's ModLoader"
+	},
+	"tag.loader.mrpack": {
+		"defaultMessage": "模組包"
+	},
+	"tag.loader.neoforge": {
+		"defaultMessage": "NeoForge"
+	},
+	"tag.loader.nilloader": {
+		"defaultMessage": "NilLoader"
+	},
+	"tag.loader.optifine": {
+		"defaultMessage": "OptiFine"
+	},
+	"tag.loader.ornithe": {
+		"defaultMessage": "Ornithe"
+	},
+	"tag.loader.paper": {
+		"defaultMessage": "Paper"
+	},
+	"tag.loader.purpur": {
+		"defaultMessage": "Purpur"
+	},
+	"tag.loader.quilt": {
+		"defaultMessage": "Quilt"
+	},
+	"tag.loader.rift": {
+		"defaultMessage": "Rift"
+	},
+	"tag.loader.spigot": {
+		"defaultMessage": "Spigot"
+	},
+	"tag.loader.sponge": {
+		"defaultMessage": "Sponge"
+	},
+	"tag.loader.vanilla": {
+		"defaultMessage": "原版著色器"
+	},
+	"tag.loader.velocity": {
+		"defaultMessage": "Velocity"
+	},
+	"tag.loader.waterfall": {
+		"defaultMessage": "Waterfall"
+	},
+	"time-frame-picker.apply": {
+		"defaultMessage": "套用"
+	},
+	"time-frame-picker.cancel": {
+		"defaultMessage": "取消"
+	},
+	"time-frame-picker.clear-range": {
+		"defaultMessage": "清除"
+	},
+	"time-frame-picker.custom-range": {
+		"defaultMessage": "自訂日期範圍..."
+	},
+	"time-frame-picker.decrease-amount": {
+		"defaultMessage": "減少時間範圍時長"
+	},
+	"time-frame-picker.empty-range": {
+		"defaultMessage": "未選取日期範圍。"
+	},
+	"time-frame-picker.end-date": {
+		"defaultMessage": "結束日期"
+	},
+	"time-frame-picker.increase-amount": {
+		"defaultMessage": "增加時間範圍時長"
+	},
+	"time-frame-picker.last-timeframe": {
+		"defaultMessage": "在過去 {amount} {unit, select, hours {{amount, plural, other {小時}}} days {{amount, plural, other {天}}} weeks {{amount, plural, other {週}}} months {{amount, plural, other {月}}} other {天}}"
+	},
+	"time-frame-picker.last-timeframe-prefix": {
+		"defaultMessage": "在過去"
+	},
+	"time-frame-picker.option.all-time": {
+		"defaultMessage": "所有時間"
+	},
+	"time-frame-picker.option.last-14-days": {
+		"defaultMessage": "過去 14 天"
+	},
+	"time-frame-picker.option.last-180-days": {
+		"defaultMessage": "過去 180 天"
+	},
+	"time-frame-picker.option.last-30-days": {
+		"defaultMessage": "過去 30 天"
+	},
+	"time-frame-picker.option.last-7-days": {
+		"defaultMessage": "過去 7 天"
+	},
+	"time-frame-picker.option.last-90-days": {
+		"defaultMessage": "過去 90 天"
+	},
+	"time-frame-picker.option.today": {
+		"defaultMessage": "今天"
+	},
+	"time-frame-picker.option.year-to-date": {
+		"defaultMessage": "今年迄今"
+	},
+	"time-frame-picker.option.yesterday": {
+		"defaultMessage": "昨天"
+	},
+	"time-frame-picker.select-timeframe": {
+		"defaultMessage": "選取時間範圍"
+	},
+	"time-frame-picker.selected-range": {
+		"defaultMessage": "選取範圍"
+	},
+	"time-frame-picker.selecting-range": {
+		"defaultMessage": "選取中"
+	},
+	"time-frame-picker.start-date": {
+		"defaultMessage": "開始日期"
+	},
+	"time-frame-picker.timeframe-amount": {
+		"defaultMessage": "時間範圍時長"
+	},
+	"time-frame-picker.timeframe-unit": {
+		"defaultMessage": "時間範圍單位"
+	},
+	"time-frame-picker.unit.days": {
+		"defaultMessage": "天"
+	},
+	"time-frame-picker.unit.hours": {
+		"defaultMessage": "小時"
+	},
+	"time-frame-picker.unit.months": {
+		"defaultMessage": "月"
+	},
+	"time-frame-picker.unit.weeks": {
+		"defaultMessage": "週"
+	},
+	"ui.component.unsaved-changes-popup.body": {
+		"defaultMessage": "你的變更尚未儲存。"
+	},
+	"ui.confirm-leave-modal.body": {
+		"defaultMessage": "您有未儲存的變更，如果離開此頁面將會遺失"
+	},
+	"ui.confirm-leave-modal.header": {
+		"defaultMessage": "您有未儲存的變更"
+	},
+	"ui.confirm-leave-modal.leave": {
+		"defaultMessage": "離開頁面"
+	},
+	"ui.confirm-leave-modal.stay": {
+		"defaultMessage": "留在頁面"
+	},
+	"ui.confirm-leave-modal.title": {
+		"defaultMessage": "離開頁面？"
+	},
+	"ui.stacked-admonitions.alert-count": {
+		"defaultMessage": "{count, plural, other {# 個警示}}"
+	},
+	"ui.stacked-admonitions.dismiss-all": {
+		"defaultMessage": "忽略全部"
+	},
+	"version.content.name": {
+		"defaultMessage": "名稱"
+	},
+	"version.content.version": {
+		"defaultMessage": "版本"
+	},
+	"version.file-type.dev-jar": {
+		"defaultMessage": "開發用 jar"
+	},
+	"version.file-type.javadoc-jar": {
+		"defaultMessage": "Javadoc jar"
+	},
+	"version.file-type.optional-resource-pack": {
+		"defaultMessage": "可選資源包"
+	},
+	"version.file-type.primary": {
+		"defaultMessage": "主要"
+	},
+	"version.file-type.required-resource-pack": {
+		"defaultMessage": "所需資源包"
+	},
+	"version.file-type.signature": {
+		"defaultMessage": "簽署文件"
+	},
+	"version.file-type.sources-jar": {
+		"defaultMessage": "原始碼 jar"
+	},
+	"version.file-type.unknown": {
+		"defaultMessage": "其他"
+	},
+	"version.section.changes": {
+		"defaultMessage": "變更"
+	},
+	"version.section.compatibility": {
+		"defaultMessage": "相容性"
+	},
+	"version.section.content": {
+		"defaultMessage": "內容"
+	},
+	"version.section.content.search-placeholder": {
+		"defaultMessage": "搜尋內容..."
+	},
+	"version.section.dependencies.any-compatible-version": {
+		"defaultMessage": "任何相容的版本"
+	},
+	"version.section.dependencies.any-version": {
+		"defaultMessage": "任何版本"
+	},
+	"version.section.dependencies.unavailable-version": {
+		"defaultMessage": "不可用版本"
+	},
+	"version.section.dependencies.unavailable-version.description": {
+		"defaultMessage": "這個版本可能已被刪除，或正在由管理員審查。"
+	},
+	"version.section.dependencies.unavailable-version.description.required": {
+		"defaultMessage": "所需版本可能已被刪除，或正在由管理員審查。"
+	},
+	"version.section.files": {
+		"defaultMessage": "檔案"
+	},
+	"version.section.included-content": {
+		"defaultMessage": "包含的內容"
+	},
+	"version.section.known-incompatibilities": {
+		"defaultMessage": "已知不相容"
+	},
+	"version.section.no-changes": {
+		"defaultMessage": "未提供變更日誌。"
+	},
+	"version.section.no-modpack-mod-loader": {
+		"defaultMessage": "無模組載入器"
+	},
+	"version.section.optional-dependencies": {
+		"defaultMessage": "可選相依項"
+	},
+	"version.section.required-content": {
+		"defaultMessage": "所需內容"
+	},
+	"version.section.supplementary-resources": {
+		"defaultMessage": "補充資源"
+	},
+	"version.supplementary-resources.file": {
+		"defaultMessage": "檔案"
+	},
+	"version.supplementary-resources.size": {
+		"defaultMessage": "檔案大小"
+	},
+	"version.supplementary-resources.type": {
+		"defaultMessage": "類型"
+	},
+	"drop.confirm.title": {
+		"message": "你想以什麼類型匯入？"
+	},
+	"drop.confirm.not-this": {
+		"message": "作為其他內容匯入"
+	},
+	"drop.confirm.cancel": {
+		"message": "取消"
+	},
+	"drop.confirm.help": {
+		"message": "我可以拖入什麼？"
+	},
+	"drop.confirm.as-mod": {
+		"message": "模組"
+	},
+	"drop.confirm.as-mod-desc": {
+		"message": "將模組 JAR 安裝到 Minecraft 實例"
+	},
+	"drop.confirm.as-instance": {
+		"message": "實例"
+	},
+	"drop.confirm.as-instance-desc": {
+		"message": "從其他啟動器匯入 Minecraft 實例"
+	},
+	"drop.confirm.as-modpack": {
+		"message": "整合包"
+	},
+	"drop.confirm.as-modpack-desc": {
+		"message": "從整合包建立新實例"
+	},
+	"drop.confirm.as-resource-pack": {
+		"message": "資源包"
+	},
+	"drop.confirm.as-resource-pack-desc": {
+		"message": "將資源包安裝到實例"
+	},
+	"drop.confirm.as-shader-pack": {
+		"message": "光影包"
+	},
+	"drop.confirm.as-shader-pack-desc": {
+		"message": "將光影包安裝到實例"
+	},
+	"drop.confirm.as-world": {
+		"message": "存檔"
+	},
+	"drop.confirm.as-world-desc": {
+		"message": "將存檔匯入到實例中"
+	},
+	"drop.confirm.as-schematic": {
+		"message": "投影"
+	},
+	"drop.confirm.as-schematic-desc": {
+		"message": "匯入 Litematic 投影檔案"
+	},
+	"drop.confirm.as-dot-minecraft": {
+		"message": ".minecraft"
+	},
+	"drop.confirm.as-dot-minecraft-desc": {
+		"message": "掃描 .minecraft 資料夾以建立實例"
+	},
+	"drop.confirm.as-launcher": {
+		"message": "啟動器"
+	},
+	"drop.confirm.as-hmcl-launcher": {
+		"message": "HMCL 啟動器"
+	},
+	"drop.generic_install.title": {
+		"message": "安裝 {type}"
+	},
+	"drop.generic_install.search": {
+		"message": "搜尋實例..."
+	},
+	"drop.generic_install.install": {
+		"message": "安裝"
+	},
+	"drop.generic_install.cancel": {
+		"message": "取消"
+	},
+	"drop.generic_install.create_new": {
+		"message": "建立新實例..."
+	},
+	"drop.generic_install.no_instances": {
+		"message": "找不到實例"
+	},
+	"app.drop.batch.scan.title": {
+		"message": "正在識別 {count, plural, one {# 個檔案} other {# 個檔案}}…"
+	},
+	"app.drop.batch.scan.subtitle": {
+		"message": "已識別 {done} / {total}"
+	},
+	"app.drop.batch.scan.cancel": {
+		"message": "取消"
+	},
+	"app.drop.batch.scan.pending": {
+		"message": "等待"
+	},
+	"app.drop.batch.scan.scanning": {
+		"message": "掃描中"
+	},
+	"app.drop.batch.scan.done": {
+		"message": "已識別"
+	},
+	"app.drop.batch.scan.skipped": {
+		"message": "已跳過"
+	},
+	"app.drop.batch.scan.error": {
+		"message": "失敗"
+	},
+	"drop.launcher_import.title": {
+		"message": "從 {launcherName} 匯入實例"
+	},
+	"drop.launcher_import.subtitle": {
+		"message": "在 {basePath} 中掃描到 {count} 個實例"
+	},
+	"drop.launcher_import.select_all": {
+		"message": "全選"
+	},
+	"drop.launcher_import.deselect_all": {
+		"message": "取消全選"
+	},
+	"drop.launcher_import.selected": {
+		"message": "已選 {n} 個"
+	},
+	"drop.launcher_import.cancel": {
+		"message": "取消"
+	},
+	"drop.launcher_import.import": {
+		"message": "匯入（{n}）"
+	},
+	"drop.launcher_import.no_instances": {
+		"message": "找不到實例"
+	},
+	"drop.symlink_method.title": {
+		"message": "選擇匯入方式"
+	},
+	"drop.symlink_method.subtitle": {
+		"message": "正在匯入 {n} 個實例"
+	},
+	"drop.symlink_method.copy_title": {
+		"message": "複製檔案"
+	},
+	"drop.symlink_method.copy_desc": {
+		"message": "複製到 Axolotl 目錄"
+	},
+	"drop.symlink_method.symlink_title": {
+		"message": "符號連結"
+	},
+	"drop.symlink_method.symlink_desc": {
+		"message": "引用原始位置"
+	},
+	"drop.symlink_method.requires_admin": {
+		"message": "建立連結時將要求一次系統管理員授權（UAC）"
+	},
+	"drop.symlink_method.unsupported_warning": {
+		"message": "此系統不支援符號連結"
+	},
+	"drop.symlink_method.cancel": {
+		"message": "取消"
+	},
+	"drop.symlink_method.reset_changes": {
+		"message": "重置更改"
+	},
+	"drop.symlink_method.confirm": {
+		"message": "確認"
+	},
+	"drop.symlink_method.next": {
+		"message": "下一步"
+	},
+	"drop.symlink_method.instance_nav_label": {
+		"message": "切換到 {name}"
+	},
+	"drop.symlink_method.detecting": {
+		"message": "檢測中..."
+	},
+	"drop.symlink_method.game_version": {
+		"message": "遊戲版本"
+	},
+	"drop.symlink_method.import_path": {
+		"message": "版本路徑"
+	},
+	"drop.symlink_method.import_path_tooltip": {
+		"message": "匯入路徑"
+	},
+	"drop.symlink_method.instance": {
+		"message": "例項"
+	},
+	"drop.symlink_method.loader": {
+		"message": "載入器"
+	},
+	"drop.symlink_method.loader_type_unknown_tooltip": {
+		"message": "此版本安裝有Mod，但未識別到載入器。"
+	},
+	"drop.symlink_method.loader_version": {
+		"message": "載入器版本"
+	},
+	"drop.symlink_method.loader_version_unknown_tooltip": {
+		"message": "未檢測到載入器版本，將使用自定義版本。"
+	},
+	"drop.symlink_method.latest": {
+		"message": "最新"
+	},
+	"drop.symlink_method.method": {
+		"message": "匯入方式"
+	},
+	"drop.symlink_method.missing": {
+		"message": "缺失"
+	},
+	"drop.symlink_method.missing_path": {
+		"message": "沒有可用的匯入路徑"
+	},
+	"drop.symlink_method.not_available": {
+		"message": "不可用"
+	},
+	"drop.symlink_method.plan_failed": {
+		"message": "未能估算進度"
+	},
+	"drop.symlink_method.unrecognized": {
+		"message": "未識別"
+	},
+	"drop.symlink_method.custom": {
+		"message": "自定義"
+	},
+	"drop.symlink_method.custom_tooltip": {
+		"message": "通常您不應該自定義它，除非您確認它識別錯誤。"
+	},
+	"drop.symlink_method.runtime_root": {
+		"message": "根目錄"
+	},
+	"drop.symlink_method.runtime_root_tooltip": {
+		"message": "Runtime 根目錄"
+	},
+	"drop.symlink_method.search_game_version": {
+		"message": "搜尋遊戲版本"
+	},
+	"drop.symlink_method.search_loader_version": {
+		"message": "搜尋載入器版本"
+	},
+	"drop.symlink_method.select_game_version": {
+		"message": "選擇遊戲版本"
+	},
+	"drop.symlink_method.select_instance": {
+		"message": "選擇例項"
+	},
+	"drop.symlink_method.select_loader_version": {
+		"message": "選擇載入器版本"
+	},
+	"drop.symlink_method.stats": {
+		"message": "估計"
+	},
+	"drop.symlink_method.stats_cache": {
+		"message": "快取"
+	},
+	"drop.symlink_method.stats_cache_tooltip": {
+		"message": "Axolotl 快取"
+	},
+	"drop.symlink_method.stats_local": {
+		"message": "複用"
+	},
+	"drop.symlink_method.stats_local_tooltip": {
+		"message": "本地複用"
+	},
+	"drop.symlink_method.stats_migrate": {
+		"message": "遷移"
+	},
+	"drop.symlink_method.stats_migrate_tooltip": {
+		"message": "需要遷移"
+	},
+	"drop.symlink_method.stats_files": {
+		"message": "{files} 個檔案"
+	},
+	"drop.symlink_method.stats_network": {
+		"message": "下載"
+	},
+	"drop.symlink_method.stats_network_tooltip": {
+		"message": "需要下載"
+	},
+	"instances.updater-modal.search-compat": {
+		"message": "尋找相容版本"
+	},
+	"project-type.schematic.category": {
+		"message": "投影"
+	},
+	"project-type.schematic.capital": {
+		"message": "{count, plural, one {投影} other {投影}}"
+	},
+	"project-type.schematic.lowercase": {
+		"message": "{count, plural, one {投影} other {投影}}"
+	},
+	"creation-flow.modal.import-instance.select-folder.description": {
+		"defaultMessage": "导入启动器文件夹或 .minecraft 文件夹"
+	},
+	"creation-flow.modal.import-instance.select-folder": {
+		"defaultMessage": "选择要导入的文件夹"
+	},
+	"creation-flow.modal.import-instance.select-file.description": {
+		"defaultMessage": "导入整合包文件或启动器(HMCL、PCL)"
+	},
+	"drop.confirm.as-data-pack": {
+		"defaultMessage": "数据包"
+	},
+	"drop.confirm.as-data-pack-desc": {
+		"defaultMessage": "将数据包安装到存档"
+	},
+	"app.translation-settings.provider.deepl": "DeepL 翻译",
+	"app.settings.updates.miawa": "柠泽镜像"
 }

--- a/packages/ui/src/locales/zh-TW/index.json
+++ b/packages/ui/src/locales/zh-TW/index.json
@@ -2,12 +2,6 @@
 	"action.no-permission": {
 		"defaultMessage": "你沒有權限。"
 	},
-	"app.symlink-warning.write.body": {
-		"message": "This instance is linked to "
-	},
-	"app.symlink-warning.write.header": {
-		"message": "Shared instance"
-	},
 	"badge.alpha": {
 		"defaultMessage": "Alpha 版"
 	},
@@ -38,17 +32,11 @@
 	"browse.selected-projects-floating-bar.aria-label": {
 		"defaultMessage": "已選取專案"
 	},
-	"browse.selected-projects-floating-bar.hide-projects": {
-		"defaultMessage": "隐藏已选项目"
-	},
 	"browse.selected-projects-floating-bar.install": {
 		"defaultMessage": "安裝 {count, plural, other {# 個專案}}"
 	},
 	"browse.selected-projects-floating-bar.selected-count": {
 		"defaultMessage": "{count, plural, other {已選取 # 個專案}}"
-	},
-	"browse.selected-projects-floating-bar.show-projects": {
-		"defaultMessage": "显示{count, plural, other {#个已选项目}}"
 	},
 	"browse.selected-projects-leave-modal.admonition-body": {
 		"defaultMessage": "你已選取 {count, plural, other {# 個專案}}來安裝。立即安裝專案，或返回而不安裝。"
@@ -61,27 +49,6 @@
 	},
 	"browse.selected-projects-leave-modal.header": {
 		"defaultMessage": "你選取的專案尚未安裝"
-	},
-	"browse.sort.date-published": {
-		"message": "Date published"
-	},
-	"browse.sort.date-updated": {
-		"message": "Date updated"
-	},
-	"browse.sort.downloads": {
-		"message": "Downloads"
-	},
-	"browse.sort.followers": {
-		"message": "Followers"
-	},
-	"browse.sort.players": {
-		"message": "Players"
-	},
-	"browse.sort.relevance": {
-		"message": "Relevance"
-	},
-	"browse.sort.verified-plays": {
-		"message": "Verified plays"
 	},
 	"browse.view-prefix": {
 		"defaultMessage": "檢視模式："
@@ -179,9 +146,6 @@
 	"button.open-folder": {
 		"defaultMessage": "開啟資料夾"
 	},
-	"button.open-in-browser": {
-		"message": "Open in browser"
-	},
 	"button.open-in-folder": {
 		"defaultMessage": "在資料夾中開啟"
 	},
@@ -250,9 +214,6 @@
 	},
 	"button.stop": {
 		"defaultMessage": "停止"
-	},
-	"button.switch-to-version": {
-		"message": "Switch to version"
 	},
 	"button.switch-version": {
 		"defaultMessage": "切換版本"
@@ -599,29 +560,8 @@
 	"console.notification.share-failed": {
 		"defaultMessage": "分享日誌失敗"
 	},
-	"console.notification.share-truncated": {
-		"defaultMessage": "日志过大，已自动截取最后 9MB 上传。"
-	},
 	"console.notification.unknown-error": {
 		"defaultMessage": "未知錯誤。"
-	},
-	"console.log.toggle-wrap": {
-		"defaultMessage": "切换换行"
-	},
-	"console.log.wrap-label": {
-		"defaultMessage": "换行"
-	},
-	"console.empty.instance-title": {
-		"defaultMessage": "暂无日志"
-	},
-	"console.empty.instance-description": {
-		"defaultMessage": "点击右上角「开始游戏」即可接收实时日志"
-	},
-	"console.empty.server-title": {
-		"defaultMessage": "欢迎使用 Modrinth 服务器！"
-	},
-	"console.empty.server-description": {
-		"defaultMessage": "点击启动按钮即可启动服务器！"
 	},
 	"console.search.placeholder": {
 		"defaultMessage": "搜尋日誌"
@@ -634,27 +574,6 @@
 	},
 	"content-type.item.lowercase": {
 		"defaultMessage": "{count, plural, other {項目}}"
-	},
-	"content.card.dependency-badge": {
-		"defaultMessage": "前置"
-	},
-	"content.card.duplicate-mod": {
-		"defaultMessage": "此模组已安装 {count, number} 次。"
-	},
-	"content.card.group.hardcore": {
-		"defaultMessage": "硬核模式"
-	},
-	"content.card.group.not-played-yet": {
-		"defaultMessage": "尚未游玩"
-	},
-	"content.card.orphaned-dependency-badge": {
-		"defaultMessage": "孤立前置"
-	},
-	"content.card.pending-manual-download": {
-		"message": "Manual download required"
-	},
-	"content.card.rollback-tooltip": {
-		"defaultMessage": "回滾到 {fileName}"
 	},
 	"content.card.select-project": {
 		"defaultMessage": "選取「{project}」"
@@ -773,9 +692,6 @@
 	"content.filter.disabled": {
 		"defaultMessage": "停用"
 	},
-	"content.filter.duplicates": {
-		"defaultMessage": "重复"
-	},
 	"content.filter.enabled": {
 		"defaultMessage": "啟用"
 	},
@@ -784,120 +700,6 @@
 	},
 	"content.filter.warnings": {
 		"defaultMessage": "警告"
-	},
-	"content.metadata-filter.author": {
-		"defaultMessage": "作者"
-	},
-	"content.metadata-filter.clear": {
-		"defaultMessage": "清除"
-	},
-	"content.metadata-filter.environment": {
-		"defaultMessage": "环境"
-	},
-	"content.metadata-filter.environment.client": {
-		"defaultMessage": "客户端"
-	},
-	"content.metadata-filter.environment.client-and-server": {
-		"defaultMessage": "客户端和服务端"
-	},
-	"content.metadata-filter.environment.server": {
-		"defaultMessage": "服务端"
-	},
-	"content.metadata-filter.environment.singleplayer": {
-		"defaultMessage": "单人游戏"
-	},
-	"content.metadata-filter.external": {
-		"defaultMessage": "外部文件"
-	},
-	"content.metadata-filter.external.external": {
-		"defaultMessage": "外部文件"
-	},
-	"content.metadata-filter.external.linked": {
-		"defaultMessage": "在线项目"
-	},
-	"content.metadata-filter.loader": {
-		"defaultMessage": "加载器"
-	},
-	"content.metadata-filter.loader.fabric": {
-		"defaultMessage": "Fabric"
-	},
-	"content.metadata-filter.loader.forge": {
-		"defaultMessage": "Forge"
-	},
-	"content.metadata-filter.loader.neoforge": {
-		"defaultMessage": "NeoForge"
-	},
-	"content.metadata-filter.loader.other": {
-		"defaultMessage": "其他"
-	},
-	"content.metadata-filter.loader.quilt": {
-		"defaultMessage": "Quilt"
-	},
-	"content.metadata-filter.long-press-reset": {
-		"defaultMessage": "长按重置筛选"
-	},
-	"content.metadata-filter.open-source": {
-		"defaultMessage": "开源"
-	},
-	"content.metadata-filter.open-source.closed": {
-		"defaultMessage": "非开源"
-	},
-	"content.metadata-filter.open-source.open": {
-		"defaultMessage": "开源"
-	},
-	"content.metadata-filter.search": {
-		"defaultMessage": "搜索..."
-	},
-	"content.metadata-filter.select-all": {
-		"defaultMessage": "全选"
-	},
-	"content.metadata-filter.source": {
-		"defaultMessage": "来源"
-	},
-	"content.metadata-filter.source.curseforge": {
-		"defaultMessage": "CurseForge"
-	},
-	"content.metadata-filter.source.imported-modpack": {
-		"defaultMessage": "导入整合包"
-	},
-	"content.metadata-filter.source.local": {
-		"defaultMessage": "本地"
-	},
-	"content.metadata-filter.source.modrinth-modpack": {
-		"defaultMessage": "Modrinth 整合包"
-	},
-	"content.metadata-filter.source.server-project": {
-		"defaultMessage": "服务器项目"
-	},
-	"content.metadata-filter.source.shared-instance": {
-		"defaultMessage": "共享实例"
-	},
-	"content.metadata-filter.state": {
-		"defaultMessage": "状态"
-	},
-	"content.metadata-filter.state.disabled": {
-		"defaultMessage": "已禁用"
-	},
-	"content.metadata-filter.state.enabled": {
-		"defaultMessage": "已启用"
-	},
-	"content.metadata-filter.toggle": {
-		"defaultMessage": "筛选"
-	},
-	"content.metadata-filter.toggle-active": {
-		"defaultMessage": "筛选（已启用 {count, number} 项）"
-	},
-	"content.metadata-filter.unknown": {
-		"defaultMessage": "未知"
-	},
-	"content.metadata-filter.update.available": {
-		"defaultMessage": "可更新"
-	},
-	"content.metadata-filter.update.up-to-date": {
-		"defaultMessage": "已是最新"
-	},
-	"content.metadata-filter.updates": {
-		"defaultMessage": "更新"
 	},
 	"content.page-layout.browse-content": {
 		"defaultMessage": "瀏覽內容"
@@ -935,12 +737,6 @@
 	"content.page-layout.sort.alphabetical": {
 		"defaultMessage": "字母順序"
 	},
-	"content.page-layout.sort.file-name-ascending": {
-		"defaultMessage": "文件名 A-Z"
-	},
-	"content.page-layout.sort.file-name-descending": {
-		"defaultMessage": "文件名 Z-A"
-	},
 	"content.page-layout.sort.date-added-newest": {
 		"defaultMessage": "最新在前"
 	},
@@ -950,26 +746,8 @@
 	"content.page-layout.sort.label": {
 		"defaultMessage": "排序依據：{mode}"
 	},
-	"content.page-layout.sort.project-name-ascending": {
-		"defaultMessage": "项目名称 A-Z"
-	},
-	"content.page-layout.sort.project-name-descending": {
-		"defaultMessage": "项目名称 Z-A"
-	},
-	"content.page-layout.pin-view": {
-		"defaultMessage": "固定当前视图"
-	},
-	"content.page-layout.reset-view": {
-		"defaultMessage": "重置视图"
-	},
-	"content.page-layout.unpin-view": {
-		"defaultMessage": "取消固定当前视图"
-	},
 	"content.page-layout.update-all": {
 		"defaultMessage": "更新全部"
-	},
-	"content.page-layout.view-options": {
-		"defaultMessage": "视图选项"
 	},
 	"content.selection-bar.all-already-disabled": {
 		"defaultMessage": "所有已選擇的內容已經停用"
@@ -1037,33 +815,6 @@
 	"creation-flow.button.setup-server": {
 		"defaultMessage": "設定伺服器"
 	},
-	"creation-flow.modal.custom-setup.adjunct.hint": {
-		"defaultMessage": "下载前会自动选择兼容版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.checking-compatibility": {
-		"defaultMessage": "正在检查兼容性……"
-	},
-	"creation-flow.modal.custom-setup.adjunct.compatibility-load-failed": {
-		"defaultMessage": "无法验证 {loader} 的兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.label": {
-		"defaultMessage": "附加加载器"
-	},
-	"creation-flow.modal.custom-setup.adjunct.optifabric-load-failed": {
-		"defaultMessage": "无法验证 OptiFabric 兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.optifabric-unsupported": {
-		"defaultMessage": "OptiFine 需要 OptiFabric，但当前游戏版本没有兼容版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.primary-unsupported": {
-		"defaultMessage": "所选主加载器不支持当前游戏版本。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.select-game-version": {
-		"defaultMessage": "请先选择游戏版本以检查兼容性。"
-	},
-	"creation-flow.modal.custom-setup.adjunct.unsupported": {
-		"defaultMessage": "{loader} 没有支持当前游戏版本的兼容版本。"
-	},
 	"creation-flow.modal.custom-setup.build-number.label": {
 		"defaultMessage": "組建編號"
 	},
@@ -1121,9 +872,6 @@
 	"creation-flow.modal.custom-setup.loader-version.search-placeholder": {
 		"defaultMessage": "搜尋載入器版本..."
 	},
-	"creation-flow.modal.custom-setup.loader.compatibility-load-failed": {
-		"defaultMessage": "无法验证加载器兼容性"
-	},
 	"creation-flow.modal.custom-setup.loader.label": {
 		"defaultMessage": "載入器"
 	},
@@ -1144,12 +892,6 @@
 	},
 	"creation-flow.modal.custom-setup.will-install-loader-version": {
 		"defaultMessage": "將會安裝：{loader} {version}"
-	},
-	"creation-flow.modal.import-instance.import-prompt": {
-		"defaultMessage": "拖拽启动器文件夹、整合包文件或 .minecraft 文件夹即可一键导入实例"
-	},
-	"creation-flow.modal.import-instance.select-file": {
-		"defaultMessage": "选择要导入的文件"
 	},
 	"creation-flow.modal.setup-type.instance.description": {
 		"defaultMessage": "實例是指具有特定載入器、版本及模組的 Minecraft 設定。"
@@ -1259,21 +1001,6 @@
 	"files.delete-modal.deleting-name": {
 		"defaultMessage": "正在刪除「{name}」"
 	},
-	"files.delete-modal.deleting-multiple": {
-		"message": "Deleting {count} items"
-	},
-	"files.delete-modal.bulk-header": {
-		"message": "Delete multiple items"
-	},
-	"files.delete-modal.bulk-warning": {
-		"message": "The selected items will be permanently deleted. This action cannot be undone."
-	},
-	"files.delete-modal.symlink-warning-header": {
-		"message": "Shared instance"
-	},
-	"files.delete-modal.symlink-warning-body": {
-		"message": "You are modifying files in a shared instance linked to "
-	},
 	"files.delete-modal.header": {
 		"defaultMessage": "刪除檔案"
 	},
@@ -1342,9 +1069,6 @@
 	},
 	"files.editor.save-failed-title": {
 		"defaultMessage": "儲存失敗"
-	},
-	"files.editor.share-truncated-warning": {
-		"defaultMessage": "日志文件过大，已自动截取最后 9MB 上传。"
 	},
 	"files.error.go-to-home": {
 		"defaultMessage": "前往家資料夾"
@@ -1454,9 +1178,6 @@
 	"files.navbar.search-files": {
 		"defaultMessage": "搜尋檔案"
 	},
-	"files.navbar.share-log": {
-		"defaultMessage": "分享日志"
-	},
 	"files.navbar.upload-from-zip": {
 		"defaultMessage": "從 .zip 檔案上傳"
 	},
@@ -1471,9 +1192,6 @@
 	},
 	"files.row.item-count": {
 		"defaultMessage": "{count, plural, other {# 個項目}}"
-	},
-	"files.row.parent-folder": {
-		"message": "Parent folder"
 	},
 	"files.table-header.created": {
 		"defaultMessage": "建立時間"
@@ -1658,9 +1376,6 @@
 	"header.category.category": {
 		"defaultMessage": "類別"
 	},
-	"header.category.cf-extra": {
-		"message": "More CurseForge categories"
-	},
 	"header.category.feature": {
 		"defaultMessage": "功能"
 	},
@@ -1774,12 +1489,6 @@
 	},
 	"installation-settings.loader-version": {
 		"defaultMessage": "{loader} 版本"
-	},
-	"installation-settings.loader-version.error": {
-		"defaultMessage": "加载加载器版本数据失败"
-	},
-	"installation-settings.loader-version.unsupported": {
-		"defaultMessage": "此加载器不支持所选游戏版本"
 	},
 	"installation-settings.platform-lock-tooltip": {
 		"defaultMessage": "你需要重設伺服器才能切換載入器。"
@@ -2213,9 +1922,6 @@
 	"label.server": {
 		"defaultMessage": "伺服器"
 	},
-	"label.server-only": {
-		"message": "Server only"
-	},
 	"label.servers": {
 		"defaultMessage": "伺服器"
 	},
@@ -2531,9 +2237,6 @@
 	"modal.open-in-app.why-use": {
 		"defaultMessage": "為何使用 Modrinth App"
 	},
-	"multiselect.selection-actions.label": {
-		"defaultMessage": "已选 {count, number} 项"
-	},
 	"notification.error.title": {
 		"defaultMessage": "發生錯誤"
 	},
@@ -2620,9 +2323,6 @@
 	},
 	"omorphia.component.environment-indicator.label.unsupported": {
 		"defaultMessage": "不支援"
-	},
-	"omorphia.component.loading-indicator.label": {
-		"message": "Loading"
 	},
 	"payment-method.amazon_pay": {
 		"defaultMessage": "Amazon Pay"
@@ -2861,9 +2561,6 @@
 	"project.about.links.issues": {
 		"defaultMessage": "回報問題"
 	},
-	"project.about.links.mcmod": {
-		"defaultMessage": "MC Mod"
-	},
 	"project.about.links.site": {
 		"defaultMessage": "前往網站"
 	},
@@ -2926,12 +2623,6 @@
 	},
 	"project.recent-plays.tooltip": {
 		"defaultMessage": "過去 2 週內來自 Modrinth 的 {count} 次{countPlural, plural, other {最近遊玩次數}}"
-	},
-	"project.environment.tag.not-applicable": {
-		"defaultMessage": "不適用"
-	},
-	"project.environment.tag.unknown": {
-		"defaultMessage": "未知"
 	},
 	"project.server.customModpackTooltip": {
 		"defaultMessage": "這個專案使用了自訂模組包"
@@ -3254,44 +2945,14 @@
 	"project.versions.channel.release.symbol": {
 		"defaultMessage": "R"
 	},
-	"project.versions.filter.toggle-tooltip": {
-		"message": "Toggle filter for {filter}"
-	},
-	"project.versions.platform.modloader.short": {
-		"message": "ModLoader"
-	},
-	"project.versions.table.downloads": {
-		"defaultMessage": "下载量"
-	},
-	"project.versions.table.environment": {
-		"defaultMessage": "运行环境"
-	},
-	"project.versions.table.game-version": {
-		"defaultMessage": "游戏版本"
-	},
-	"project.versions.table.platform": {
-		"defaultMessage": "平台"
-	},
-	"project.versions.table.published": {
-		"defaultMessage": "发布时间"
-	},
-	"project.versions.table.version": {
-		"defaultMessage": "版本"
-	},
 	"project.versions.version.withheld": {
 		"defaultMessage": "保留"
 	},
 	"project.versions.version.withheld.tooltip": {
 		"defaultMessage": "版本由於缺少授權資訊而被保留"
 	},
-	"project.versions.filter.projectChannels": {
-		"defaultMessage": "更新通道"
-	},
 	"project.versions.withheld-versions-warning.resolve-button": {
 		"defaultMessage": "解決"
-	},
-	"project.versions.filter.gameVersions": {
-		"defaultMessage": "游戏版本"
 	},
 	"project.visibility.archived": {
 		"defaultMessage": "已封存"
@@ -3364,18 +3025,6 @@
 	},
 	"search.filter.option.show_more": {
 		"defaultMessage": "顯示更多內容"
-	},
-	"search.filter_type.advanced": {
-		"message": "Advanced"
-	},
-	"search.filter_type.advanced.exclude_datapack": {
-		"message": "Exclude data packs"
-	},
-	"search.filter_type.advanced.exclude_mod": {
-		"message": "Exclude mods"
-	},
-	"search.filter_type.advanced.exclude_plugin": {
-		"message": "Exclude plugins"
 	},
 	"search.filter_type.environment": {
 		"defaultMessage": "環境"
@@ -3568,9 +3217,6 @@
 	},
 	"settings.sessions.title": {
 		"defaultMessage": "工作階段"
-	},
-	"skin.preview.drag-to-rotate": {
-		"message": "Drag to rotate"
 	},
 	"tag.category.128x": {
 		"defaultMessage": "128x"
@@ -4196,11 +3842,14 @@
 	"version.supplementary-resources.type": {
 		"defaultMessage": "類型"
 	},
+	"files.row.parent-folder": {
+		"message": "Parent folder"
+	},
+	"omorphia.component.loading-indicator.label": {
+		"message": "Loading"
+	},
 	"drop.confirm.title": {
 		"message": "你想以什麼類型匯入？"
-	},
-	"drop.confirm.not-this": {
-		"message": "作為其他內容匯入"
 	},
 	"drop.confirm.cancel": {
 		"message": "取消"
@@ -4280,30 +3929,6 @@
 	"drop.generic_install.no_instances": {
 		"message": "找不到實例"
 	},
-	"app.drop.batch.scan.title": {
-		"message": "正在識別 {count, plural, one {# 個檔案} other {# 個檔案}}…"
-	},
-	"app.drop.batch.scan.subtitle": {
-		"message": "已識別 {done} / {total}"
-	},
-	"app.drop.batch.scan.cancel": {
-		"message": "取消"
-	},
-	"app.drop.batch.scan.pending": {
-		"message": "等待"
-	},
-	"app.drop.batch.scan.scanning": {
-		"message": "掃描中"
-	},
-	"app.drop.batch.scan.done": {
-		"message": "已識別"
-	},
-	"app.drop.batch.scan.skipped": {
-		"message": "已跳過"
-	},
-	"app.drop.batch.scan.error": {
-		"message": "失敗"
-	},
 	"drop.launcher_import.title": {
 		"message": "從 {launcherName} 匯入實例"
 	},
@@ -4355,11 +3980,398 @@
 	"drop.symlink_method.cancel": {
 		"message": "取消"
 	},
-	"drop.symlink_method.reset_changes": {
-		"message": "重置更改"
-	},
 	"drop.symlink_method.confirm": {
 		"message": "確認"
+	},
+	"project.versions.filter.toggle-tooltip": {
+		"message": "Toggle filter for {filter}"
+	},
+	"project.versions.platform.modloader.short": {
+		"message": "ModLoader"
+	},
+	"skin.preview.drag-to-rotate": {
+		"message": "Drag to rotate"
+	},
+	"browse.sort.relevance": {
+		"message": "Relevance"
+	},
+	"browse.sort.downloads": {
+		"message": "Downloads"
+	},
+	"browse.sort.followers": {
+		"message": "Followers"
+	},
+	"browse.sort.date-published": {
+		"message": "Date published"
+	},
+	"browse.sort.date-updated": {
+		"message": "Date updated"
+	},
+	"browse.sort.verified-plays": {
+		"message": "Verified plays"
+	},
+	"browse.sort.players": {
+		"message": "Players"
+	},
+	"content.card.pending-manual-download": {
+		"message": "Manual download required"
+	},
+	"content.card.rollback-tooltip": {
+		"defaultMessage": "回滾到 {fileName}"
+	},
+	"app.symlink-warning.write.header": {
+		"message": "Shared instance"
+	},
+	"app.symlink-warning.write.body": {
+		"message": "This instance is linked to "
+	},
+	"instances.updater-modal.search-compat": {
+		"message": "尋找相容版本"
+	},
+	"files.delete-modal.bulk-header": {
+		"message": "Delete multiple items"
+	},
+	"files.delete-modal.deleting-multiple": {
+		"message": "Deleting {count} items"
+	},
+	"files.delete-modal.bulk-warning": {
+		"message": "The selected items will be permanently deleted. This action cannot be undone."
+	},
+	"files.delete-modal.symlink-warning-header": {
+		"message": "Shared instance"
+	},
+	"files.delete-modal.symlink-warning-body": {
+		"message": "You are modifying files in a shared instance linked to "
+	},
+	"button.open-in-browser": {
+		"message": "Open in browser"
+	},
+	"label.server-only": {
+		"message": "Server only"
+	},
+	"button.switch-to-version": {
+		"message": "Switch to version"
+	},
+	"project-type.schematic.category": {
+		"message": "投影"
+	},
+	"project-type.schematic.capital": {
+		"message": "{count, plural, one {投影} other {投影}}"
+	},
+	"project-type.schematic.lowercase": {
+		"message": "{count, plural, one {投影} other {投影}}"
+	},
+	"search.filter_type.advanced.exclude_mod": {
+		"message": "Exclude mods"
+	},
+	"search.filter_type.advanced.exclude_plugin": {
+		"message": "Exclude plugins"
+	},
+	"search.filter_type.advanced.exclude_datapack": {
+		"message": "Exclude data packs"
+	},
+	"search.filter_type.advanced": {
+		"message": "Advanced"
+	},
+	"header.category.cf-extra": {
+		"message": "More CurseForge categories"
+	},
+	"project.environment.tag.not-applicable": {
+		"defaultMessage": "不適用"
+	},
+	"project.environment.tag.unknown": {
+		"defaultMessage": "未知"
+	},
+	"browse.selected-projects-floating-bar.hide-projects": {
+		"defaultMessage": "隐藏已选项目"
+	},
+	"browse.selected-projects-floating-bar.show-projects": {
+		"defaultMessage": "显示{count, plural, other {#个已选项目}}"
+	},
+	"console.notification.share-truncated": {
+		"defaultMessage": "日志过大，已自动截取最后 9MB 上传。"
+	},
+	"console.log.toggle-wrap": {
+		"defaultMessage": "切换换行"
+	},
+	"console.log.wrap-label": {
+		"defaultMessage": "换行"
+	},
+	"console.empty.instance-title": {
+		"defaultMessage": "暂无日志"
+	},
+	"console.empty.instance-description": {
+		"defaultMessage": "点击右上角「开始游戏」即可接收实时日志"
+	},
+	"console.empty.server-title": {
+		"defaultMessage": "欢迎使用 Modrinth 服务器！"
+	},
+	"console.empty.server-description": {
+		"defaultMessage": "点击启动按钮即可启动服务器！"
+	},
+	"content.card.dependency-badge": {
+		"defaultMessage": "前置"
+	},
+	"content.card.duplicate-mod": {
+		"defaultMessage": "此模组已安装 {count, number} 次。"
+	},
+	"content.card.group.hardcore": {
+		"defaultMessage": "硬核模式"
+	},
+	"content.card.group.not-played-yet": {
+		"defaultMessage": "尚未游玩"
+	},
+	"content.card.orphaned-dependency-badge": {
+		"defaultMessage": "孤立前置"
+	},
+	"content.filter.duplicates": {
+		"defaultMessage": "重复"
+	},
+	"content.metadata-filter.author": {
+		"defaultMessage": "作者"
+	},
+	"content.metadata-filter.clear": {
+		"defaultMessage": "清除"
+	},
+	"content.metadata-filter.environment": {
+		"defaultMessage": "环境"
+	},
+	"content.metadata-filter.environment.client": {
+		"defaultMessage": "客户端"
+	},
+	"content.metadata-filter.environment.client-and-server": {
+		"defaultMessage": "客户端和服务端"
+	},
+	"content.metadata-filter.environment.server": {
+		"defaultMessage": "服务端"
+	},
+	"content.metadata-filter.environment.singleplayer": {
+		"defaultMessage": "单人游戏"
+	},
+	"content.metadata-filter.external": {
+		"defaultMessage": "外部文件"
+	},
+	"content.metadata-filter.external.external": {
+		"defaultMessage": "外部文件"
+	},
+	"content.metadata-filter.external.linked": {
+		"defaultMessage": "在线项目"
+	},
+	"content.metadata-filter.loader": {
+		"defaultMessage": "加载器"
+	},
+	"content.metadata-filter.loader.fabric": {
+		"defaultMessage": "Fabric"
+	},
+	"content.metadata-filter.loader.forge": {
+		"defaultMessage": "Forge"
+	},
+	"content.metadata-filter.loader.neoforge": {
+		"defaultMessage": "NeoForge"
+	},
+	"content.metadata-filter.loader.other": {
+		"defaultMessage": "其他"
+	},
+	"content.metadata-filter.loader.quilt": {
+		"defaultMessage": "Quilt"
+	},
+	"content.metadata-filter.long-press-reset": {
+		"defaultMessage": "长按重置筛选"
+	},
+	"content.metadata-filter.open-source": {
+		"defaultMessage": "开源"
+	},
+	"content.metadata-filter.open-source.closed": {
+		"defaultMessage": "非开源"
+	},
+	"content.metadata-filter.open-source.open": {
+		"defaultMessage": "开源"
+	},
+	"content.metadata-filter.search": {
+		"defaultMessage": "搜索..."
+	},
+	"content.metadata-filter.select-all": {
+		"defaultMessage": "全选"
+	},
+	"content.metadata-filter.source": {
+		"defaultMessage": "来源"
+	},
+	"content.metadata-filter.source.curseforge": {
+		"defaultMessage": "CurseForge"
+	},
+	"content.metadata-filter.source.imported-modpack": {
+		"defaultMessage": "导入整合包"
+	},
+	"content.metadata-filter.source.local": {
+		"defaultMessage": "本地"
+	},
+	"content.metadata-filter.source.modrinth-modpack": {
+		"defaultMessage": "Modrinth 整合包"
+	},
+	"content.metadata-filter.source.server-project": {
+		"defaultMessage": "服务器项目"
+	},
+	"content.metadata-filter.source.shared-instance": {
+		"defaultMessage": "共享实例"
+	},
+	"content.metadata-filter.state": {
+		"defaultMessage": "状态"
+	},
+	"content.metadata-filter.state.disabled": {
+		"defaultMessage": "已禁用"
+	},
+	"content.metadata-filter.state.enabled": {
+		"defaultMessage": "已启用"
+	},
+	"content.metadata-filter.toggle": {
+		"defaultMessage": "筛选"
+	},
+	"content.metadata-filter.toggle-active": {
+		"defaultMessage": "筛选（已启用 {count, number} 项）"
+	},
+	"content.metadata-filter.unknown": {
+		"defaultMessage": "未知"
+	},
+	"content.metadata-filter.update.available": {
+		"defaultMessage": "可更新"
+	},
+	"content.metadata-filter.update.up-to-date": {
+		"defaultMessage": "已是最新"
+	},
+	"content.metadata-filter.updates": {
+		"defaultMessage": "更新"
+	},
+	"content.page-layout.sort.file-name-ascending": {
+		"defaultMessage": "文件名 A-Z"
+	},
+	"content.page-layout.sort.file-name-descending": {
+		"defaultMessage": "文件名 Z-A"
+	},
+	"content.page-layout.sort.project-name-ascending": {
+		"defaultMessage": "项目名称 A-Z"
+	},
+	"content.page-layout.sort.project-name-descending": {
+		"defaultMessage": "项目名称 Z-A"
+	},
+	"content.page-layout.pin-view": {
+		"defaultMessage": "固定当前视图"
+	},
+	"content.page-layout.reset-view": {
+		"defaultMessage": "重置视图"
+	},
+	"content.page-layout.unpin-view": {
+		"defaultMessage": "取消固定当前视图"
+	},
+	"content.page-layout.view-options": {
+		"defaultMessage": "视图选项"
+	},
+	"creation-flow.modal.custom-setup.adjunct.hint": {
+		"defaultMessage": "下载前会自动选择兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.checking-compatibility": {
+		"defaultMessage": "正在检查兼容性……"
+	},
+	"creation-flow.modal.custom-setup.adjunct.compatibility-load-failed": {
+		"defaultMessage": "无法验证 {loader} 的兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.label": {
+		"defaultMessage": "附加加载器"
+	},
+	"creation-flow.modal.custom-setup.adjunct.optifabric-load-failed": {
+		"defaultMessage": "无法验证 OptiFabric 兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.optifabric-unsupported": {
+		"defaultMessage": "OptiFine 需要 OptiFabric，但当前游戏版本没有兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.primary-unsupported": {
+		"defaultMessage": "所选主加载器不支持当前游戏版本。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.select-game-version": {
+		"defaultMessage": "请先选择游戏版本以检查兼容性。"
+	},
+	"creation-flow.modal.custom-setup.adjunct.unsupported": {
+		"defaultMessage": "{loader} 没有支持当前游戏版本的兼容版本。"
+	},
+	"creation-flow.modal.custom-setup.loader.compatibility-load-failed": {
+		"defaultMessage": "无法验证加载器兼容性"
+	},
+	"creation-flow.modal.import-instance.import-prompt": {
+		"defaultMessage": "拖拽启动器文件夹、整合包文件或 .minecraft 文件夹即可一键导入实例"
+	},
+	"creation-flow.modal.import-instance.select-file": {
+		"defaultMessage": "选择要导入的文件"
+	},
+	"files.editor.share-truncated-warning": {
+		"defaultMessage": "日志文件过大，已自动截取最后 9MB 上传。"
+	},
+	"files.navbar.share-log": {
+		"defaultMessage": "分享日志"
+	},
+	"installation-settings.loader-version.error": {
+		"defaultMessage": "加载加载器版本数据失败"
+	},
+	"installation-settings.loader-version.unsupported": {
+		"defaultMessage": "此加载器不支持所选游戏版本"
+	},
+	"multiselect.selection-actions.label": {
+		"defaultMessage": "已选 {count, number} 项"
+	},
+	"project.about.links.mcmod": {
+		"defaultMessage": "MC Mod"
+	},
+	"project.versions.table.downloads": {
+		"defaultMessage": "下载量"
+	},
+	"project.versions.table.environment": {
+		"defaultMessage": "运行环境"
+	},
+	"project.versions.table.game-version": {
+		"defaultMessage": "游戏版本"
+	},
+	"project.versions.table.platform": {
+		"defaultMessage": "平台"
+	},
+	"project.versions.table.published": {
+		"defaultMessage": "发布时间"
+	},
+	"project.versions.table.version": {
+		"defaultMessage": "版本"
+	},
+	"project.versions.filter.projectChannels": {
+		"defaultMessage": "更新通道"
+	},
+	"project.versions.filter.gameVersions": {
+		"defaultMessage": "游戏版本"
+	},
+	"drop.confirm.not-this": {
+		"message": "作為其他內容匯入"
+	},
+	"app.drop.batch.scan.title": {
+		"message": "正在識別 {count, plural, one {# 個檔案} other {# 個檔案}}…"
+	},
+	"app.drop.batch.scan.subtitle": {
+		"message": "已識別 {done} / {total}"
+	},
+	"app.drop.batch.scan.cancel": {
+		"message": "取消"
+	},
+	"app.drop.batch.scan.pending": {
+		"message": "等待"
+	},
+	"app.drop.batch.scan.scanning": {
+		"message": "掃描中"
+	},
+	"app.drop.batch.scan.done": {
+		"message": "已識別"
+	},
+	"app.drop.batch.scan.skipped": {
+		"message": "已跳過"
+	},
+	"app.drop.batch.scan.error": {
+		"message": "失敗"
+	},
+	"drop.symlink_method.reset_changes": {
+		"message": "重置更改"
 	},
 	"drop.symlink_method.next": {
 		"message": "下一步"
@@ -4471,18 +4483,6 @@
 	},
 	"drop.symlink_method.stats_network_tooltip": {
 		"message": "需要下載"
-	},
-	"instances.updater-modal.search-compat": {
-		"message": "尋找相容版本"
-	},
-	"project-type.schematic.category": {
-		"message": "投影"
-	},
-	"project-type.schematic.capital": {
-		"message": "{count, plural, one {投影} other {投影}}"
-	},
-	"project-type.schematic.lowercase": {
-		"message": "{count, plural, one {投影} other {投影}}"
 	},
 	"creation-flow.modal.import-instance.select-folder.description": {
 		"defaultMessage": "导入启动器文件夹或 .minecraft 文件夹"


### PR DESCRIPTION
zh-TW 一直缺了 1016 条（app-frontend）和 141 条（packages/ui），缺的条目运行时回退成英文，繁体界面大概三分之一是英文。

这次从 zh-CN 用 OpenCC（s2twp，带台湾用语：服务器->伺服器、设置->设定、缓存->快取）转换补齐。只新增缺失条目，已有繁体条目没动。

说明：
- 机器转换，个别术语可能不顺，建议合并前人工过一遍；或者拿去当 Crowdin 底稿能省不少活
- 纯 JSON 变更，无代码改动

## Sourcery 摘要

改進：
- 完善應用程式前端和 UI 套件中缺少的 zh-TW 翻譯，使用台灣特有的繁體中文術語，同時保留現有翻譯。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Complete the missing zh-TW translations across the app frontend and UI package using Taiwan-specific Traditional Chinese terminology while preserving existing translations.

</details>