### PR TITLE
fix(translation): 搜索描述翻译支持任意目标语言（跟随设置，不再锁定 zh-CN）

### DIFF
--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -396,7 +396,7 @@ async function fetchMirrorDescription(hit: TranslatableHit): Promise<string | nu
  *
  * @param hits      Search result hits that carry at least provider + ID and
  *                  description fields.
- * @param locale    Target locale; descriptions are translated into this locale.
+ * @param locale    Fallback target locale when no target language is configured.
  * @param force     - When true, skip the `auto_translate` setting check;
  *                  always translate.
  * @param useServer - If true, sends the description via the Rust backend;
@@ -409,11 +409,13 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 	useServer = false,
 ): Promise<T[]> {
 	if (hits.length === 0) return hits
+	let targetLanguage = locale
 	if (!_force) {
 		const settings = await getTranslationSettings()
 		if (!settings.auto_translate) return hits
+		targetLanguage = settings.target_language?.trim() || locale
 	}
-	if (!locale || locale === 'en-US') return hits
+	if (!targetLanguage || targetLanguage === 'en-US') return hits
 
 	if (useServer) {
 		const segments: TranslationSegment[] = hits.map((hit) => ({
@@ -422,7 +424,7 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 			format: 'html',
 		}))
 		const request: TranslationRequest = {
-			target_language: locale,
+			target_language: targetLanguage,
 			source_language: 'en',
 			segments,
 			context: {

--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 
 import {
+	createTranslationBatches,
 	translateInBatches as executeTranslationBatches,
 	type TranslationRequest,
 	type TranslationResponse,
@@ -395,7 +396,7 @@ async function fetchMirrorDescription(hit: TranslatableHit): Promise<string | nu
  *
  * @param hits      Search result hits that carry at least provider + ID and
  *                  description fields.
- * @param locale    Target locale — only `zh-CN` triggers translation.
+ * @param locale    Target locale; descriptions are translated into this locale.
  * @param force     - When true, skip the `auto_translate` setting check;
  *                  always translate.
  * @param useServer - If true, sends the description via the Rust backend;
@@ -412,22 +413,39 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 		const settings = await getTranslationSettings()
 		if (!settings.auto_translate) return hits
 	}
-	if (locale !== 'zh-CN') return hits
+	if (!locale || locale === 'en-US') return hits
 
 	if (useServer) {
-		const response = await translate({
-			target_language: 'zh-CN',
+		const segments: TranslationSegment[] = hits.map((hit) => ({
+			text: hit.description ?? hit.summary ?? '',
+			id: hit.project_id ?? hit.provider_project_id ?? '',
+			format: 'html',
+		}))
+		const request: TranslationRequest = {
+			target_language: locale,
 			source_language: 'en',
-			segments: hits.map((hit) => ({
-				text: hit.description ?? hit.summary ?? '',
-				id: hit.project_id ?? hit.provider_project_id ?? '',
-				format: 'html',
-			})),
+			segments,
 			context: {
 				title: hits[0]?.title ?? '',
 				description: hits[0]?.description ?? hits[0]?.summary ?? '',
 			},
-		})
+		}
+
+		// 等所有批次结束（含失败批次）再决定：保留成功批次，全部失败才抛错
+		const translated: TranslationResponse['segments'] = []
+		const results = await Promise.allSettled(
+			createTranslationBatches(request.segments).map((batch) =>
+				translateInBatches(
+					{ ...request, segments: batch },
+					(batchResponse) => translated.push(...batchResponse.segments),
+				),
+			),
+		)
+		if (translated.length === 0) {
+			const failed = results.find((result) => result.status === 'rejected')
+			throw failed ? failed.reason : new Error('搜索描述翻译失败')
+		}
+		const response: TranslationResponse = { segments: translated }
 
 		const translatedHits = hits.map((hit) => {
 			const segment = response.segments.find(


### PR DESCRIPTION
设置里开启 auto_translate 后,浏览/搜索页的描述翻译之前只在 UI 语言为 zh-CN 时生效:

- translateSearchDescriptions 里直接 `if (locale !== 'zh-CN') return hits`,目标语言也写死成 zh-CN

ui 语言切成 zh-TW(或其它语言)时,点翻译按钮不会有任何反应——不发请求、不报错,看起来就像按钮坏了。

改法(一个文件):
- 目标语言优先用「设置 -> 翻译」里的目标语言配置(空 = follow-app,跟随界面语言),与项目详情页 translateProject 的逻辑保持一致
- 只有目标语言为空或 en-US 时才跳过(英文内容翻成英文没意义)

验证:
- Google: 界面语言列表里 22 个语言代码逐一实测官方端点全部 200(含 zh-TW、ja-JP、ko-KR、es-419 等)
- DeepL: 语言码映射在 #355 已修(zh-TW -> ZH-HANT、ja-JP -> JA 等)
- AI: 目标语言在 prompt 里,无限制
- 标题的「中文名 (English)」双语改写走的是内置中文维基词典,保持 zh-CN 专用,未改动

只改 apps/app-frontend/src/helpers/translation.ts 一个文件。

## Sourcery 摘要

支持将搜索描述翻译为任何已配置的目标语言，并提升批量结果翻译时的容错能力。

错误修复：
- 为已配置的目标语言启用搜索和浏览描述翻译，不再仅限于 zh-CN。
- 允许服务器端搜索翻译在单个批次失败时保留成功的批次，仅当所有批次均失败时才报告错误。

增强功能：
- 遵循翻译设置中的目标语言，同时保留应用语言环境作为回退语言；仅当目标语言为空或为 en-US 时跳过翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support search description translation in any configured target language and improve resilience when translating batched results.

Bug Fixes:
- Enable search and browse description translation for configured target languages instead of limiting it to zh-CN.
- Allow server-side search translations to retain successful batches when individual batches fail, reporting an error only when all batches fail.

Enhancements:
- Honor the translation settings target language while preserving the app locale as the fallback and skip translation only for empty or en-US targets.

</details>