### PR TITLE
fix(mod-metadata): 从 MANIFEST 实现版本解析 Forge 占位版本号

### DIFF
--- a/packages/app-lib/src/mod_metadata/manifest.rs
+++ b/packages/app-lib/src/mod_metadata/manifest.rs
@@ -35,6 +35,20 @@ pub fn read_jar_manifest(path: &Path) -> Option<JarManifest> {
     Some(parse_manifest(&content))
 }
 
+/// Read and parse `META-INF/MANIFEST.MF` from an already-opened ZIP archive.
+///
+/// Used by mod metadata extraction to resolve Gradle placeholders such as
+/// `${file.jarVersion}` in Forge `mods.toml` files.
+pub(crate) fn archive_manifest<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Option<JarManifest> {
+    let mut entry = archive.by_name("META-INF/MANIFEST.MF").ok()?;
+    let mut content = String::new();
+    entry.read_to_string(&mut content).ok()?;
+
+    Some(parse_manifest(&content))
+}
+
 /// Parse raw MANIFEST.MF text into a `JarManifest`.
 ///
 /// Handles continuation lines (lines starting with a space) and

--- a/packages/app-lib/src/mod_metadata/mod.rs
+++ b/packages/app-lib/src/mod_metadata/mod.rs
@@ -171,9 +171,11 @@ fn try_toml_path(
     archive: &mut zip::ZipArchive<std::io::Cursor<&[u8]>>,
     path: &str,
 ) -> Option<LocalModMetadata> {
-    let mut file = archive.by_name(path).ok()?;
     let mut content = String::new();
-    std::io::Read::read_to_string(&mut file, &mut content).ok()?;
+    {
+        let mut file = archive.by_name(path).ok()?;
+        std::io::Read::read_to_string(&mut file, &mut content).ok()?;
+    }
     let parsed: toml_mod::ModsToml = toml::from_str(&content).ok()?;
 
     // A mod jar may declare several [[mods]] entries (bundled mods); report
@@ -240,10 +242,16 @@ fn try_toml_path(
         })
         .unwrap_or_default();
 
