### PR TITLE
fix(translation): 搜索描述翻译支持任意目标语言（跟随设置，不再锁定 zh-CN）

### DIFF
--- a/apps/app-frontend/src/helpers/translation.ts
+++ b/apps/app-frontend/src/helpers/translation.ts
@@ -396,7 +396,7 @@ async function fetchMirrorDescription(hit: TranslatableHit): Promise<string | nu
  *
  * @param hits      Search result hits that carry at least provider + ID and
  *                  description fields.
- * @param locale    Target locale — only `zh-CN` triggers translation.
+ * @param locale    Fallback target locale when no target language is configured.
  * @param force     - When true, skip the `auto_translate` setting check;
  *                  always translate.
  * @param useServer - If true, sends the description via the Rust backend;
@@ -409,11 +409,15 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 	useServer = false,
 ): Promise<T[]> {
 	if (hits.length === 0) return hits
-	if (!_force) {
-		const settings = await getTranslationSettings()
-		if (!settings.auto_translate) return hits
+	let targetLanguage = locale
+	const settings = await getTranslationSettings()
+	if (!_force && !settings.auto_translate) return hits
+	targetLanguage = settings.target_language?.trim() || locale
+	if (!targetLanguage || targetLanguage === 'en-US') return hits
+	// mcimirror 镜像只缓存中文翻译,非中文目标改走服务端路径
+	if (!useServer && targetLanguage !== 'zh-CN' && targetLanguage !== 'zh') {
+		useServer = true
 	}
-	if (locale !== 'zh-CN') return hits
 
 	if (useServer) {
 		const segments: TranslationSegment[] = hits.map((hit) => ({
@@ -422,7 +426,7 @@ export async function translateSearchDescriptions<T extends TranslatableHit>(
 			format: 'html',
 		}))
 		const request: TranslationRequest = {
-			target_language: 'zh-CN',
+			target_language: targetLanguage,
 			source_language: 'en',
 			segments,
 			context: {


### PR DESCRIPTION
设置里开启 auto_translate 后,浏览/搜索页的描述翻译之前只在 UI 语言为 zh-CN 时生效:

- translateSearchDescriptions 里直接 `if (locale !== 'zh-CN') return hits`,目标语言也写死成 zh-CN

ui 语言切成 zh-TW(或其它语言)时,点翻译按钮不会有任何反应——不发请求、不报错,看起来就像按钮坏了。

改法(一个文件):
- 目标语言优先用「设置 -> 翻译」里的目标语言配置(空 = follow-app,跟随界面语言),与项目详情页 translateProject 的逻辑保持一致
- 只有目标语言为空或 en-US 时才跳过(英文内容翻成英文没意义)

验证:
- Google: 界面语言列表里 22 个语言代码逐一实测官方端点全部 200(含 zh-TW、ja-JP、ko-KR、es-419 等)
- DeepL: 语言码映射在 #355 已修(zh-TW -> ZH-HANT、ja-JP -> JA 等)
- AI: 目标语言在 prompt 里,无限制
- 标题的「中文名 (English)」双语改写走的是内置中文维基词典,保持 zh-CN 专用,未改动

只改 apps/app-frontend/src/helpers/translation.ts 一个文件。

## Sourcery 总结

启用搜索描述翻译，使其遵循配置的目标语言，同时保留现有的中文专属标题翻译行为。

错误修复：
- 允许搜索和浏览描述翻译适用于任何配置的目标语言，而不再仅限于 zh-CN。
- 当有效目标语言未设置或为 en-US 时，避免发起翻译请求。

增强功能：
- 使搜索描述翻译与配置的翻译目标保持一致；未设置目标语言时，回退到应用语言区域设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持为配置的目标语言翻译搜索描述，同时保留现有的仅翻译中文标题的行为。

错误修复：
- 允许搜索和浏览描述使用配置的目标语言进行翻译，不再限制为 zh-CN。
- 当有效目标语言未设置或为 en-US 时，跳过翻译请求。

增强功能：
- 使搜索描述翻译与翻译目标配置保持一致；未配置目标语言时回退到应用语言环境。
- 将非中文描述翻译通过服务支持的翻译路径处理，同时保留现有的中文镜像行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable search description translation for configured target languages while preserving the existing Chinese-only title translation behavior.

Bug Fixes:
- Allow search and browsing description translations to use the configured target language instead of restricting translation to zh-CN.
- Skip translation requests when the effective target language is unset or en-US.

Enhancements:
- Align search description translation with the translation target configuration, falling back to the application locale when no target is configured.
- Route non-Chinese description translations through the service-backed translation path while preserving existing Chinese mirror behavior.

</details>

</details>