### PR TITLE
fix(translation): 修复 DeepL 翻译完成后日志预览崩溃

### DIFF
--- a/packages/app-lib/src/api/translation.rs
+++ b/packages/app-lib/src/api/translation.rs
@@ -450,6 +450,13 @@ fn decode_basic_entities(value: &str) -> String {
         .replace("&amp;", "&")
 }
 
+/// Debug-log preview that never panics on multi-byte UTF-8 text (e.g. Chinese
+/// translations returned by DeepL): a byte-offset slice like `&text[..50]`
+/// panics when byte 50 lands inside a multi-byte character.
+fn truncate_preview(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
 fn provider_language(locale: &str, provider: TranslationProvider) -> String {
     let normalized = locale.replace('_', "-");
     match provider {
@@ -578,9 +585,10 @@ async fn deepl_translate(
         source = %source_language,
         target = %target_language,
         api_key_len = %api_key.len(),
-        api_key_prefix = %if api_key.len() > 4 { &api_key[..4] } else { "***" },
+        api_key_prefix =
+            %if api_key.len() > 4 { truncate_preview(api_key, 4) } else { "***".to_string() },
         text_len = %segment.text.len(),
-        text_preview = %if segment.text.len() > 50 { &segment.text[..50] } else { &segment.text },
+        text_preview = %truncate_preview(&segment.text, 50),
         "Preparing DeepL translation request"
     );
 
@@ -746,7 +754,7 @@ async fn deepl_translate(
 
     tracing::info!(
         translated_text_len = %translated.len(),
-        translated_preview = %if translated.len() > 50 { &translated[..50] } else { &translated },
+        translated_preview = %truncate_preview(translated, 50),
         "DeepL translation successful"
     );
 
@@ -1308,6 +1316,18 @@ mod tests {
             strip_json_fence("<think>reasoning</think>```json\n{\"a\":1}\n```"),
             "{\"a\":1}"
         );
+    }
+
+    #[test]
+    fn truncate_preview_never_panics_on_multibyte_text() {
+        // U+6E2C is 3 bytes in UTF-8, so byte 50 sits inside a character.
+        let text = "\u{6e2c}".repeat(60);
+        assert!(text.len() > 50);
+        assert!(!text.is_char_boundary(50));
+        let preview = truncate_preview(&text, 50);
+        assert_eq!(preview.chars().count(), 50);
+        assert_eq!(preview, text.chars().take(50).collect::<String>());
+        assert_eq!(truncate_preview("hello", 50), "hello");
     }
 
     #[test]


### PR DESCRIPTION
## 摘要

修复 #360：使用 DeepL 作为翻译源时，翻译完成后启动器闪退（Windows 事件日志为 `0xc0000409` fail-fast）。在 v1.8.12 / Windows 11 上可稳定复现：打开任意资源详情页，等翻译完成即崩溃，五次崩溃的异常偏移完全一致，指向同一个码位。

## 复现路径

1. 设置 → 翻译 → 选择 DeepL 并填入 API Key；
2. 发现页打开任意资源详情页（自动翻译或手动点击翻译）；
3. DeepL 返回 200 后、翻译写入页面之前，启动器直接退出。

launcher 日志每次都停在同一条「`DeepL response status (primary attempt) status=200`」之后——下一行日志「`DeepL translation successful`」永远不会打印。

## 根因

`packages/app-lib/src/api/translation.rs` 的 `deepl_translate` 中，三个日志字段按**字节偏移**取前缀/预览：

```rust
api_key_prefix = %if api_key.len() > 4 { &api_key[..4] } else { "***" },
text_preview = %if segment.text.len() > 50 { &segment.text[..50] } else { &segment.text },
translated_preview = %if translated.len() > 50 { &translated[..50] } else { &translated },
```

DeepL 返回的中文译文是 UTF-8 多字节文本（每个汉字 3 字节），经常超过 50 字节，而第 50 字节大概率落在某个汉字的中间。`&str` 在非 `char` 边界处切片会直接 panic（`byte index 50 is not a char boundary`）；release 构建为 `panic=abort`，整个进程立刻 fail-fast，正好对应事件日志中固定的异常码和偏移。`&segment.text[..50]` 与 `&api_key[..4]` 同理。

## 修复

- 新增 `truncate_preview()`：按 Unicode **字符数**截取日志预览，永不 panic；
- `api_key_prefix` / `text_preview` / `translated_preview` 三处日志字段改用该函数（`api_key` 保留短密钥 `***` 脱敏语义）；
- 新增回归测试 `truncate_preview_never_panics_on_multibyte_text`：构造第 50 字节落在多字节字符中间的最短输入（`\u{6e2c}` × 60），断言 `is_char_boundary(50) == false` 且函数仍正常返回 50 个字符。

## 验证

- 本地：`cargo fmt --all --check` 通过；
- 新增 unittest 覆盖多字节输入；
- 已处理 Sourcery 审阅意见（`api_key_prefix` 同源隐患一并修复）；
- `guardrails` / `desktop` 等 CI 检查见下方状态。

Closes #360