+    // Forge `mods.toml` commonly stores the version as a Gradle placeholder
+    // (e.g. `${file.jarVersion}`) that the loader resolves at runtime from the
+    // JAR manifest's `Implementation-Version`. Resolve it here so the
+    // placeholder never surfaces as a version in the UI.
+    let version = resolve_toml_version(entry.version.clone(), archive);
+
     Some(LocalModMetadata {
         mod_id,
         name: entry.display_name,
-        version: entry.version,
+        version,
         authors,
         description: entry.description,
         url: entry.display_url,
@@ -308,4 +316,94 @@ fn extract_contact_url(contact: &Option<serde_json::Value>) -> Option<String> {
     }
     // Fallback: return the first string field found.
     obj.values().find_map(|v| v.as_str().map(String::from))
+}
+
+/// Resolve a Forge `mods.toml` version string.
+///
+/// Gradle builds often write an unresolved placeholder (e.g.
+/// `${file.jarVersion}`) which the loader substitutes from the JAR manifest at
+/// runtime; surface the real `Implementation-Version` from the manifest when
+/// present, falling back to the original value otherwise.
+fn resolve_toml_version(
+    version: Option<String>,
+    archive: &mut zip::ZipArchive<std::io::Cursor<&[u8]>>,
+) -> Option<String> {
+    let placeholder = version.clone()?;
+    if !placeholder.starts_with("${") {
+        return Some(placeholder);
+    }
+
+    Some(
+        manifest::archive_manifest(archive)
+            .and_then(|manifest| manifest.implementation_version)
+            .filter(|resolved| !resolved.trim().is_empty())
+            .unwrap_or(placeholder),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    fn build_jar(entries: &[(&str, &str)]) -> bytes::Bytes {
+        let mut buffer = std::io::Cursor::new(Vec::new());
+        {
+            let mut archive = zip::ZipWriter::new(&mut buffer);
+            let options = zip::write::FileOptions::<()>::default();
+            for (name, content) in entries {
+                archive.start_file(*name, options).expect("start zip entry");
+                archive
+                    .write_all(content.as_bytes())
+                    .expect("write zip entry");
+            }
+            archive.finish().expect("finish zip");
+        }
+        bytes::Bytes::from(buffer.into_inner())
+    }
+
+    #[test]
+    fn forge_placeholder_version_resolves_from_manifest() {
+        let jar = build_jar(&[
+            (
+                "META-INF/MANIFEST.MF",
+                "Manifest-Version: 1.0\nImplementation-Title: Example\nImplementation-Version: 1.2.3\n",
+            ),
+            (
+                "META-INF/mods.toml",
+                "modLoader = \"javafml\"\nloaderVersion = \"[4,)\"\n\n[[mods]]\nmodId = \"example\"\ndisplayName = \"Example\"\nversion = \"${file.jarVersion}\"\n",
+            ),
+        ]);
+
+        let meta = super::extract_mod_metadata(&jar).expect("mod metadata");
+        assert_eq!(meta.mod_id, "example");
+        assert_eq!(meta.version.as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn resolved_mods_toml_version_is_kept_as_is() {
+        let jar = build_jar(&[
+            (
+                "META-INF/MANIFEST.MF",
+                "Manifest-Version: 1.0\nImplementation-Version: 9.9.9\n",
+            ),
+            (
+                "META-INF/mods.toml",
+                "[[mods]]\nmodId = \"example\"\nversion = \"1.0.0\"\n",
+            ),
+        ]);
+
+        let meta = super::extract_mod_metadata(&jar).expect("mod metadata");
+        assert_eq!(meta.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn placeholder_version_without_manifest_attribute_is_kept() {
+        let jar = build_jar(&[(
+            "META-INF/mods.toml",
+            "[[mods]]\nmodId = \"example\"\nversion = \"${file.jarVersion}\"\n",
+        )]);
+
+        let meta = super::extract_mod_metadata(&jar).expect("mod metadata");
+        assert_eq!(meta.version.as_deref(), Some("${file.jarVersion}"));
+    }
 }


### PR DESCRIPTION
## 摘要

修复 #376：手动安装的 Forge 模组（`META-INF/mods.toml`）使用 Gradle 占位符 `${file.jarVersion}` 作为版本号时，实例内容界面会直接把 `${file.jarVersion}` 显示为版本号。

## 根因

Forge/Gradle 插件会把 `build.gradle` 中的 `version` 写入最终 JAR 的 `META-INF/MANIFEST.MF → Implementation-Version`，而 `mods.toml` 里的 `version = "${file.jarVersion}"` 只是由加载器在运行时替换的占位符。启动器解析 `mods.toml` 时直接返回了原始文本，没有展开。

## 修复

- `mod_metadata/manifest` 新增 `archive_manifest()`：从已打开的 ZIP 归档中读取 `MANIFEST.MF`（复用现有解析逻辑，支持续行与大小写不敏感属性）；
- `try_toml_path()` 解析 `mods.toml` 后，若版本文本以 `${` 开头，回退到同一 JAR 内 `Implementation-Version`；清单缺失或属性为空时保留原始占位符，不丢失版本信息；
- 新增三个回归测试：占位符从清单解析（`1.2.3`）、真实版本不被改动（`1.0.0`）、无清单属性时保留原值。

## 验证

- `cargo fmt --all --check` 本地通过（toolchain 1.95.0 + rustfmt，与 CI 一致）；
- 新增 3 个单元测试交由 CI 的 Rust 构建执行（本机缺少 MSVC/Windows SDK 无法本地编译）；
- 复现：实例内容界面查看手动安装的 Forge 模组即可。

Closes #376

## Sourcery 摘要

从 JAR 元数据中解析 Forge 模组版本占位符，以便实例视图在可用时显示实际版本。

Bug 修复：
- 从 JAR 清单的 `Implementation-Version` 中解析 `mods.toml` 里的 Forge Gradle 版本占位符；如果没有可用的清单版本，则保留原始值。

增强功能：
- 在提取模组元数据时，复用已打开归档的清单解析结果。

测试：
- 添加回归测试，覆盖基于清单的占位符解析、保留显式版本，以及在没有清单属性时保留占位符的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve Forge mod version placeholders from JAR metadata so instance views display the actual version when available.

Bug Fixes:
- Resolve Forge Gradle version placeholders in `mods.toml` from the JAR manifest’s `Implementation-Version`, while preserving the original value when no usable manifest version is available.

Enhancements:
- Reuse manifest parsing for already-opened archives during mod metadata extraction.

Tests:
- Add regression coverage for manifest-based placeholder resolution, preserving explicit versions, and retaining placeholders without a manifest attribute.

</details>