### PR TITLE
新增整合包一键开服功能

### DIFF
--- a/apps/app-frontend/src/components/multiplayer/servers/CreateServerModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/CreateServerModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { commonMessages, MultiStageModal } from '@modrinth/ui'
-import { computed, useTemplateRef, watch } from 'vue'
+import { commonMessages, defineMessages, MultiStageModal } from '@modrinth/ui'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
 import {
@@ -19,25 +19,72 @@ const eulaModal = useTemplateRef<ComponentExposed<typeof EulaModal>>('eulaModal'
 const ctx = createCreateServerFlowContext(modal)
 provideCreateServerFlow(ctx)
 
-const cancelButton = computed(() => ({
-	label: ctx.formatMessage(commonMessages.cancelButton),
-	disabled: ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
-	onClick: () => modal.value?.hide(),
-}))
+const messages = defineMessages({
+	downloadInBackground: {
+		id: 'app.servers.wizard.download-in-background',
+		defaultMessage: 'Download in background',
+	},
+})
+
+const wizardShown = ref(false)
+const wasHiddenDuringInstall = ref(false)
+const creationReported = ref(false)
+
+const cancelButton = computed(() => {
+	if (ctx.installPhase.value === 'done') {
+		return null
+	}
+	// The download continues in the background once the wizard closes; only the
+	// first-run boot locks closing until the server reaches its EULA gate.
+	return {
+		label: ctx.formatMessage(
+			ctx.installPhase.value === 'downloading'
+				? messages.downloadInBackground
+				: commonMessages.cancelButton,
+		),
+		disabled: ctx.installPhase.value === 'first-run',
+		onClick: () => modal.value?.hide(),
+	}
+})
 
 watch(ctx.showEulaModal, (visible) => {
-	if (visible) eulaModal.value?.show()
-	else eulaModal.value?.hide()
+	if (visible) {
+		// When the setup finished in the background, don't pop a EULA dialog over
+		// whatever page the user is on; starting the server gates on it instead.
+		if (wizardShown.value) eulaModal.value?.show()
+	} else {
+		eulaModal.value?.hide()
+	}
 })
 
 function show() {
+	wizardShown.value = true
+	wasHiddenDuringInstall.value = false
+	creationReported.value = false
 	ctx.reset()
 	modal.value?.setStage(0)
 	modal.value?.show()
 }
 
 function handleHide() {
-	if (ctx.createdServer.value) emit('created', ctx.createdServer.value.id)
+	const wasShown = wizardShown.value
+	wizardShown.value = false
+	// An explicit "Finish" (wizard still open at a terminal state) navigates to
+	// the new server. A background close (wizard dismissed mid-install) leaves
+	// the server in the list instead of yanking the user to another page.
+	if (
+		wasShown &&
+		!wasHiddenDuringInstall.value &&
+		ctx.createdServer.value &&
+		(ctx.installPhase.value === 'done' || ctx.installPhase.value === 'eula')
+	) {
+		if (!creationReported.value) {
+			creationReported.value = true
+			emit('created', ctx.createdServer.value.id)
+		}
+	} else {
+		wasHiddenDuringInstall.value = true
+	}
 }
 
 defineExpose({ show, hide: () => modal.value?.hide() })

--- a/apps/app-frontend/src/components/multiplayer/servers/CreateServerModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/CreateServerModal.vue
@@ -58,7 +58,7 @@ defineExpose({ show, hide: () => modal.value?.hide() })
 	<EulaModal
 		ref="eulaModal"
 		:text="ctx.eulaText.value"
-		@accept="ctx.acceptEula"
+		@continue="ctx.acceptEula"
 		@decline="ctx.declineEula"
 	/>
 </template>

--- a/apps/app-frontend/src/components/multiplayer/servers/EulaModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/EulaModal.vue
@@ -4,12 +4,8 @@ import { ButtonStyled, defineMessages, NewModal, useVIntl } from '@modrinth/ui'
 import { useTemplateRef } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
-const props = defineProps<{
-	text: string
-}>()
-
 const emit = defineEmits<{
-	accept: []
+	continue: []
 	decline: []
 }>()
 
@@ -19,11 +15,11 @@ const messages = defineMessages({
 	description: {
 		id: 'app.servers.eula.description',
 		defaultMessage:
-			'The server must accept the Minecraft End User License Agreement before it can start. Review the notice below:',
+			'By continuing, you agree to the Minecraft End User License Agreement (EULA). Please review the agreement below before proceeding.',
 	},
-	accept: {
-		id: 'app.servers.eula.accept',
-		defaultMessage: 'Accept and continue',
+	continue: {
+		id: 'app.servers.eula.continue',
+		defaultMessage: 'Continue',
 	},
 	decline: { id: 'app.servers.eula.decline', defaultMessage: 'Cancel' },
 })
@@ -42,10 +38,6 @@ defineExpose({
 			<p class="m-0 text-secondary">
 				{{ formatMessage(messages.description) }}
 			</p>
-			<pre
-				class="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-xl bg-surface-2 p-4 font-mono text-sm text-contrast"
-				>{{ props.text }}</pre
-			>
 		</div>
 		<template #actions>
 			<div class="flex flex-col justify-end gap-2 sm:flex-row">
@@ -56,9 +48,9 @@ defineExpose({
 					</button>
 				</ButtonStyled>
 				<ButtonStyled color="brand">
-					<button type="button" @click="emit('accept')">
+					<button type="button" @click="emit('continue')">
 						<CheckIcon />
-						{{ formatMessage(messages.accept) }}
+						{{ formatMessage(messages.continue) }}
 					</button>
 				</ButtonStyled>
 			</div>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerCard.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerCard.vue
@@ -8,8 +8,8 @@ import {
 	SERVER_STATUS_META,
 } from '@/components/multiplayer/servers/server-status'
 import ServerIcon from '@/components/multiplayer/servers/ServerIcon.vue'
-import { type ServerView } from '@/composables/useServers'
 import { serverSetupStatus } from '@/composables/useServerInstalls'
+import type { ServerView } from '@/composables/useServers'
 
 const props = defineProps<{
 	server: ServerView

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerCard.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { PlayIcon, StopCircleIcon } from '@modrinth/assets'
+import { DownloadIcon, PlayIcon, RefreshCwIcon, SpinnerIcon, StopCircleIcon } from '@modrinth/assets'
 import { ButtonStyled, defineMessages, TagItem, useVIntl } from '@modrinth/ui'
 import { computed } from 'vue'
 
@@ -8,7 +8,8 @@ import {
 	SERVER_STATUS_META,
 } from '@/components/multiplayer/servers/server-status'
 import ServerIcon from '@/components/multiplayer/servers/ServerIcon.vue'
-import type { ServerView } from '@/composables/useServers'
+import { type ServerView } from '@/composables/useServers'
+import { serverSetupStatus } from '@/composables/useServerInstalls'
 
 const props = defineProps<{
 	server: ServerView
@@ -18,16 +19,51 @@ const props = defineProps<{
 const emit = defineEmits<{
 	open: []
 	'start-stop': []
+	resume: []
 }>()
 
 const { formatMessage } = useVIntl()
 const messages = defineMessages({
 	start: { id: 'app.servers.action.start', defaultMessage: 'Start' },
 	stop: { id: 'app.servers.action.stop', defaultMessage: 'Stop' },
+	continueDownload: {
+		id: 'app.servers.action.continue-download',
+		defaultMessage: 'Continue download',
+	},
+	retryDownload: { id: 'app.servers.action.retry-download', defaultMessage: 'Retry download' },
+	downloading: { id: 'app.servers.status.downloading', defaultMessage: 'Downloading' },
+	downloadInterrupted: {
+		id: 'app.servers.status.download-interrupted',
+		defaultMessage: 'Download interrupted',
+	},
+	downloadFailed: { id: 'app.servers.status.download-failed', defaultMessage: 'Download failed' },
 })
 
 const statusMeta = computed(() => SERVER_STATUS_META[props.server.status])
-const showStatus = computed(() => isServerStatusVisible(props.server.status))
+
+const setupStatus = computed(() => serverSetupStatus(props.server))
+
+/** Setup states take precedence over the runtime status tag. */
+const displayTag = computed(() => {
+	switch (setupStatus.value) {
+		case 'installing':
+			return { label: messages.downloading, color: 'text-orange' }
+		case 'interrupted':
+			return { label: messages.downloadInterrupted, color: 'text-orange' }
+		case 'failed':
+			return { label: messages.downloadFailed, color: 'text-red' }
+		default:
+			return isServerStatusVisible(props.server.status)
+				? { label: statusMeta.value.label, color: statusMeta.value.color }
+				: null
+	}
+})
+
+const setupTooltip = computed(() => {
+	if (setupStatus.value === 'interrupted') return formatMessage(messages.continueDownload)
+	if (setupStatus.value === 'failed') return formatMessage(messages.retryDownload)
+	return formatMessage(messages.downloading)
+})
 </script>
 
 <template>
@@ -50,13 +86,50 @@ const showStatus = computed(() => isServerStatusVisible(props.server.status))
 				:server-id="server.id"
 				size="96px"
 			/>
-			<TagItem v-if="showStatus" class="absolute left-3 top-3">
-				<span :class="'font-semibold ' + statusMeta.color">
-					{{ formatMessage(statusMeta.label) }}
+			<TagItem v-if="displayTag" class="absolute left-3 top-3">
+				<span :class="'font-semibold ' + displayTag.color">
+					{{ formatMessage(displayTag.label) }}
 				</span>
 			</TagItem>
 			<div class="absolute bottom-1.5 right-1.5" @click.stop @keydown.stop>
-				<ButtonStyled v-if="server.status !== 'running'" color="brand" size="large" circular>
+				<div
+					v-if="setupStatus === 'installing'"
+					v-tooltip="setupTooltip"
+					class="flex size-10 items-center justify-center rounded-full border border-solid border-surface-5 bg-surface-3"
+				>
+					<SpinnerIcon class="size-5 animate-spin text-orange" />
+				</div>
+				<ButtonStyled
+					v-else-if="setupStatus === 'interrupted'"
+					v-tooltip="setupTooltip"
+					color="brand"
+					size="large"
+					circular
+				>
+					<button
+						type="button"
+						class="scale-75 opacity-0 transition-all group-hover:scale-100 group-hover:opacity-100 group-focus-within:scale-100 group-focus-within:opacity-100"
+						@click="emit('resume')"
+					>
+						<DownloadIcon />
+					</button>
+				</ButtonStyled>
+				<ButtonStyled
+					v-else-if="setupStatus === 'failed'"
+					v-tooltip="setupTooltip"
+					color="red"
+					size="large"
+					circular
+				>
+					<button
+						type="button"
+						class="scale-75 opacity-0 transition-all group-hover:scale-100 group-hover:opacity-100 group-focus-within:scale-100 group-focus-within:opacity-100"
+						@click="emit('resume')"
+					>
+						<RefreshCwIcon />
+					</button>
+				</ButtonStyled>
+				<ButtonStyled v-else-if="server.status !== 'running'" color="brand" size="large" circular>
 					<button
 						v-tooltip="formatMessage(messages.start)"
 						type="button"
@@ -106,7 +179,49 @@ const showStatus = computed(() => isServerStatusVisible(props.server.status))
 				class="transition-all group-hover:brightness-75"
 			/>
 			<div class="absolute inset-0 flex items-center justify-center" @click.stop @keydown.stop>
-				<ButtonStyled v-if="server.status !== 'running'" color="brand" size="large" circular>
+				<div
+					v-if="setupStatus === 'installing'"
+					v-tooltip="setupTooltip"
+					class="flex size-9 origin-bottom scale-75 items-center justify-center rounded-full border border-solid border-surface-5 bg-surface-3 opacity-0 transition-all group-hover:scale-100 group-hover:opacity-100 group-focus-within:scale-100 group-focus-within:opacity-100"
+				>
+					<SpinnerIcon class="size-4 animate-spin text-orange" />
+				</div>
+				<ButtonStyled
+					v-else-if="setupStatus === 'interrupted'"
+					v-tooltip="setupTooltip"
+					color="brand"
+					size="large"
+					circular
+				>
+					<button
+						type="button"
+						class="origin-bottom scale-75 opacity-0 transition-all group-hover:scale-100 group-hover:opacity-100 group-focus-within:scale-100 group-focus-within:opacity-100"
+						@click="emit('resume')"
+					>
+						<DownloadIcon />
+					</button>
+				</ButtonStyled>
+				<ButtonStyled
+					v-else-if="setupStatus === 'failed'"
+					v-tooltip="setupTooltip"
+					color="red"
+					size="large"
+					circular
+				>
+					<button
+						type="button"
+						class="origin-bottom scale-75 opacity-0 transition-all group-hover:scale-100 group-hover:opacity-100 group-focus-within:scale-100 group-focus-within:opacity-100"
+						@click="emit('resume')"
+					>
+						<RefreshCwIcon />
+					</button>
+				</ButtonStyled>
+				<ButtonStyled
+					v-else-if="server.status !== 'running'"
+					color="brand"
+					size="large"
+					circular
+				>
 					<button
 						v-tooltip="formatMessage(messages.start)"
 						type="button"
@@ -133,9 +248,9 @@ const showStatus = computed(() => isServerStatusVisible(props.server.status))
 				<p class="m-0 min-w-0 truncate text-base font-bold leading-tight text-contrast">
 					{{ server.name }}
 				</p>
-				<TagItem v-if="showStatus" class="shrink-0">
-					<span :class="'font-semibold ' + statusMeta.color">
-						{{ formatMessage(statusMeta.label) }}
+				<TagItem v-if="displayTag" class="shrink-0">
+					<span :class="'font-semibold ' + displayTag.color">
+						{{ formatMessage(displayTag.label) }}
 					</span>
 				</TagItem>
 			</div>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
@@ -33,11 +33,15 @@ const loading = ref(true)
 const hasLogs = computed(() => consoleState.output.value.length > 0)
 let consumedLines = 0
 
-onMounted(async () => {
+async function hydrateAndDisplay() {
 	await hydrateLog(props.server.id)
 	const buffer = logLines[props.server.id] ?? []
 	if (buffer.length > 0) await consoleState.addLegacyLog(buffer.join('\n'))
 	consumedLines = buffer.length
+}
+
+onMounted(async () => {
+	await hydrateAndDisplay()
 	loading.value = false
 })
 
@@ -71,11 +75,12 @@ async function handleSendCommand(command: string) {
 const consoleLayout = ref<InstanceType<typeof ConsolePageLayout> | null>(null)
 watch(
 	() => props.server.running,
-	(running, previousRunning) => {
+	async (running, previousRunning) => {
 		if (!running || previousRunning) return
 		consoleState.clear()
 		consumedLines = 0
 		logLines[props.server.id] = []
+		await hydrateAndDisplay()
 		consoleLayout.value?.scrollToBottom()
 	},
 )

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
@@ -30,6 +30,7 @@ const messages = defineMessages({
 const { logLines, sendCommand } = useServers()
 const consoleState = createConsoleState()
 const loading = ref(true)
+const hasLogs = computed(() => consoleState.output.value.length > 0)
 let consumedLines = 0
 
 onMounted(async () => {
@@ -63,6 +64,22 @@ async function handleSendCommand(command: string) {
 	if (sent) void consoleState.addLegacyLog(formatMessage(messages.commandEcho, { command }))
 }
 
+// Starting a server always resets the console to a clean slate and resumes
+// bottom-following. The logLines replacement in startServer usually triggers
+// the length watcher above, but resetting here too makes the refresh
+// deterministic instead of relying on that indirect detection.
+const consoleLayout = ref<InstanceType<typeof ConsolePageLayout> | null>(null)
+watch(
+	() => props.server.running,
+	(running, previousRunning) => {
+		if (!running || previousRunning) return
+		consoleState.clear()
+		consumedLines = 0
+		logLines[props.server.id] = []
+		consoleLayout.value?.scrollToBottom()
+	},
+)
+
 provideConsoleManager({
 	logLines: consoleState.output,
 	sendCommand: (command: string) => void handleSendCommand(command),
@@ -83,7 +100,11 @@ provideConsoleManager({
 </script>
 
 <template>
-	<div data-onboarding-id="server-console" class="flex h-full min-h-0 flex-col">
-		<ConsolePageLayout />
+	<div
+		data-onboarding-id="server-console"
+		class="flex flex-col pb-3"
+		:class="hasLogs ? 'h-[calc(100dvh-80px)] shrink-0' : 'h-full min-h-[240px]'"
+	>
+		<ConsolePageLayout ref="consoleLayout" />
 	</div>
 </template>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
@@ -473,7 +473,7 @@ async function shareOnline() {
 				<ServerSettingsPanel :server="server" @deleted="router.push('/multiplayer/servers')" />
 			</div>
 
-			<EulaModal ref="eulaModal" :text="eulaText" @accept="acceptEula" @decline="declineEula" />
+			<EulaModal ref="eulaModal" :text="eulaText" @continue="acceptEula" @decline="declineEula" />
 		</template>
 	</div>
 </template>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
 	ArrowLeftIcon,
+	DownloadIcon,
 	FolderOpenIcon,
 	GlobeIcon,
 	LoaderCircleIcon,
@@ -39,6 +40,7 @@ import ServerSettingsPanel from '@/components/multiplayer/servers/ServerSettings
 import { useMultiplayerSession } from '@/composables/useMultiplayerSession'
 import { useServerLifecycle } from '@/composables/useServerLifecycle'
 import { useServers } from '@/composables/useServers'
+import { serverSetupStatus } from '@/composables/useServerInstalls'
 import { type PortProcessInfoData, servers as serversApi } from '@/helpers/servers'
 import { openPath } from '@/helpers/utils'
 
@@ -47,7 +49,8 @@ const router = useRouter()
 const serverId = route.params.id as string
 
 const { servers, refresh, stopServer } = useServers()
-const { eulaModal, eulaText, tryStartServer, acceptEula, declineEula } = useServerLifecycle()
+const { eulaModal, eulaText, tryStartServer, acceptEula, declineEula, resumeInstall } =
+	useServerLifecycle()
 const filePicker = injectFilePicker()
 const multiplayerSession = useMultiplayerSession()
 const { formatMessage } = useVIntl()
@@ -59,6 +62,17 @@ const messages = defineMessages({
 	back: { id: 'app.servers.detail.back', defaultMessage: 'Servers' },
 	start: { id: 'app.servers.action.start', defaultMessage: 'Start' },
 	stop: { id: 'app.servers.action.stop', defaultMessage: 'Stop' },
+	continueDownload: {
+		id: 'app.servers.action.continue-download',
+		defaultMessage: 'Continue download',
+	},
+	retryDownload: { id: 'app.servers.action.retry-download', defaultMessage: 'Retry download' },
+	downloading: { id: 'app.servers.status.downloading', defaultMessage: 'Downloading' },
+	downloadInterrupted: {
+		id: 'app.servers.status.download-interrupted',
+		defaultMessage: 'Download interrupted',
+	},
+	downloadFailed: { id: 'app.servers.status.download-failed', defaultMessage: 'Download failed' },
 	openFolder: { id: 'app.servers.action.open-folder', defaultMessage: 'Open folder' },
 	share: { id: 'app.servers.action.share', defaultMessage: 'Share online' },
 	notFound: {
@@ -108,6 +122,24 @@ const statusMeta = computed(() => (server.value ? SERVER_STATUS_META[server.valu
 const showStatus = computed(() =>
 	server.value ? isServerStatusVisible(server.value.status) : false,
 )
+
+const setupStatus = computed(() => (server.value ? serverSetupStatus(server.value) : null))
+
+/** Setup states take precedence over the runtime status tag. */
+const displayTag = computed(() => {
+	switch (setupStatus.value) {
+		case 'installing':
+			return { label: messages.downloading, color: 'text-orange' }
+		case 'interrupted':
+			return { label: messages.downloadInterrupted, color: 'text-orange' }
+		case 'failed':
+			return { label: messages.downloadFailed, color: 'text-red' }
+		default:
+			return showStatus.value && statusMeta.value
+				? { label: statusMeta.value.label, color: statusMeta.value.color }
+				: null
+	}
+})
 
 const isLoaded = ref(false)
 const hasSeenServer = ref(false)
@@ -312,9 +344,9 @@ async function shareOnline() {
 							<h2 class="m-0 truncate text-xl font-semibold text-contrast">
 								{{ server.name }}
 							</h2>
-							<TagItem v-if="showStatus && statusMeta" class="shrink-0">
-								<span :class="`font-semibold ${statusMeta.color}`">
-									{{ formatMessage(statusMeta.label) }}
+							<TagItem v-if="displayTag" class="shrink-0">
+								<span :class="`font-semibold ${displayTag.color}`">
+									{{ formatMessage(displayTag.label) }}
 								</span>
 							</TagItem>
 						</div>
@@ -335,16 +367,34 @@ async function shareOnline() {
 				</div>
 
 				<div class="flex flex-wrap gap-2">
-					<ButtonStyled v-if="server.status !== 'running' && !portConflict" color="brand">
-						<button type="button" @click="toggleRunning">
-							<PlayIcon />
-							{{ formatMessage(messages.start) }}
-						</button>
-					</ButtonStyled>
-					<ButtonStyled v-else-if="server.status === 'running'" color="red" type="outlined">
+					<ButtonStyled v-if="server.status === 'running'" color="red" type="outlined">
 						<button type="button" @click="toggleRunning">
 							<StopCircleIcon />
 							{{ formatMessage(messages.stop) }}
+						</button>
+					</ButtonStyled>
+					<ButtonStyled v-else-if="setupStatus === 'installing'" type="outlined">
+						<button type="button" disabled>
+							<LoaderCircleIcon class="animate-spin" />
+							{{ formatMessage(messages.downloading) }}
+						</button>
+					</ButtonStyled>
+					<ButtonStyled v-else-if="setupStatus === 'interrupted'" color="brand">
+						<button type="button" @click="resumeInstall(server)">
+							<DownloadIcon />
+							{{ formatMessage(messages.continueDownload) }}
+						</button>
+					</ButtonStyled>
+					<ButtonStyled v-else-if="setupStatus === 'failed'" color="brand">
+						<button type="button" @click="resumeInstall(server)">
+							<RefreshCwIcon />
+							{{ formatMessage(messages.retryDownload) }}
+						</button>
+					</ButtonStyled>
+					<ButtonStyled v-else-if="!portConflict" color="brand">
+						<button type="button" @click="toggleRunning">
+							<PlayIcon />
+							{{ formatMessage(messages.start) }}
 						</button>
 					</ButtonStyled>
 					<ButtonStyled v-if="server.status === 'running' && server.port" type="outlined">
@@ -396,6 +446,14 @@ async function shareOnline() {
 						</ButtonStyled>
 					</div>
 				</template>
+			</Admonition>
+
+			<Admonition
+				v-if="setupStatus === 'failed' && server.installError"
+				type="warning"
+				:header="formatMessage(messages.downloadFailed)"
+			>
+				{{ server.installError }}
 			</Admonition>
 
 			<NavTabs

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
@@ -38,9 +38,9 @@ import ServerFilesPanel from '@/components/multiplayer/servers/ServerFilesPanel.
 import ServerIcon from '@/components/multiplayer/servers/ServerIcon.vue'
 import ServerSettingsPanel from '@/components/multiplayer/servers/ServerSettingsPanel.vue'
 import { useMultiplayerSession } from '@/composables/useMultiplayerSession'
+import { serverSetupStatus } from '@/composables/useServerInstalls'
 import { useServerLifecycle } from '@/composables/useServerLifecycle'
 import { useServers } from '@/composables/useServers'
-import { serverSetupStatus } from '@/composables/useServerInstalls'
 import { type PortProcessInfoData, servers as serversApi } from '@/helpers/servers'
 import { openPath } from '@/helpers/utils'
 

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerDetail.vue
@@ -293,7 +293,7 @@ async function shareOnline() {
 </script>
 
 <template>
-	<div class="multiplayer-fixed-render flex min-h-0 w-full flex-1 flex-col gap-3">
+	<div class="multiplayer-fixed-render flex h-full min-h-0 w-full flex-col gap-3">
 		<div v-if="!server && isLoaded && !hasSeenServer" class="text-secondary">
 			{{ formatMessage(messages.notFound) }}
 		</div>
@@ -463,7 +463,7 @@ async function shareOnline() {
 				@tab-click="tabIndex = $event"
 			/>
 
-			<div v-if="tabIndex === 0" class="max-h-[calc(100dvh-var(--top-bar-height))] min-h-0 flex-1">
+			<div v-if="tabIndex === 0" class="min-h-0 flex-1">
 				<ServerConsole :server="server" />
 			</div>
 			<div v-else-if="tabIndex === 1" class="min-h-0 flex-1 overflow-y-auto pr-1">
@@ -480,17 +480,26 @@ async function shareOnline() {
 
 <style>
 /*
- * fixed 渲染模式（服务器详情页）：页面自身不滚动，控制台/设置区内部滚动，
- * 命令输入框始终停留在可视区域内。
- * 显式把 page-transition-grid 定高（100%），让整条 h-full 百分比高度链有确定参照，
- * 避免网格行高被日志内容撑开导致终端无限增高。
- * 只去掉 .app-viewport 的 scrollbar-gutter（避免多余的空滚动条轨道），
- * 保留 overflow: auto 作为兜底——内容万一超出视口仍可滚动，不会被裁切。
+ * fixed 渲染模式（服务器详情页）：控制台/设置区内部滚动。
+ * page-transition-grid 与 page-transition-layer 显式定高（100%）且允许
+ * 收缩（min-height: 0）。grid 必须显式声明 minmax(0, 1fr) 行——隐式 auto 行
+ * 以内容自适应，行高不 definite 时 layer 的百分比高度会退化为 auto，
+ * 整条 h-full 链随之失效，日志一多终端就会把页面撑出视口。
+ * app-viewport 保留 overflow: auto 作为兜底：控制台区块在有日志时固定为
+ * calc(100dvh - 80px)，高于可视剩余空间，页面需要可以滚动露出命令输入框；
+ * scrollbar-gutter: auto 避免滚动条出现/消失时布局跳动。
  */
-.app-viewport:has(.multiplayer-fixed-render) .page-transition-grid {
-	height: 100%;
-}
 .app-viewport:has(.multiplayer-fixed-render) {
 	scrollbar-gutter: auto;
+}
+
+.app-viewport:has(.multiplayer-fixed-render) .page-transition-grid,
+.app-viewport:has(.multiplayer-fixed-render) .page-transition-layer {
+	height: 100%;
+	min-height: 0;
+}
+
+.app-viewport:has(.multiplayer-fixed-render) .page-transition-grid {
+	grid-template-rows: minmax(0, 1fr);
 }
 </style>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
@@ -63,7 +63,10 @@ onMounted(() => {
 	void refresh()
 })
 
-function openServer(id: string) {
+async function openServer(id: string) {
+	// Refresh first so the freshly created server is present in the shared store
+	// before ServerDetail mounts; otherwise it briefly shows "server not found".
+	await refresh().catch(() => {})
 	void router.push('/multiplayer/servers/' + encodeURIComponent(id))
 }
 
@@ -171,7 +174,7 @@ async function toggleRunning(server: ServerView) {
 			/>
 		</div>
 
-		<CreateServerModal ref="createModal" />
+		<CreateServerModal ref="createModal" @created="openServer" />
 		<EulaModal ref="eulaModal" :text="eulaText" @continue="acceptEula" @decline="declineEula" />
 	</div>
 </template>

--- a/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
@@ -25,7 +25,8 @@ import {
 const router = useRouter()
 const { formatMessage } = useVIntl()
 const { servers, isRefreshing, refresh, stopServer } = useServers()
-const { eulaModal, eulaText, tryStartServer, acceptEula, declineEula } = useServerLifecycle()
+const { eulaModal, eulaText, tryStartServer, acceptEula, declineEula, resumeInstall } =
+	useServerLifecycle()
 const createModal = useTemplateRef<ComponentExposed<typeof CreateServerModal>>('createModal')
 
 const messages = defineMessages({
@@ -166,6 +167,7 @@ async function toggleRunning(server: ServerView) {
 				:variant="displayMode === 'cards' ? 'library' : 'standard'"
 				@open="openServer(entry.id)"
 				@start-stop="toggleRunning(entry)"
+				@resume="resumeInstall(entry)"
 			/>
 		</div>
 

--- a/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServersOverview.vue
@@ -172,7 +172,7 @@ async function toggleRunning(server: ServerView) {
 		</div>
 
 		<CreateServerModal ref="createModal" />
-		<EulaModal ref="eulaModal" :text="eulaText" @accept="acceptEula" @decline="declineEula" />
+		<EulaModal ref="eulaModal" :text="eulaText" @continue="acceptEula" @decline="declineEula" />
 	</div>
 </template>
 

--- a/apps/app-frontend/src/components/multiplayer/servers/create-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/create-server-flow.ts
@@ -59,9 +59,9 @@ export interface LoaderVersionOption {
 	stable: boolean
 }
 
-export interface CreateServerFlowContext {
+export interface CreateServerFlowContext<TCtx extends CreateServerFlowContext<TCtx>> {
 	modal: Ref<ComponentExposed<typeof MultiStageModal> | null>
-	stageConfigs: StageConfigInput<CreateServerFlowContext>[]
+	stageConfigs: StageConfigInput<TCtx>[]
 	formatMessage: ReturnType<typeof useVIntl>['formatMessage']
 
 	serverType: Ref<ServerTypeId>
@@ -103,8 +103,11 @@ export interface CreateServerFlowContext {
 	reset: () => void
 }
 
+/** Concrete context used by the vanilla (non-modpack) server creation flow. */
+export type CreateServerFlowContextValue = CreateServerFlowContext<CreateServerFlowContextValue>
+
 export const [injectCreateServerFlow, provideCreateServerFlow] =
-	createContext<CreateServerFlowContext>('CreateServerFlow')
+	createContext<CreateServerFlowContextValue>('CreateServerFlow')
 
 interface VanillaVersionEntry {
 	id: string
@@ -186,7 +189,7 @@ function javaMajorFromVersion(version: string): number | null {
 
 export function createCreateServerFlowContext(
 	modal: Ref<ComponentExposed<typeof MultiStageModal> | null>,
-): CreateServerFlowContext {
+): CreateServerFlowContextValue {
 	const { formatMessage } = useVIntl()
 
 	const wizardMessages = defineMessages({
@@ -482,7 +485,7 @@ export function createCreateServerFlowContext(
 			(!needsLoaderVersion.value || selectedLoaderVersion.value !== ''),
 	)
 
-	const stageConfigs: StageConfigInput<CreateServerFlowContext>[] = [
+	const stageConfigs: StageConfigInput<CreateServerFlowContextValue>[] = [
 		{
 			id: 'type',
 			stageContent: markRaw(TypeStage),

--- a/apps/app-frontend/src/components/multiplayer/servers/create-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/create-server-flow.ts
@@ -25,17 +25,17 @@ import { type as osType } from '@tauri-apps/plugin-os'
 import { computed, markRaw, type Ref, ref } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
+import { createServerDownloadBridge } from '@/composables/server-download-bridge'
 import { refresh as refreshServerList } from '@/composables/useServers'
 import { find_filtered_jres, get_java_default_versions, get_max_memory } from '@/helpers/jre'
 import { get_game_versions, get_loader_versions } from '@/helpers/metadata'
 import {
 	serverEventListener,
-	type ServerEventPayload,
 	type ServerManifestData,
 	servers,
 } from '@/helpers/servers'
+import { injectDownloadManager } from '@/providers/download-manager'
 
-import ConfigureStage from './stages/ConfigureStage.vue'
 import InstallStage from './stages/InstallStage.vue'
 import SetupStage from './stages/SetupStage.vue'
 import TypeStage from './stages/TypeStage.vue'
@@ -160,23 +160,6 @@ function toErrorMessage(error: unknown): string {
 	}
 }
 
-async function waitForServerStop(serverId: string): Promise<ServerEventPayload | null> {
-	return new Promise((resolve) => {
-		void serverEventListener((eventServerId, payload) => {
-			if (eventServerId !== serverId || payload.event !== 'stopped') return
-			resolve(payload)
-		}).then((unlisten) => {
-			setTimeout(
-				() => {
-					unlisten()
-					resolve(null)
-				},
-				10 * 60 * 1000,
-			)
-		})
-	})
-}
-
 function javaMajorFromVersion(version: string): number | null {
 	const parts = version
 		.split(/[._]/)
@@ -191,6 +174,18 @@ export function createCreateServerFlowContext(
 	modal: Ref<ComponentExposed<typeof MultiStageModal> | null>,
 ): CreateServerFlowContextValue {
 	const { formatMessage } = useVIntl()
+
+	// [SERVER-DOWNLOAD-BRIDGE] Capture the download manager once during Vue
+	// setup context.  Vue's inject() only works in the synchronous setup
+	// scope — after any `await` the injection context is lost.  We store the
+	// reference here and pass it explicitly to the shared download bridge so
+	// the vanilla server download appears in the sidebar like the modpack flow.
+	let downloadManager: ReturnType<typeof injectDownloadManager> | null = null
+	try {
+		downloadManager = injectDownloadManager()
+	} catch {
+		// Not inside a provider tree — server downloads will not appear in sidebar.
+	}
 
 	const wizardMessages = defineMessages({
 		typeStageTitle: { id: 'app.servers.wizard.type-title', defaultMessage: 'Server type' },
@@ -318,6 +313,10 @@ export function createCreateServerFlowContext(
 		installError.value = null
 		installLog.value = []
 		downloadProgress.value = null
+		// A cancelled/retried install leaves its download promise running in the
+		// background; reopening the wizard starts a fresh call. The bridge is
+		// captured per-call and closed out in the surrounding try/finally.
+		let activeBridge: ReturnType<typeof createServerDownloadBridge> | null = null
 		try {
 			const requiredJava = requiredJavaMajorVersion(selectedGameVersion.value)
 			const selectedMajor = javaMajorFromVersion(selectedJava.value.version)
@@ -387,43 +386,45 @@ export function createCreateServerFlowContext(
 			}
 
 			installPhase.value = 'downloading'
+			// [SERVER-DOWNLOAD-BRIDGE] Mirror this server download in the sidebar
+			// so it behaves like the modpack flow: the user can close the wizard
+			// and the job keeps running (and is cancellable) from Downloads.
+			const syntheticJobId = `server-${manifest.id}`
+			activeBridge = downloadManager
+				? createServerDownloadBridge(downloadManager, syntheticJobId, {
+						title: name.value,
+						icon: null,
+						provider: 'minecraft',
+					})
+				: null
+			activeBridge?.cancel(async () => {
+				await servers.stop(manifest.id).catch(() => {})
+			})
 			const unlistenProgress = await serverEventListener((serverId, payload) => {
 				if (serverId !== manifest.id || payload.event !== 'download_progress') return
 				downloadProgress.value = {
 					downloaded: payload.downloaded,
 					total: payload.total ?? null,
 				}
+				activeBridge?.update(downloadProgress.value, null, null)
 			})
 			try {
 				await servers.downloadFile(manifest.id, url, filename, sha1)
+				activeBridge?.complete(true, downloadProgress.value ?? undefined)
 			} finally {
 				unlistenProgress()
 			}
 
-			installPhase.value = 'first-run'
-			const unlistenLogs = await serverEventListener((serverId, payload) => {
-				if (serverId !== manifest.id || payload.event !== 'log') return
-				installLog.value.push(payload.line)
-				if (installLog.value.length > 500) installLog.value.splice(0, installLog.value.length - 500)
-			})
-			try {
-				await servers.start(manifest.id)
-				await waitForServerStop(manifest.id)
-			} finally {
-				unlistenLogs()
-			}
-
-			const eula = await servers.readFile(manifest.id, 'eula.txt').catch(() => null)
-			if (eula !== null && !eula.includes('eula=true')) {
-				eulaText.value = eula
-				showEulaModal.value = true
-				installPhase.value = 'eula'
-				return
-			}
+			// [SERVER-EULA] Like the modpack flow, the server is not auto-started.
+			// A code-created `eula.txt` (eula=false) is written so the manual start
+			// gate (useServerLifecycle) can offer the EULA without booting the jar.
+			const eula = setEulaAccepted('', false)
+			await servers.writeFile(manifest.id, 'eula.txt', eula).catch(() => {})
 			installPhase.value = 'done'
 		} catch (error) {
 			installPhase.value = 'error'
 			installError.value = toErrorMessage(error)
+			activeBridge?.complete(false, downloadProgress.value ?? undefined)
 			// A half-installed server must not linger in the list; retrying starts over.
 			if (createdServer.value) {
 				const failed = createdServer.value
@@ -520,12 +521,13 @@ export function createCreateServerFlowContext(
 			stageContent: markRaw(InstallStage),
 			title: (ctx) => ctx.formatMessage(wizardMessages.installStageTitle),
 			cannotNavigateForward: (ctx) => ctx.installPhase.value !== 'done',
-			disableClose: (ctx) =>
-				ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
+			// Downloads continue in the background once the wizard closes; only
+			// the first-run boot locks closing until the server reaches its EULA gate.
+			disableClose: (ctx) => ctx.installPhase.value === 'first-run',
 			leftButtonConfig: () => null,
 			rightButtonConfig: (ctx) => ({
 				label: ctx.formatMessage(
-					ctx.installPhase.value === 'error' ? wizardMessages.retry : wizardMessages.next,
+					ctx.installPhase.value === 'error' ? wizardMessages.retry : wizardMessages.finish,
 				),
 				color: 'brand',
 				icon: ctx.installPhase.value === 'error' ? RefreshCwIcon : null,
@@ -536,22 +538,8 @@ export function createCreateServerFlowContext(
 						ctx.retryInstall()
 						return
 					}
-					ctx.modal.value?.nextStage()
-				},
-			}),
-		},
-		{
-			id: 'configure',
-			stageContent: markRaw(ConfigureStage),
-			title: (ctx) => ctx.formatMessage(wizardMessages.configureStageTitle),
-			maxWidth: 'min(60rem, calc(95vw - 10rem))',
-			leftButtonConfig: () => null,
-			rightButtonConfig: (ctx) => ({
-				label: ctx.formatMessage(wizardMessages.finish),
-				color: 'brand',
-				onClick: async () => {
-					const save = ctx.saveServerProperties.value
-					if (save === null || (await save())) ctx.modal.value?.hide()
+					// Server is ready — close the wizard so the host can navigate to it.
+					ctx.modal.value?.hide()
 				},
 			}),
 		},

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Labrinth } from '@modrinth/api-client'
-import { commonMessages, MultiStageModal } from '@modrinth/ui'
+import { commonMessages, defineMessages, MultiStageModal } from '@modrinth/ui'
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
@@ -22,17 +22,35 @@ const ctx = createModpackServerFlowContext(modal)
 provideCreateServerFlow(ctx)
 provideModpackServerFlow(ctx)
 
+const messages = defineMessages({
+	downloadInBackground: {
+		id: 'app.servers.modpack.download-in-background',
+		defaultMessage: 'Download in background',
+	},
+})
+
+const wizardShown = ref(false)
 const wasHiddenDuringInstall = ref(false)
+const creationReported = ref(false)
 
 const cancelButton = computed(() => ({
-	label: ctx.formatMessage(commonMessages.cancelButton),
-	disabled: ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
+	label: ctx.formatMessage(
+		ctx.installPhase.value === 'downloading'
+			? messages.downloadInBackground
+			: commonMessages.cancelButton,
+	),
+	disabled: ctx.installPhase.value === 'first-run',
 	onClick: () => modal.value?.hide(),
 }))
 
 watch(ctx.showEulaModal, (visible) => {
-	if (visible) eulaModal.value?.show()
-	else eulaModal.value?.hide()
+	if (visible) {
+		// When the setup finished in the background, don't pop a EULA dialog over
+		// whatever page the user is on; starting the server gates on it instead.
+		if (wizardShown.value) eulaModal.value?.show()
+	} else {
+		eulaModal.value?.hide()
+	}
 })
 
 // The download keeps running in the background even if the wizard is closed.
@@ -40,14 +58,18 @@ watch(ctx.showEulaModal, (visible) => {
 watch(
 	() => ctx.installPhase.value,
 	(phase) => {
-		if (phase === 'done' && wasHiddenDuringInstall.value && ctx.createdServer.value) {
+		if (!wasHiddenDuringInstall.value || creationReported.value) return
+		if ((phase === 'done' || phase === 'eula') && ctx.createdServer.value) {
+			creationReported.value = true
 			emit('created', ctx.createdServer.value.id)
 		}
 	},
 )
 
 function show(project: Labrinth.Projects.v2.Project, version: Labrinth.Versions.v2.Version) {
+	wizardShown.value = true
 	wasHiddenDuringInstall.value = false
+	creationReported.value = false
 	ctx.reset()
 	ctx.setPack(project, version)
 	modal.value?.setStage(0)
@@ -55,8 +77,18 @@ function show(project: Labrinth.Projects.v2.Project, version: Labrinth.Versions.
 }
 
 function handleHide() {
-	if (ctx.createdServer.value) emit('created', ctx.createdServer.value.id)
-	else wasHiddenDuringInstall.value = true
+	wizardShown.value = false
+	if (
+		ctx.createdServer.value &&
+		(ctx.installPhase.value === 'done' || ctx.installPhase.value === 'eula')
+	) {
+		if (!creationReported.value) {
+			creationReported.value = true
+			emit('created', ctx.createdServer.value.id)
+		}
+	} else {
+		wasHiddenDuringInstall.value = true
+	}
 }
 
 defineExpose({ show, hide: () => modal.value?.hide() })

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
@@ -33,15 +33,20 @@ const wizardShown = ref(false)
 const wasHiddenDuringInstall = ref(false)
 const creationReported = ref(false)
 
-const cancelButton = computed(() => ({
-	label: ctx.formatMessage(
-		ctx.installPhase.value === 'downloading'
-			? messages.downloadInBackground
-			: commonMessages.cancelButton,
-	),
-	disabled: ctx.installPhase.value === 'first-run',
-	onClick: () => modal.value?.hide(),
-}))
+const cancelButton = computed(() => {
+	if (ctx.installPhase.value === 'done') {
+		return null
+	}
+	return {
+		label: ctx.formatMessage(
+			ctx.installPhase.value === 'downloading'
+				? messages.downloadInBackground
+				: commonMessages.cancelButton,
+		),
+		disabled: ctx.installPhase.value === 'first-run',
+		onClick: () => modal.value?.hide(),
+	}
+})
 
 watch(ctx.showEulaModal, (visible) => {
 	if (visible) {
@@ -110,7 +115,7 @@ defineExpose({ show, hide: () => modal.value?.hide() })
 	<EulaModal
 		ref="eulaModal"
 		:text="ctx.eulaText.value"
-		@accept="ctx.acceptEula"
+		@continue="ctx.acceptEula"
 		@decline="ctx.declineEula"
 	/>
 </template>

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/CreateModpackServerModal.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import type { Labrinth } from '@modrinth/api-client'
+import { commonMessages, MultiStageModal } from '@modrinth/ui'
+import { computed, ref, useTemplateRef, watch } from 'vue'
+import type { ComponentExposed } from 'vue-component-type-helpers'
+
+import { provideCreateServerFlow } from '@/components/multiplayer/servers/create-server-flow'
+import EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
+import {
+	createModpackServerFlowContext,
+	provideModpackServerFlow,
+} from '@/components/multiplayer/servers/modpack/create-modpack-server-flow'
+
+const emit = defineEmits<{
+	created: [serverId: string]
+}>()
+
+const modal = useTemplateRef<ComponentExposed<typeof MultiStageModal>>('modal')
+const eulaModal = useTemplateRef<ComponentExposed<typeof EulaModal>>('eulaModal')
+
+const ctx = createModpackServerFlowContext(modal)
+provideCreateServerFlow(ctx)
+provideModpackServerFlow(ctx)
+
+const wasHiddenDuringInstall = ref(false)
+
+const cancelButton = computed(() => ({
+	label: ctx.formatMessage(commonMessages.cancelButton),
+	disabled: ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
+	onClick: () => modal.value?.hide(),
+}))
+
+watch(ctx.showEulaModal, (visible) => {
+	if (visible) eulaModal.value?.show()
+	else eulaModal.value?.hide()
+})
+
+// The download keeps running in the background even if the wizard is closed.
+// Report the finished server once the flow reaches a terminal success state.
+watch(
+	() => ctx.installPhase.value,
+	(phase) => {
+		if (phase === 'done' && wasHiddenDuringInstall.value && ctx.createdServer.value) {
+			emit('created', ctx.createdServer.value.id)
+		}
+	},
+)
+
+function show(project: Labrinth.Projects.v2.Project, version: Labrinth.Versions.v2.Version) {
+	wasHiddenDuringInstall.value = false
+	ctx.reset()
+	ctx.setPack(project, version)
+	modal.value?.setStage(0)
+	modal.value?.show()
+}
+
+function handleHide() {
+	if (ctx.createdServer.value) emit('created', ctx.createdServer.value.id)
+	else wasHiddenDuringInstall.value = true
+}
+
+defineExpose({ show, hide: () => modal.value?.hide() })
+</script>
+
+<template>
+	<MultiStageModal
+		ref="modal"
+		:stages="ctx.stageConfigs"
+		:context="ctx"
+		breadcrumbs
+		:back-button-enabled="
+			(flowCtx) =>
+				flowCtx.installPhase.value !== 'downloading' && flowCtx.installPhase.value !== 'first-run'
+		"
+		:cancel-button="cancelButton"
+		@hide="handleHide"
+	/>
+	<EulaModal
+		ref="eulaModal"
+		:text="ctx.eulaText.value"
+		@accept="ctx.acceptEula"
+		@decline="ctx.declineEula"
+	/>
+</template>

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -5,6 +5,7 @@ import {
 	createContext,
 	defineMessages,
 	type MultiStageModal,
+	type StageConfigInput,
 	useVIntl,
 } from '@modrinth/ui'
 import { computed, markRaw, type Ref, ref } from 'vue'
@@ -40,7 +41,7 @@ export interface ModpackServerOptions {
 	version: Labrinth.Versions.v2.Version
 }
 
-export interface ModpackServerFlowContext extends CreateServerFlowContext {
+export interface ModpackServerFlowContext extends CreateServerFlowContext<ModpackServerFlowContext> {
 	modpackTitle: Ref<string>
 	modpackVersionNumber: Ref<string>
 	modpackIconUrl: Ref<string | undefined>
@@ -388,15 +389,15 @@ export function createModpackServerFlowContext(
 		void loadMaxMemory()
 	}
 
-	const stageConfigs = [
+	const stageConfigs: StageConfigInput<ModpackServerFlowContext>[] = [
 		{
 			id: 'setup',
 			stageContent: markRaw(ModpackSetupStage),
-			title: (ctx) => ctx.formatMessage(wizardMessages.setupTitle),
-			cannotNavigateForward: (ctx) =>
+			title: (ctx: ModpackServerFlowContext) => ctx.formatMessage(wizardMessages.setupTitle),
+			cannotNavigateForward: (ctx: ModpackServerFlowContext) =>
 				ctx.name.value.trim() === '' || !ctx.canContinueFromType.value,
 			leftButtonConfig: () => null,
-			rightButtonConfig: (ctx) => ({
+			rightButtonConfig: (ctx: ModpackServerFlowContext) => ({
 				label: ctx.formatMessage(wizardMessages.next),
 				color: 'brand',
 				disabled: ctx.name.value.trim() === '' || !ctx.canContinueFromType.value,
@@ -409,13 +410,13 @@ export function createModpackServerFlowContext(
 		{
 			id: 'install',
 			stageContent: markRaw(ModpackInstallStage),
-			title: (ctx) => ctx.formatMessage(wizardMessages.installTitle),
-			cannotNavigateForward: (ctx) => ctx.installPhase.value !== 'done',
+			title: (ctx: ModpackServerFlowContext) => ctx.formatMessage(wizardMessages.installTitle),
+			cannotNavigateForward: (ctx: ModpackServerFlowContext) => ctx.installPhase.value !== 'done',
 			// Downloads continue in the background once the wizard closes; only
 			// the first-run boot locks closing.
-			disableClose: (ctx) => ctx.installPhase.value === 'first-run',
+			disableClose: (ctx: ModpackServerFlowContext) => ctx.installPhase.value === 'first-run',
 			leftButtonConfig: () => null,
-			rightButtonConfig: (ctx) => ({
+			rightButtonConfig: (ctx: ModpackServerFlowContext) => ({
 				label: ctx.formatMessage(
 					ctx.installPhase.value === 'error'
 						? wizardMessages.retry
@@ -439,7 +440,8 @@ export function createModpackServerFlowContext(
 					ctx.modal.value?.nextStage()
 				},
 			}),
-		},]
+		},
+	]
 
 	return {
 		modal,
@@ -474,7 +476,7 @@ export function createModpackServerFlowContext(
 		loaderLabel,
 		loaderSupported,
 		gameVersionLabel,
-loadVersions,
+		loadVersions,
 		loadLoaderVersions,
 		loadDefaultJava,
 		beginInstall,

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -5,14 +5,13 @@ import {
 	createContext,
 	defineMessages,
 	type MultiStageModal,
-	type StageConfigInput,
 	useVIntl,
 } from '@modrinth/ui'
 import { computed, markRaw, type Ref, ref } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
-import { refresh as refreshServerList } from '@/composables/useServers'
 import { startModpackServerInstall } from '@/composables/useServerInstalls'
+import { refresh as refreshServerList } from '@/composables/useServers'
 import { find_filtered_jres, get_java_default_versions, get_max_memory } from '@/helpers/jre'
 import { get_loader_versions } from '@/helpers/metadata'
 import { serverEventListener, type ServerManifestData, servers } from '@/helpers/servers'
@@ -24,7 +23,6 @@ import {
 	toErrorMessage,
 	waitForServerStop,
 } from '../server-flow-utils'
-import ConfigureStage from '../stages/ConfigureStage.vue'
 import ModpackInstallStage from './stages/ModpackInstallStage.vue'
 import ModpackSetupStage from './stages/ModpackSetupStage.vue'
 
@@ -324,21 +322,8 @@ export function createModpackServerFlowContext(
 				})
 				if (isStale()) return
 
-				installPhase.value = 'first-run'
-				await servers.start(serverId)
-				const stopped = await waitForServerStop(serverId)
-				if (isStale()) return
-				if (stopped?.event === 'stopped' && stopped.crashed) {
-					throw new Error(formatMessage(wizardMessages.firstRunCrashed))
-				}
-
-				const eula = await servers.readFile(serverId, 'eula.txt').catch(() => null)
-				if (eula !== null && !eula.includes('eula=true')) {
-					eulaText.value = eula
-					showEulaModal.value = true
-					installPhase.value = 'eula'
-					return
-				}
+				// Modpack installation complete, no auto-start.
+				// User will click "Start" later, which will handle EULA check via tryStartServer.
 				installPhase.value = 'done'
 			} catch (error) {
 				if (!dispatched && createdServer.value) {
@@ -369,6 +354,14 @@ export function createModpackServerFlowContext(
 			await servers.writeFile(createdServer.value.id, 'eula.txt', updated)
 			showEulaModal.value = false
 			installPhase.value = 'done'
+			// Start the server after accepting EULA
+			await servers.start(createdServer.value.id)
+			// Wait for server to stop (crash or normal)
+			const stopped = await waitForServerStop(createdServer.value.id)
+			if (stopped?.event === 'stopped' && stopped.crashed) {
+				throw new Error(formatMessage(wizardMessages.firstRunCrashed))
+			}
+			installPhase.value = 'done'
 		} catch (error) {
 			installError.value = toErrorMessage(error)
 			installPhase.value = 'error'
@@ -395,7 +388,7 @@ export function createModpackServerFlowContext(
 		void loadMaxMemory()
 	}
 
-	const stageConfigs: StageConfigInput<CreateServerFlowContext>[] = [
+	const stageConfigs = [
 		{
 			id: 'setup',
 			stageContent: markRaw(ModpackSetupStage),
@@ -424,7 +417,11 @@ export function createModpackServerFlowContext(
 			leftButtonConfig: () => null,
 			rightButtonConfig: (ctx) => ({
 				label: ctx.formatMessage(
-					ctx.installPhase.value === 'error' ? wizardMessages.retry : wizardMessages.next,
+					ctx.installPhase.value === 'error'
+						? wizardMessages.retry
+						: ctx.installPhase.value === 'done'
+							? wizardMessages.finish
+							: wizardMessages.next,
 				),
 				color: 'brand',
 				icon: ctx.installPhase.value === 'error' ? RefreshCwIcon : null,
@@ -435,26 +432,14 @@ export function createModpackServerFlowContext(
 						void ctx.retryInstall()
 						return
 					}
+					if (ctx.installPhase.value === 'done') {
+						ctx.modal.value?.hide()
+						return
+					}
 					ctx.modal.value?.nextStage()
 				},
 			}),
-		},
-		{
-			id: 'configure',
-			stageContent: markRaw(ConfigureStage),
-			title: (ctx) => ctx.formatMessage(wizardMessages.configureTitle),
-			maxWidth: 'min(60rem, calc(95vw - 10rem))',
-			leftButtonConfig: () => null,
-			rightButtonConfig: (ctx) => ({
-				label: ctx.formatMessage(wizardMessages.finish),
-				color: 'brand',
-				onClick: async () => {
-					const save = ctx.saveServerProperties.value
-					if (save === null || (await save())) ctx.modal.value?.hide()
-				},
-			}),
-		},
-	]
+		},]
 
 	return {
 		modal,
@@ -489,7 +474,7 @@ export function createModpackServerFlowContext(
 		loaderLabel,
 		loaderSupported,
 		gameVersionLabel,
-		loadVersions,
+loadVersions,
 		loadLoaderVersions,
 		loadDefaultJava,
 		beginInstall,

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -1,0 +1,484 @@
+import type { Labrinth } from '@modrinth/api-client'
+import { RefreshCwIcon } from '@modrinth/assets'
+import { type ServerTypeId, setEulaAccepted } from '@modrinth/server'
+import {
+	createContext,
+	defineMessages,
+	type MultiStageModal,
+	type StageConfigInput,
+	useVIntl,
+} from '@modrinth/ui'
+import { computed, markRaw, type Ref, ref } from 'vue'
+import type { ComponentExposed } from 'vue-component-type-helpers'
+
+import { refresh as refreshServerList } from '@/composables/useServers'
+import { find_filtered_jres, get_java_default_versions, get_max_memory } from '@/helpers/jre'
+import { get_loader_versions } from '@/helpers/metadata'
+import { serverEventListener, type ServerManifestData, servers } from '@/helpers/servers'
+
+import type { CreateServerFlowContext, JavaSelection } from '../create-server-flow'
+import {
+	javaMajorFromVersion,
+	resolveServerLauncher,
+	toErrorMessage,
+	waitForServerStop,
+} from '../server-flow-utils'
+import ConfigureStage from '../stages/ConfigureStage.vue'
+import ModpackInstallStage from './stages/ModpackInstallStage.vue'
+import ModpackSetupStage from './stages/ModpackSetupStage.vue'
+
+export type ModpackInstallPhase =
+	| 'idle'
+	| 'preparing'
+	| 'downloading'
+	| 'first-run'
+	| 'eula'
+	| 'error'
+	| 'done'
+
+export interface ModpackServerOptions {
+	project: Labrinth.Projects.v2.Project
+	version: Labrinth.Versions.v2.Version
+}
+
+export interface ModpackServerFlowContext extends CreateServerFlowContext {
+	modpackTitle: Ref<string>
+	modpackVersionNumber: Ref<string>
+	modpackIconUrl: Ref<string | undefined>
+	loaderLabel: Ref<string>
+	loaderSupported: Ref<boolean>
+	gameVersionLabel: Ref<string>
+	setPack: (project: Labrinth.Projects.v2.Project, version: Labrinth.Versions.v2.Version) => void
+}
+
+export const [injectModpackServerFlow, provideModpackServerFlow] =
+	createContext<ModpackServerFlowContext>('ModpackServerFlow')
+
+const MODPACK_SERVER_TYPES: Record<string, { type: ServerTypeId; label: string }> = {
+	fabric: { type: 'fabric', label: 'Fabric' },
+	quilt: { type: 'quilt', label: 'Quilt' },
+	neoforge: { type: 'neoforge', label: 'NeoForge' },
+	forge: { type: 'forge', label: 'Forge' },
+}
+
+/** Loaders whose server launcher the app can download and boot directly. */
+const SUPPORTED_MODPACK_LOADERS: ServerTypeId[] = ['vanilla', 'fabric', 'quilt']
+
+export function resolveModpackLoader(loaders: string[]): { type: ServerTypeId; label: string } {
+	for (const loader of loaders) {
+		const entry = MODPACK_SERVER_TYPES[loader.toLowerCase()]
+		if (entry) return entry
+	}
+	return { type: 'vanilla', label: 'Vanilla' }
+}
+
+export function createModpackServerFlowContext(
+	modal: Ref<ComponentExposed<typeof MultiStageModal> | null>,
+): ModpackServerFlowContext {
+	const { formatMessage } = useVIntl()
+
+	const wizardMessages = defineMessages({
+		setupTitle: { id: 'app.servers.wizard.setup-title', defaultMessage: 'Setup' },
+		installTitle: { id: 'app.servers.wizard.install-title', defaultMessage: 'Install' },
+		configureTitle: { id: 'app.servers.wizard.configure-title', defaultMessage: 'Configure' },
+		next: { id: 'app.servers.wizard.next', defaultMessage: 'Next' },
+		retry: { id: 'app.servers.wizard.retry', defaultMessage: 'Retry' },
+		finish: { id: 'app.servers.wizard.finish', defaultMessage: 'Finish' },
+		javaTooOld: {
+			id: 'app.servers.wizard.java-too-old',
+			defaultMessage:
+				'Java {selected} cannot run this game version; Java {required} or newer is required.',
+		},
+		firstRunCrashed: {
+			id: 'app.servers.modpack.first-run-crashed',
+			defaultMessage:
+				'The server crashed during its first start. Check that your selected Java version is compatible, then try again.',
+		},
+	})
+
+	const project = ref<Labrinth.Projects.v2.Project | null>(null)
+	const version = ref<Labrinth.Versions.v2.Version | null>(null)
+
+	const serverType = ref<ServerTypeId>('vanilla')
+	const availableGameVersions = ref<string[]>([])
+	const selectedGameVersion = ref('')
+	const showSnapshots = ref(false)
+	const loaderVersions = ref<{ id: string; stable: boolean }[]>([])
+	const selectedLoaderVersion = ref('')
+	const isVersionsLoading = ref(false)
+	const versionsError = ref<string | null>(null)
+
+	const name = ref('')
+	const selectedJava = ref<JavaSelection>({ path: '', version: '' })
+	const memoryMb = ref(2048)
+	const maxMemoryMb = ref(8192)
+
+	const installPhase = ref<ModpackInstallPhase>('idle')
+	const downloadProgress = ref<{ downloaded: number; total: number | null } | null>(null)
+	const installLog = ref<string[]>([])
+	const installError = ref<string | null>(null)
+	const eulaText = ref('')
+	const createdServer = ref<ServerManifestData | null>(null)
+	const showEulaModal = ref(false)
+	const saveServerProperties = ref<(() => Promise<boolean>) | null>(null)
+
+	const modpackTitle = ref('')
+	const modpackVersionNumber = ref('')
+	const modpackIconUrl = ref<string | undefined>(undefined)
+	const loaderLabel = ref('')
+	const loaderSupported = ref(false)
+	const gameVersionLabel = ref('')
+
+	const needsLoaderVersion = computed(
+		() => serverType.value === 'fabric' || serverType.value === 'quilt',
+	)
+	const typeSupported = computed(() => loaderSupported.value)
+	const canContinueFromType = computed(() => loaderSupported.value)
+
+	function setPack(
+		packProject: Labrinth.Projects.v2.Project,
+		packVersion: Labrinth.Versions.v2.Version,
+	) {
+		project.value = packProject
+		version.value = packVersion
+		modpackTitle.value = packProject.title
+		modpackVersionNumber.value = packVersion.version_number ?? ''
+		modpackIconUrl.value = packProject.icon_url ?? undefined
+
+		const gameVersion = packVersion.game_versions?.[0] ?? ''
+		const loader = resolveModpackLoader(packVersion.loaders ?? [])
+		serverType.value = loader.type
+		loaderLabel.value = loader.label
+		gameVersionLabel.value = gameVersion
+		selectedGameVersion.value = gameVersion
+		availableGameVersions.value = gameVersion ? [gameVersion] : []
+		loaderSupported.value = SUPPORTED_MODPACK_LOADERS.includes(loader.type)
+
+		name.value = packProject.title
+		selectedLoaderVersion.value = ''
+		loaderVersions.value = []
+	}
+
+	async function loadVersions() {
+		// The modpack fixes the game version; nothing to load.
+	}
+
+	async function loadLoaderVersions() {
+		selectedLoaderVersion.value = ''
+		loaderVersions.value = []
+		if (!needsLoaderVersion.value || !selectedGameVersion.value) return
+		try {
+			const manifest = (await get_loader_versions(serverType.value, selectedGameVersion.value)) as {
+				gameVersions: Array<{ id: string; loaders: { id: string; stable: boolean }[] }>
+			}
+			const entry = manifest.gameVersions.find((game) => game.id === selectedGameVersion.value)
+			loaderVersions.value = entry?.loaders ?? []
+			const stable = loaderVersions.value.find((option) => option.stable) ?? loaderVersions.value[0]
+			selectedLoaderVersion.value = stable?.id ?? ''
+		} catch {
+			loaderVersions.value = []
+		}
+	}
+
+	async function loadDefaultJava() {
+		if (selectedJava.value.path !== '') return
+		const major = javaMajorFromVersion(selectedGameVersion.value || '1.21') ?? 21
+		try {
+			const defaults = (await get_java_default_versions()) as Array<{
+				parsed_version: number
+				version: string
+				path: string
+			}>
+			const match =
+				defaults.find((entry) => entry.parsed_version === major) ??
+				defaults.find((entry) => entry.parsed_version >= major)
+			if (match) {
+				selectedJava.value = { path: match.path, version: match.version }
+				return
+			}
+		} catch {
+			// Fall through to a filtered scan
+		}
+		try {
+			const javas = (await find_filtered_jres(major)) as JavaSelection[]
+			if (javas.length > 0) selectedJava.value = javas[0]
+		} catch {
+			// Leave empty; the user picks manually in the setup stage
+		}
+	}
+
+	async function loadMaxMemory() {
+		try {
+			const maxKiB = (await get_max_memory()) as number
+			maxMemoryMb.value = Math.max(1024, Math.floor(maxKiB / 1024))
+		} catch {
+			maxMemoryMb.value = 8192
+		}
+	}
+
+	async function beginInstall() {
+		if (installPhase.value === 'downloading' || installPhase.value === 'first-run') return
+		if (!project.value || !version.value) return
+		if (!loaderSupported.value) return
+
+		installPhase.value = 'preparing'
+		installError.value = null
+		installLog.value = []
+		downloadProgress.value = null
+		try {
+			await loadLoaderVersions()
+
+			const requiredJava = javaMajorFromVersion(selectedGameVersion.value) ?? 21
+			const selectedMajor = javaMajorFromVersion(selectedJava.value.version)
+			if (
+				selectedJava.value.path !== '' &&
+				selectedMajor !== null &&
+				selectedMajor < requiredJava
+			) {
+				throw new Error(
+					formatMessage(wizardMessages.javaTooOld, {
+						selected: selectedMajor,
+						required: requiredJava,
+					}),
+				)
+			}
+
+			const manifest = await servers.create({
+				name: name.value,
+				serverType: serverType.value,
+				gameVersion: selectedGameVersion.value,
+				loaderVersion: needsLoaderVersion.value ? selectedLoaderVersion.value : undefined,
+				javaPath: selectedJava.value.path || undefined,
+				memoryMb: memoryMb.value,
+			})
+			createdServer.value = manifest
+
+			const jar = await resolveServerLauncher(
+				serverType.value,
+				selectedGameVersion.value,
+				selectedLoaderVersion.value,
+			)
+			if (!jar) {
+				throw new Error(
+					`No server launcher available for ${loaderLabel.value} on ${selectedGameVersion.value}`,
+				)
+			}
+
+			const primaryFile = version.value.files.find((file) => file.primary) ?? version.value.files[0]
+			if (!primaryFile?.url) {
+				throw new Error('Modpack has no downloadable file')
+			}
+
+			installPhase.value = 'downloading'
+			const unlistenProgress = await serverEventListener((serverId, payload) => {
+				if (serverId !== manifest.id || payload.event !== 'download_progress') return
+				downloadProgress.value = {
+					downloaded: payload.downloaded,
+					total: payload.total ?? null,
+				}
+			})
+			const unlistenLogs = await serverEventListener((serverId, payload) => {
+				if (serverId !== manifest.id || payload.event !== 'log') return
+				installLog.value.push(payload.line)
+				if (installLog.value.length > 500) {
+					installLog.value.splice(0, installLog.value.length - 500)
+				}
+			})
+			try {
+				await servers.installModpack(manifest.id, {
+					mrpackUrl: primaryFile.url,
+					mrpackSha1: primaryFile.hashes?.sha1,
+					jarUrl: jar.url,
+					jarFilename: jar.filename,
+					jarSha1: jar.sha1,
+					modpackProjectId: project.value.id,
+					modpackVersionId: version.value.id,
+					modpackTitle: modpackTitle.value,
+					modpackIconUrl: modpackIconUrl.value,
+				})
+			} finally {
+				unlistenProgress()
+				unlistenLogs()
+			}
+
+			installPhase.value = 'first-run'
+			const unlistenFirstRunLogs = await serverEventListener((serverId, payload) => {
+				if (serverId !== manifest.id || payload.event !== 'log') return
+				installLog.value.push(payload.line)
+				if (installLog.value.length > 500) {
+					installLog.value.splice(0, installLog.value.length - 500)
+				}
+			})
+			try {
+				await servers.start(manifest.id)
+				const stopped = await waitForServerStop(manifest.id)
+				if (stopped?.event === 'stopped' && stopped.crashed) {
+					throw new Error(formatMessage(wizardMessages.firstRunCrashed))
+				}
+			} finally {
+				unlistenFirstRunLogs()
+			}
+
+			const eula = await servers.readFile(manifest.id, 'eula.txt').catch(() => null)
+			if (eula !== null && !eula.includes('eula=true')) {
+				eulaText.value = eula
+				showEulaModal.value = true
+				installPhase.value = 'eula'
+				return
+			}
+			installPhase.value = 'done'
+		} catch (error) {
+			installPhase.value = 'error'
+			installError.value = toErrorMessage(error)
+			// A half-installed server must not linger in the list; retrying starts over.
+			if (createdServer.value) {
+				const failed = createdServer.value
+				createdServer.value = null
+				await servers.delete(failed.id).catch(() => {})
+				void refreshServerList()
+			}
+		}
+	}
+
+	function retryInstall(): Promise<void> {
+		installPhase.value = 'idle'
+		return beginInstall()
+	}
+
+	async function acceptEula() {
+		if (!createdServer.value) return
+		try {
+			const updated = setEulaAccepted(eulaText.value, true)
+			await servers.writeFile(createdServer.value.id, 'eula.txt', updated)
+			showEulaModal.value = false
+			installPhase.value = 'done'
+		} catch (error) {
+			installError.value = toErrorMessage(error)
+			installPhase.value = 'error'
+			showEulaModal.value = false
+		}
+	}
+
+	function declineEula() {
+		showEulaModal.value = false
+		modal.value?.hide()
+	}
+
+	function reset() {
+		installPhase.value = 'idle'
+		installLog.value = []
+		installError.value = null
+		downloadProgress.value = null
+		eulaText.value = ''
+		createdServer.value = null
+		showEulaModal.value = false
+		saveServerProperties.value = null
+		selectedJava.value = { path: '', version: '' }
+		memoryMb.value = 2048
+		void loadMaxMemory()
+	}
+
+	const stageConfigs: StageConfigInput<CreateServerFlowContext>[] = [
+		{
+			id: 'setup',
+			stageContent: markRaw(ModpackSetupStage),
+			title: (ctx) => ctx.formatMessage(wizardMessages.setupTitle),
+			cannotNavigateForward: (ctx) =>
+				ctx.name.value.trim() === '' || !ctx.canContinueFromType.value,
+			leftButtonConfig: () => null,
+			rightButtonConfig: (ctx) => ({
+				label: ctx.formatMessage(wizardMessages.next),
+				color: 'brand',
+				disabled: ctx.name.value.trim() === '' || !ctx.canContinueFromType.value,
+				onClick: async () => {
+					await ctx.loadDefaultJava()
+					ctx.modal.value?.nextStage()
+				},
+			}),
+		},
+		{
+			id: 'install',
+			stageContent: markRaw(ModpackInstallStage),
+			title: (ctx) => ctx.formatMessage(wizardMessages.installTitle),
+			cannotNavigateForward: (ctx) => ctx.installPhase.value !== 'done',
+			disableClose: (ctx) =>
+				ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
+			leftButtonConfig: () => null,
+			rightButtonConfig: (ctx) => ({
+				label: ctx.formatMessage(
+					ctx.installPhase.value === 'error' ? wizardMessages.retry : wizardMessages.next,
+				),
+				color: 'brand',
+				icon: ctx.installPhase.value === 'error' ? RefreshCwIcon : null,
+				iconPosition: 'after',
+				disabled: ctx.installPhase.value !== 'done' && ctx.installPhase.value !== 'error',
+				onClick: () => {
+					if (ctx.installPhase.value === 'error') {
+						void ctx.retryInstall()
+						return
+					}
+					ctx.modal.value?.nextStage()
+				},
+			}),
+		},
+		{
+			id: 'configure',
+			stageContent: markRaw(ConfigureStage),
+			title: (ctx) => ctx.formatMessage(wizardMessages.configureTitle),
+			maxWidth: 'min(60rem, calc(95vw - 10rem))',
+			leftButtonConfig: () => null,
+			rightButtonConfig: (ctx) => ({
+				label: ctx.formatMessage(wizardMessages.finish),
+				color: 'brand',
+				onClick: async () => {
+					const save = ctx.saveServerProperties.value
+					if (save === null || (await save())) ctx.modal.value?.hide()
+				},
+			}),
+		},
+	]
+
+	return {
+		modal,
+		stageConfigs,
+		formatMessage,
+		serverType,
+		availableGameVersions,
+		selectedGameVersion,
+		showSnapshots,
+		loaderVersions,
+		selectedLoaderVersion,
+		isVersionsLoading,
+		versionsError,
+		name,
+		selectedJava,
+		memoryMb,
+		maxMemoryMb,
+		installPhase,
+		downloadProgress,
+		installLog,
+		installError,
+		eulaText,
+		createdServer,
+		showEulaModal,
+		saveServerProperties,
+		needsLoaderVersion,
+		typeSupported,
+		canContinueFromType,
+		modpackTitle,
+		modpackVersionNumber,
+		modpackIconUrl,
+		loaderLabel,
+		loaderSupported,
+		gameVersionLabel,
+		loadVersions,
+		loadLoaderVersions,
+		loadDefaultJava,
+		beginInstall,
+		retryInstall,
+		acceptEula,
+		declineEula,
+		reset,
+		setPack,
+	}
+}

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -12,6 +12,7 @@ import { computed, markRaw, type Ref, ref } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
 import { refresh as refreshServerList } from '@/composables/useServers'
+import { startModpackServerInstall } from '@/composables/useServerInstalls'
 import { find_filtered_jres, get_java_default_versions, get_max_memory } from '@/helpers/jre'
 import { get_loader_versions } from '@/helpers/metadata'
 import { serverEventListener, type ServerManifestData, servers } from '@/helpers/servers'
@@ -121,6 +122,7 @@ export function createModpackServerFlowContext(
 	const createdServer = ref<ServerManifestData | null>(null)
 	const showEulaModal = ref(false)
 	const saveServerProperties = ref<(() => Promise<boolean>) | null>(null)
+	let installSession = 0
 
 	const modpackTitle = ref('')
 	const modpackVersionNumber = ref('')
@@ -221,12 +223,19 @@ export function createModpackServerFlowContext(
 		if (!project.value || !version.value) return
 		if (!loaderSupported.value) return
 
+		// A closed wizard leaves its install promise running in the background.
+		// Reopening the wizard starts a fresh session; stale sessions must stop
+		// touching the shared state once their token is superseded.
+		const session = ++installSession
+		const isStale = () => installSession !== session
+
 		installPhase.value = 'preparing'
 		installError.value = null
 		installLog.value = []
 		downloadProgress.value = null
 		try {
 			await loadLoaderVersions()
+			if (isStale()) return
 
 			const requiredJava = javaMajorFromVersion(selectedGameVersion.value) ?? 21
 			const selectedMajor = javaMajorFromVersion(selectedJava.value.version)
@@ -243,49 +252,66 @@ export function createModpackServerFlowContext(
 				)
 			}
 
-			const manifest = await servers.create({
-				name: name.value,
-				serverType: serverType.value,
-				gameVersion: selectedGameVersion.value,
-				loaderVersion: needsLoaderVersion.value ? selectedLoaderVersion.value : undefined,
-				javaPath: selectedJava.value.path || undefined,
-				memoryMb: memoryMb.value,
-			})
-			createdServer.value = manifest
-
-			const jar = await resolveServerLauncher(
-				serverType.value,
-				selectedGameVersion.value,
-				selectedLoaderVersion.value,
-			)
-			if (!jar) {
-				throw new Error(
-					`No server launcher available for ${loaderLabel.value} on ${selectedGameVersion.value}`,
-				)
-			}
-
-			const primaryFile = version.value.files.find((file) => file.primary) ?? version.value.files[0]
-			if (!primaryFile?.url) {
-				throw new Error('Modpack has no downloadable file')
-			}
-
-			installPhase.value = 'downloading'
-			const unlistenProgress = await serverEventListener((serverId, payload) => {
-				if (serverId !== manifest.id || payload.event !== 'download_progress') return
-				downloadProgress.value = {
-					downloaded: payload.downloaded,
-					total: payload.total ?? null,
+			if (!createdServer.value) {
+				const manifest = await servers.create({
+					name: name.value,
+					serverType: serverType.value,
+					gameVersion: selectedGameVersion.value,
+					loaderVersion: needsLoaderVersion.value ? selectedLoaderVersion.value : undefined,
+					javaPath: selectedJava.value.path || undefined,
+					memoryMb: memoryMb.value,
+				})
+				if (isStale()) {
+					await servers.delete(manifest.id).catch(() => {})
+					void refreshServerList()
+					return
 				}
-			})
-			const unlistenLogs = await serverEventListener((serverId, payload) => {
-				if (serverId !== manifest.id || payload.event !== 'log') return
-				installLog.value.push(payload.line)
-				if (installLog.value.length > 500) {
-					installLog.value.splice(0, installLog.value.length - 500)
+				createdServer.value = manifest
+			}
+			const serverId = createdServer.value.id
+
+			// Past this point the server directory exists and the backend tracks
+			// install state on its manifest, so failures leave a retryable entry
+			// instead of being cleaned up. Only pre-install resolution errors
+			// (no launcher, no pack file) still remove the stub.
+			let dispatched = false
+			const unlistenEvents = await serverEventListener((id, payload) => {
+				if (id !== serverId || isStale()) return
+				if (payload.event === 'download_progress') {
+					downloadProgress.value = {
+						downloaded: payload.downloaded,
+						total: payload.total ?? null,
+					}
+				} else if (payload.event === 'log') {
+					installLog.value.push(payload.line)
+					if (installLog.value.length > 500) {
+						installLog.value.splice(0, installLog.value.length - 500)
+					}
 				}
 			})
 			try {
-				await servers.installModpack(manifest.id, {
+				const jar = await resolveServerLauncher(
+					serverType.value,
+					selectedGameVersion.value,
+					selectedLoaderVersion.value,
+				)
+				if (!jar) {
+					throw new Error(
+						`No server launcher available for ${loaderLabel.value} on ${selectedGameVersion.value}`,
+					)
+				}
+
+				const primaryFile =
+					version.value.files.find((file) => file.primary) ?? version.value.files[0]
+				if (!primaryFile?.url) {
+					throw new Error('Modpack has no downloadable file')
+				}
+
+				// The download runs through the shared background runner, so closing
+				// the wizard keeps it going; progress renders from the shared registry.
+				dispatched = true
+				installPhase.value = 'downloading'
+				await startModpackServerInstall(serverId, {
 					mrpackUrl: primaryFile.url,
 					mrpackSha1: primaryFile.hashes?.sha1,
 					jarUrl: jar.url,
@@ -296,47 +322,38 @@ export function createModpackServerFlowContext(
 					modpackTitle: modpackTitle.value,
 					modpackIconUrl: modpackIconUrl.value,
 				})
-			} finally {
-				unlistenProgress()
-				unlistenLogs()
-			}
+				if (isStale()) return
 
-			installPhase.value = 'first-run'
-			const unlistenFirstRunLogs = await serverEventListener((serverId, payload) => {
-				if (serverId !== manifest.id || payload.event !== 'log') return
-				installLog.value.push(payload.line)
-				if (installLog.value.length > 500) {
-					installLog.value.splice(0, installLog.value.length - 500)
-				}
-			})
-			try {
-				await servers.start(manifest.id)
-				const stopped = await waitForServerStop(manifest.id)
+				installPhase.value = 'first-run'
+				await servers.start(serverId)
+				const stopped = await waitForServerStop(serverId)
+				if (isStale()) return
 				if (stopped?.event === 'stopped' && stopped.crashed) {
 					throw new Error(formatMessage(wizardMessages.firstRunCrashed))
 				}
-			} finally {
-				unlistenFirstRunLogs()
-			}
 
-			const eula = await servers.readFile(manifest.id, 'eula.txt').catch(() => null)
-			if (eula !== null && !eula.includes('eula=true')) {
-				eulaText.value = eula
-				showEulaModal.value = true
-				installPhase.value = 'eula'
-				return
+				const eula = await servers.readFile(serverId, 'eula.txt').catch(() => null)
+				if (eula !== null && !eula.includes('eula=true')) {
+					eulaText.value = eula
+					showEulaModal.value = true
+					installPhase.value = 'eula'
+					return
+				}
+				installPhase.value = 'done'
+			} catch (error) {
+				if (!dispatched && createdServer.value) {
+					const failed = createdServer.value
+					createdServer.value = null
+					await servers.delete(failed.id).catch(() => {})
+					void refreshServerList()
+				}
+				throw error
+			} finally {
+				unlistenEvents()
 			}
-			installPhase.value = 'done'
 		} catch (error) {
 			installPhase.value = 'error'
 			installError.value = toErrorMessage(error)
-			// A half-installed server must not linger in the list; retrying starts over.
-			if (createdServer.value) {
-				const failed = createdServer.value
-				createdServer.value = null
-				await servers.delete(failed.id).catch(() => {})
-				void refreshServerList()
-			}
 		}
 	}
 
@@ -365,10 +382,10 @@ export function createModpackServerFlowContext(
 	}
 
 	function reset() {
+		installSession++
 		installPhase.value = 'idle'
 		installLog.value = []
 		installError.value = null
-		downloadProgress.value = null
 		eulaText.value = ''
 		createdServer.value = null
 		showEulaModal.value = false
@@ -401,8 +418,9 @@ export function createModpackServerFlowContext(
 			stageContent: markRaw(ModpackInstallStage),
 			title: (ctx) => ctx.formatMessage(wizardMessages.installTitle),
 			cannotNavigateForward: (ctx) => ctx.installPhase.value !== 'done',
-			disableClose: (ctx) =>
-				ctx.installPhase.value === 'downloading' || ctx.installPhase.value === 'first-run',
+			// Downloads continue in the background once the wizard closes; only
+			// the first-run boot locks closing.
+			disableClose: (ctx) => ctx.installPhase.value === 'first-run',
 			leftButtonConfig: () => null,
 			rightButtonConfig: (ctx) => ({
 				label: ctx.formatMessage(

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -16,6 +16,7 @@ import { refresh as refreshServerList } from '@/composables/useServers'
 import { find_filtered_jres, get_java_default_versions, get_max_memory } from '@/helpers/jre'
 import { get_loader_versions } from '@/helpers/metadata'
 import { serverEventListener, type ServerManifestData, servers } from '@/helpers/servers'
+import { injectDownloadManager } from '@/providers/download-manager'
 
 import type { CreateServerFlowContext, JavaSelection } from '../create-server-flow'
 import {
@@ -76,6 +77,17 @@ export function createModpackServerFlowContext(
 	modal: Ref<ComponentExposed<typeof MultiStageModal> | null>,
 ): ModpackServerFlowContext {
 	const { formatMessage } = useVIntl()
+
+	// [SERVER-DOWNLOAD-BRIDGE] Capture the download manager once during Vue
+	// setup context.  Vue's inject() only works in the synchronous setup
+	// scope — after any `await` the injection context is lost.  We store
+	// the reference here and pass it explicitly to `startModpackServerInstall`.
+	let downloadManager: ReturnType<typeof injectDownloadManager> | null = null
+	try {
+		downloadManager = injectDownloadManager()
+	} catch {
+		// Not inside a provider tree — server downloads will not appear in sidebar.
+	}
 
 	const wizardMessages = defineMessages({
 		setupTitle: { id: 'app.servers.wizard.setup-title', defaultMessage: 'Setup' },
@@ -306,11 +318,15 @@ export function createModpackServerFlowContext(
 					throw new Error('Modpack has no downloadable file')
 				}
 
-				// The download runs through the shared background runner, so closing
-				// the wizard keeps it going; progress renders from the shared registry.
-				dispatched = true
-				installPhase.value = 'downloading'
-				await startModpackServerInstall(serverId, {
+			// The download runs through the shared background runner, so closing
+			// the wizard keeps it going; progress renders from the shared registry.
+			dispatched = true
+			installPhase.value = 'downloading'
+			// [SERVER-DOWNLOAD-BRIDGE] Pass the download manager reference
+			// captured during setup so the synthetic job appears in sidebar.
+			await startModpackServerInstall(
+				serverId,
+				{
 					mrpackUrl: primaryFile.url,
 					mrpackSha1: primaryFile.hashes?.sha1,
 					jarUrl: jar.url,
@@ -320,7 +336,9 @@ export function createModpackServerFlowContext(
 					modpackVersionId: version.value.id,
 					modpackTitle: modpackTitle.value,
 					modpackIconUrl: modpackIconUrl.value,
-				})
+				},
+				downloadManager,
+			)
 				if (isStale()) return
 
 				// Modpack installation complete, no auto-start.

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -343,6 +343,10 @@ export function createModpackServerFlowContext(
 
 				// Modpack installation complete, no auto-start.
 				// User will click "Start" later, which will handle EULA check via tryStartServer.
+				// A code-created `eula.txt` (eula=false) is written so the manual start
+				// gate can offer the EULA without booting the jar.
+				const eula = setEulaAccepted('', false)
+				await servers.writeFile(serverId, 'eula.txt', eula).catch(() => {})
 				installPhase.value = 'done'
 			} catch (error) {
 				if (!dispatched && createdServer.value) {

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { CheckCircleIcon, SpinnerIcon } from '@modrinth/assets'
+import { Admonition, defineMessages, ProgressBar, useVIntl } from '@modrinth/ui'
+import { computed, onMounted } from 'vue'
+
+import { injectCreateServerFlow } from '../../create-server-flow'
+
+const { formatMessage } = useVIntl()
+const ctx = injectCreateServerFlow()
+
+const messages = defineMessages({
+	downloading: {
+		id: 'app.servers.modpack.downloading',
+		defaultMessage: 'Downloading modpack files...',
+	},
+	preparing: {
+		id: 'app.servers.modpack.preparing',
+		defaultMessage: 'Preparing server...',
+	},
+	firstRun: { id: 'app.servers.wizard.first-run', defaultMessage: 'Running first start...' },
+	eulaWait: {
+		id: 'app.servers.wizard.eula-wait',
+		defaultMessage: 'Waiting for EULA confirmation',
+	},
+	done: { id: 'app.servers.wizard.done', defaultMessage: 'Server ready' },
+	failed: { id: 'app.servers.wizard.failed', defaultMessage: 'Setup failed' },
+	installLog: { id: 'app.servers.wizard.log', defaultMessage: 'Output' },
+	currentFile: {
+		id: 'app.servers.modpack.current-file',
+		defaultMessage: 'Now installing {file}',
+	},
+})
+
+onMounted(() => {
+	if (ctx.installPhase.value === 'idle' || ctx.installPhase.value === 'error') {
+		void ctx.beginInstall()
+	}
+})
+
+const phaseText = computed(() => {
+	switch (ctx.installPhase.value) {
+		case 'preparing':
+			return formatMessage(messages.preparing)
+		case 'first-run':
+			return formatMessage(messages.firstRun)
+		case 'eula':
+			return formatMessage(messages.eulaWait)
+		case 'done':
+			return formatMessage(messages.done)
+		case 'error':
+			return formatMessage(messages.failed)
+		default:
+			return formatMessage(messages.downloading)
+	}
+})
+
+const progressPercent = computed(() => {
+	const progress = ctx.downloadProgress.value
+	if (!progress || !progress.total) return 0
+	return Math.min(100, (progress.downloaded / progress.total) * 100)
+})
+
+const currentFile = computed(() => {
+	const match = [...ctx.installLog.value]
+		.map((line) => /^Downloading (.+)$/.exec(line)?.[1])
+		.filter(Boolean)
+		.at(-1)
+	return match ?? null
+})
+
+const isBusy = computed(
+	() =>
+		ctx.installPhase.value === 'preparing' ||
+		ctx.installPhase.value === 'downloading' ||
+		ctx.installPhase.value === 'first-run',
+)
+</script>
+
+<template>
+	<div class="flex flex-col gap-5">
+		<div class="flex items-center gap-3">
+			<SpinnerIcon v-if="isBusy" class="size-6 shrink-0 animate-spin text-orange" />
+			<CheckCircleIcon
+				v-else-if="ctx.installPhase.value === 'done'"
+				class="size-6 shrink-0 text-green"
+			/>
+			<span class="text-lg font-semibold text-contrast">{{ phaseText }}</span>
+		</div>
+
+		<ProgressBar
+			v-if="ctx.installPhase.value === 'downloading'"
+			full-width
+			:progress="progressPercent"
+			:max="100"
+			:waiting="progressPercent === 0"
+			:label="formatMessage(messages.downloading)"
+			show-progress
+		/>
+
+		<p
+			v-if="currentFile && ctx.installPhase.value === 'downloading'"
+			class="m-0 -mt-2 truncate text-xs font-medium text-secondary"
+		>
+			{{ formatMessage(messages.currentFile, { file: currentFile }) }}
+		</p>
+
+		<Admonition
+			v-if="ctx.installPhase.value === 'error'"
+			type="critical"
+			:header="formatMessage(messages.failed)"
+		>
+			{{ ctx.installError.value }}
+		</Admonition>
+
+		<div
+			v-if="
+				ctx.installPhase.value === 'first-run' ||
+				ctx.installPhase.value === 'eula' ||
+				ctx.installPhase.value === 'done' ||
+				ctx.installPhase.value === 'error'
+			"
+			class="flex flex-col gap-2"
+		>
+			<span class="text-sm font-semibold text-secondary">
+				{{ formatMessage(messages.installLog) }}
+			</span>
+			<pre
+				class="max-h-56 overflow-y-auto whitespace-pre-wrap rounded-xl border border-solid border-surface-4 bg-surface-3 p-3 font-mono text-xs leading-relaxed text-primary"
+				>{{ ctx.installLog.value.slice(-40).join('\n') }}</pre
+			>
+		</div>
+	</div>
+</template>

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
@@ -29,6 +29,10 @@ const messages = defineMessages({
 		id: 'app.servers.modpack.current-file',
 		defaultMessage: 'Now installing {file}',
 	},
+	backgroundHint: {
+		id: 'app.servers.modpack.background-hint',
+		defaultMessage: 'You can close this window — the download continues in the background.',
+	},
 })
 
 onMounted(() => {
@@ -102,6 +106,13 @@ const isBusy = computed(
 			class="m-0 -mt-2 truncate text-xs font-medium text-secondary"
 		>
 			{{ formatMessage(messages.currentFile, { file: currentFile }) }}
+		</p>
+
+		<p
+			v-if="ctx.installPhase.value === 'downloading'"
+			class="m-0 text-xs font-medium text-secondary"
+		>
+			{{ formatMessage(messages.backgroundHint) }}
 		</p>
 
 		<Admonition

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
@@ -17,12 +17,7 @@ const messages = defineMessages({
 		id: 'app.servers.modpack.preparing',
 		defaultMessage: 'Preparing server...',
 	},
-	firstRun: { id: 'app.servers.wizard.first-run', defaultMessage: 'Running first start...' },
-	eulaWait: {
-		id: 'app.servers.wizard.eula-wait',
-		defaultMessage: 'Waiting for EULA confirmation',
-	},
-	done: { id: 'app.servers.wizard.done', defaultMessage: 'Server ready' },
+	done: { id: 'app.servers.modpack.done', defaultMessage: 'Installation complete' },
 	failed: { id: 'app.servers.wizard.failed', defaultMessage: 'Setup failed' },
 	installLog: { id: 'app.servers.wizard.log', defaultMessage: 'Output' },
 	currentFile: {
@@ -45,10 +40,6 @@ const phaseText = computed(() => {
 	switch (ctx.installPhase.value) {
 		case 'preparing':
 			return formatMessage(messages.preparing)
-		case 'first-run':
-			return formatMessage(messages.firstRun)
-		case 'eula':
-			return formatMessage(messages.eulaWait)
 		case 'done':
 			return formatMessage(messages.done)
 		case 'error':
@@ -75,8 +66,7 @@ const currentFile = computed(() => {
 const isBusy = computed(
 	() =>
 		ctx.installPhase.value === 'preparing' ||
-		ctx.installPhase.value === 'downloading' ||
-		ctx.installPhase.value === 'first-run',
+		ctx.installPhase.value === 'downloading',
 )
 </script>
 
@@ -125,8 +115,6 @@ const isBusy = computed(
 
 		<div
 			v-if="
-				ctx.installPhase.value === 'first-run' ||
-				ctx.installPhase.value === 'eula' ||
 				ctx.installPhase.value === 'done' ||
 				ctx.installPhase.value === 'error'
 			"

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackInstallStage.vue
@@ -114,10 +114,7 @@ const isBusy = computed(
 		</Admonition>
 
 		<div
-			v-if="
-				ctx.installPhase.value === 'done' ||
-				ctx.installPhase.value === 'error'
-			"
+			v-if="ctx.installPhase.value === 'error'"
 			class="flex flex-col gap-2"
 		>
 			<span class="text-sm font-semibold text-secondary">

--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackSetupStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/stages/ModpackSetupStage.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ServerIcon } from '@modrinth/assets'
+import { requiredJavaMajorVersion } from '@modrinth/server'
+import {
+	Admonition,
+	Avatar,
+	defineMessages,
+	Slider,
+	StyledInput,
+	TagItem,
+	useVIntl,
+} from '@modrinth/ui'
+import { computed, onMounted } from 'vue'
+
+import JavaSelector from '@/components/ui/JavaSelector.vue'
+
+import { injectModpackServerFlow } from '../create-modpack-server-flow'
+
+const { formatMessage } = useVIntl()
+const ctx = injectModpackServerFlow()
+
+const messages = defineMessages({
+	name: { id: 'app.servers.wizard.name', defaultMessage: 'Server name' },
+	java: { id: 'app.servers.settings.java', defaultMessage: 'Java' },
+	memory: { id: 'app.servers.settings.memory', defaultMessage: 'Memory' },
+	memoryValue: { id: 'app.servers.wizard.memory-value', defaultMessage: '{value} MB' },
+	unsupportedLoaderTitle: {
+		id: 'app.servers.modpack.unsupported-loader-title',
+		defaultMessage: '{loader} servers are not supported yet',
+	},
+	unsupportedLoaderDescription: {
+		id: 'app.servers.modpack.unsupported-loader-description',
+		defaultMessage:
+			'This modpack uses {loader}, but Axolotl can only start modpack servers with vanilla, Fabric, or Quilt. Support for {loader} is coming soon.',
+	},
+})
+
+const requiredJava = computed(() =>
+	requiredJavaMajorVersion(ctx.selectedGameVersion.value || '1.21'),
+)
+
+onMounted(() => {
+	void ctx.loadDefaultJava()
+})
+</script>
+
+<template>
+	<div class="flex flex-col gap-5">
+		<div
+			class="flex items-center gap-3 rounded-xl border border-solid border-surface-4 bg-surface-2 p-3"
+		>
+			<Avatar
+				:src="ctx.modpackIconUrl.value"
+				:alt="ctx.modpackTitle.value"
+				size="56px"
+				class="shrink-0"
+			/>
+			<div class="min-w-0 flex-1">
+				<p class="m-0 truncate text-base font-bold leading-tight text-contrast">
+					{{ ctx.modpackTitle.value }}
+				</p>
+				<p class="m-0 mt-0.5 truncate text-sm font-medium text-secondary">
+					{{ ctx.modpackVersionNumber.value }}
+				</p>
+				<div class="mt-1.5 flex flex-wrap items-center gap-1.5">
+					<TagItem>
+						<span class="font-semibold">{{ ctx.loaderLabel.value }}</span>
+					</TagItem>
+					<TagItem v-if="ctx.gameVersionLabel.value">
+						<span class="font-semibold">{{ ctx.gameVersionLabel.value }}</span>
+					</TagItem>
+				</div>
+			</div>
+		</div>
+
+		<Admonition
+			v-if="!ctx.loaderSupported.value"
+			type="critical"
+			:header="
+				formatMessage(messages.unsupportedLoaderTitle, {
+					loader: ctx.loaderLabel.value,
+				})
+			"
+		>
+			{{
+				formatMessage(messages.unsupportedLoaderDescription, {
+					loader: ctx.loaderLabel.value,
+				})
+			}}
+		</Admonition>
+
+		<label class="flex min-w-0 flex-col gap-2" for="modpack-server-name">
+			<span class="font-semibold text-contrast">{{ formatMessage(messages.name) }}</span>
+			<StyledInput
+				id="modpack-server-name"
+				v-model="ctx.name.value"
+				:icon="ServerIcon"
+				:placeholder="ctx.modpackTitle.value"
+			/>
+		</label>
+
+		<div class="flex min-w-0 flex-col gap-2">
+			<span class="font-semibold text-contrast">{{ formatMessage(messages.java) }}</span>
+			<JavaSelector
+				id="modpack-java-selector"
+				v-model="ctx.selectedJava.value"
+				:version="requiredJava"
+				select-all-versions
+			/>
+		</div>
+
+		<div class="flex min-w-0 flex-col gap-2">
+			<div class="flex items-center justify-between gap-3">
+				<span class="font-semibold text-contrast">{{ formatMessage(messages.memory) }}</span>
+				<span
+					class="rounded-md border border-solid border-surface-5 bg-surface-3 px-2 py-1 text-xs font-semibold leading-none text-contrast"
+				>
+					{{ formatMessage(messages.memoryValue, { value: ctx.memoryMb.value }) }}
+				</span>
+			</div>
+			<Slider v-model="ctx.memoryMb.value" :min="1024" :max="ctx.maxMemoryMb.value" :step="512" />
+		</div>
+	</div>
+</template>

--- a/apps/app-frontend/src/components/multiplayer/servers/server-flow-utils.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/server-flow-utils.ts
@@ -1,0 +1,126 @@
+import {
+	type FabricInstallerVersionsResponse,
+	fabricInstallerVersionsUrl,
+	quiltInstallerVersionsUrl,
+	resolveServerJar,
+	type ServerJarDownload,
+	type ServerTypeId,
+	type VanillaVersionInfo,
+} from '@modrinth/server'
+import { getVersion } from '@tauri-apps/api/app'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { type as osType } from '@tauri-apps/plugin-os'
+
+import { get_game_versions } from '@/helpers/metadata'
+import { serverEventListener, type ServerEventPayload } from '@/helpers/servers'
+
+/** Best-effort conversion of an unknown error into a user-presentable string. */
+export function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message
+	if (typeof error === 'string') return error
+	if (error && typeof error === 'object') {
+		const record = error as Record<string, unknown>
+		for (const key of ['message', 'error', 'description'] as const) {
+			if (typeof record[key] === 'string') return record[key]
+		}
+	}
+	try {
+		return JSON.stringify(error)
+	} catch {
+		return String(error)
+	}
+}
+
+/** Extracts the Java major version from strings like `17`, `1.8`, or `21.0.1`. */
+export function javaMajorFromVersion(version: string): number | null {
+	const parts = version
+		.split(/[._]/)
+		.map(Number)
+		.filter((value) => Number.isInteger(value) && value >= 0)
+	if (parts.length === 0) return null
+	if (parts[0] === 1 && parts.length > 1) return parts[1]
+	return parts[0]
+}
+
+/**
+ * Waits for the server to emit a `stopped` event, resolving with the payload
+ * or `null` after a timeout. Used to run the first start during setup and know
+ * when the JVM has exited.
+ */
+export async function waitForServerStop(serverId: string): Promise<ServerEventPayload | null> {
+	return new Promise((resolve) => {
+		void serverEventListener((eventServerId, payload) => {
+			if (eventServerId !== serverId || payload.event !== 'stopped') return
+			resolve(payload)
+		}).then((unlisten) => {
+			setTimeout(
+				() => {
+					unlisten()
+					resolve(null)
+				},
+				10 * 60 * 1000,
+			)
+		})
+	})
+}
+
+let userAgentPromise: Promise<string> | null = null
+
+/**
+ * Identifying User-Agent, required by services like the PaperMC downloads API.
+ * Mirrors the format used by the Rust backend.
+ */
+function launcherUserAgent(): Promise<string> {
+	userAgentPromise ??= Promise.all([getVersion(), osType()]).then(
+		([version, platform]) =>
+			`garbage-human-studio/axolotl/${version} (${platform}; +https://www.ghs.red)`,
+	)
+	userAgentPromise = userAgentPromise.catch(
+		() => 'garbage-human-studio/axolotl (+https://www.ghs.red)',
+	)
+	return userAgentPromise
+}
+
+export async function fetchJson<T>(url: string): Promise<T> {
+	const response = await tauriFetch(url, {
+		headers: { 'User-Agent': await launcherUserAgent() },
+	})
+	if (!response.ok) throw new Error('GET ' + url + ' failed: ' + response.status)
+	return (await response.json()) as T
+}
+
+/**
+ * Resolves the server launcher jar download for a modpack server. Vanilla
+ * pulls the Mojang server jar; Fabric and Quilt use their meta service launcher
+ * jars with the newest stable installer.
+ */
+export async function resolveServerLauncher(
+	type: ServerTypeId,
+	gameVersion: string,
+	loaderVersion?: string,
+): Promise<ServerJarDownload | null> {
+	switch (type) {
+		case 'vanilla': {
+			const manifest = (await get_game_versions()) as {
+				versions: { id: string; url: string }[]
+			}
+			const entry = manifest.versions.find((v) => v.id === gameVersion)
+			if (!entry) return null
+			const versionInfo = await fetchJson<VanillaVersionInfo>(entry.url)
+			return resolveServerJar('vanilla', { gameVersion, vanillaVersionInfo: versionInfo })
+		}
+		case 'fabric':
+		case 'quilt': {
+			const installers = await fetchJson<FabricInstallerVersionsResponse[]>(
+				type === 'fabric' ? fabricInstallerVersionsUrl() : quiltInstallerVersionsUrl(),
+			)
+			return resolveServerJar(type, {
+				gameVersion,
+				loaderVersion,
+				installerVersion: installers[0]?.version,
+			})
+		}
+		default:
+			return null
+	}
+}

--- a/apps/app-frontend/src/components/multiplayer/servers/stages/InstallStage.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/stages/InstallStage.vue
@@ -8,20 +8,24 @@ import { injectCreateServerFlow } from '../create-server-flow'
 const { formatMessage } = useVIntl()
 const ctx = injectCreateServerFlow()
 
-const messages = defineMessages({
-	downloading: {
-		id: 'app.servers.wizard.downloading',
-		defaultMessage: 'Downloading server files...',
-	},
-	firstRun: { id: 'app.servers.wizard.first-run', defaultMessage: 'Running first start...' },
-	eulaWait: {
-		id: 'app.servers.wizard.eula-wait',
-		defaultMessage: 'Waiting for EULA confirmation',
-	},
-	done: { id: 'app.servers.wizard.done', defaultMessage: 'Server ready' },
-	failed: { id: 'app.servers.wizard.failed', defaultMessage: 'Setup failed' },
-	installLog: { id: 'app.servers.wizard.log', defaultMessage: 'Output' },
-})
+	const messages = defineMessages({
+		downloading: {
+			id: 'app.servers.wizard.downloading',
+			defaultMessage: 'Downloading server files...',
+		},
+		firstRun: { id: 'app.servers.wizard.first-run', defaultMessage: 'Running first start...' },
+		eulaWait: {
+			id: 'app.servers.wizard.eula-wait',
+			defaultMessage: 'Waiting for EULA confirmation',
+		},
+		done: { id: 'app.servers.wizard.done', defaultMessage: 'Server ready' },
+		failed: { id: 'app.servers.wizard.failed', defaultMessage: 'Setup failed' },
+		installLog: { id: 'app.servers.wizard.log', defaultMessage: 'Output' },
+		backgroundHint: {
+			id: 'app.servers.wizard.background-hint',
+			defaultMessage: 'You can close this window — the download continues in the background.',
+		},
+	})
 
 onMounted(() => {
 	if (ctx.installPhase.value === 'idle' || ctx.installPhase.value === 'error') {
@@ -79,6 +83,13 @@ const isBusy = computed(
 			show-progress
 		/>
 
+		<p
+			v-if="ctx.installPhase.value === 'downloading'"
+			class="m-0 text-xs font-medium text-secondary"
+		>
+			{{ formatMessage(messages.backgroundHint) }}
+		</p>
+
 		<Admonition
 			v-if="ctx.installPhase.value === 'error'"
 			type="critical"
@@ -88,11 +99,7 @@ const isBusy = computed(
 		</Admonition>
 
 		<div
-			v-if="
-				ctx.installPhase.value !== 'idle' &&
-				ctx.installPhase.value !== 'preparing' &&
-				ctx.installPhase.value !== 'downloading'
-			"
+			v-if="ctx.installPhase.value === 'error'"
 			class="flex flex-col gap-2"
 		>
 			<span class="text-sm font-semibold text-secondary">

--- a/apps/app-frontend/src/components/ui/MinecraftCrashModal.vue
+++ b/apps/app-frontend/src/components/ui/MinecraftCrashModal.vue
@@ -603,7 +603,7 @@ onUnmounted(() => {
 	unlistenProcess?.()
 })
 
-defineExpose({ handleLaunchError, handleWarning, isLaunchFailure, showPreview })
+defineExpose({ handleLaunchError, handleWarning, isLaunchFailure, showPreview, openAIAnalysis: _openAIAnalysis })
 </script>
 
 <template>

--- a/apps/app-frontend/src/composables/server-download-bridge.ts
+++ b/apps/app-frontend/src/composables/server-download-bridge.ts
@@ -1,0 +1,104 @@
+import type { InstallJobSnapshot } from '@/helpers/install'
+import type { DownloadManager } from '@/providers/download-manager'
+
+export interface ServerDownloadJobDisplay {
+	title: string
+	icon: string | null
+	provider: InstallJobSnapshot['provider']
+}
+
+export interface ServerDownloadProgress {
+	downloaded: number
+	total: number | null
+}
+
+/**
+ * Drives a synthetic install job in the global Downloads page so that a
+ * server download (modpack or vanilla) appears in the sidebar and history
+ * exactly like a backend-tracked install job.
+ *
+ * A single shared implementation is used by every server-download flow so the
+ * snapshot shape, status transitions, and cancel handling stay consistent.
+ */
+export interface ServerDownloadBridge {
+	update(progress: ServerDownloadProgress, speed: number | null, eta: number | null): void
+	complete(success: boolean, progress?: ServerDownloadProgress): void
+	cancel(handler: () => void | Promise<void>): void
+}
+
+export function createServerDownloadBridge(
+	downloadManager: DownloadManager,
+	jobId: string,
+	display: ServerDownloadJobDisplay,
+): ServerDownloadBridge {
+	const created = new Date().toISOString()
+
+	function snapshot(
+		status: InstallJobSnapshot['status'],
+		phase: InstallJobSnapshot['phase'],
+		progress: ServerDownloadProgress,
+		speed: number | null,
+		eta: number | null,
+		finished?: string,
+	): InstallJobSnapshot {
+		const modified = new Date().toISOString()
+		return {
+			job_id: jobId,
+			instance_id: null,
+			instance_deleted: false,
+			kind: 'create_instance',
+			status,
+			execution_mode: 'normal',
+			provider: display.provider,
+			target: { type: 'new_instance' },
+			phase,
+			details: { type: 'empty' },
+			created,
+			modified,
+			finished,
+			display: { title: display.title, icon: display.icon },
+			summary: {
+				files_completed: 0,
+				files_total: null,
+				bytes_downloaded: progress.downloaded,
+				bytes_total: progress.total,
+				speed_bytes_per_second: speed,
+				eta_seconds: eta,
+				source: null,
+				fallback_count: 0,
+			},
+			items: [],
+		}
+	}
+
+	downloadManager.addSyntheticJob(
+		snapshot('running', 'downloading_content', { downloaded: 0, total: null }, null, null),
+	)
+
+	return {
+		update(progress, speed, eta) {
+			downloadManager.setSyntheticJob(snapshot('running', 'downloading_content', progress, speed, eta))
+		},
+		complete(success, progress) {
+			downloadManager.offSyntheticCancel(jobId)
+			const finalProgress = progress ?? { downloaded: 0, total: null }
+			const finished = new Date().toISOString()
+			downloadManager.setSyntheticJob(
+				snapshot(
+					success ? 'succeeded' : 'failed',
+					success ? 'completed' : 'downloading_content',
+					finalProgress,
+					null,
+					null,
+					finished,
+				),
+			)
+		},
+		cancel(handler) {
+			downloadManager.onSyntheticCancel(jobId, async () => {
+				downloadManager.offSyntheticCancel(jobId)
+				await handler()
+			})
+		},
+	}
+}

--- a/apps/app-frontend/src/composables/useDropImport.ts
+++ b/apps/app-frontend/src/composables/useDropImport.ts
@@ -925,8 +925,8 @@ export function useDropImport(options: DropImportOptions) {
 			dropDebug('handleDropConfirm: data pack requires a world target', {
 				filePath,
 			})
-			pendingInstall.value = { type, filePath, innerBase }
-			dataPackWorldModal.value?.show(isInInstance.value ? instanceId.value : undefined)
+		pendingInstall.value = { type, filePath, innerBase }
+		dataPackWorldModal.value?.show(isInInstance.value ? (instanceId.value ?? undefined) : undefined)
 			return
 		}
 

--- a/apps/app-frontend/src/composables/useDropImport.ts
+++ b/apps/app-frontend/src/composables/useDropImport.ts
@@ -9,16 +9,19 @@ import type {
 	BatchDropGroup,
 	BatchDropItem,
 	BatchDropPhase,
+	ClassificationResult,
 	SymlinkMethodChoice,
 } from '@modrinth/ui'
-import { useDebugLogger, useGlobalDrop, useVIntl } from '@modrinth/ui'
-import { useInstanceContext } from '@modrinth/ui/src/composables/use-instance-context'
+import {
+	useDebugLogger,
+	useGlobalDrop,
+	useInstanceContext,
+	useVIntl,
+} from '@modrinth/ui'
 import { computed, type ComputedRef, nextTick, ref } from 'vue'
 import type { Router } from 'vue-router'
 
-import type { ContentInstallContext } from '@/providers/content-install'
 import {
-	type ClassificationResult,
 	classifyDroppedItem,
 	classifyDroppedItemWithExtraction,
 	detectFileLock,
@@ -44,6 +47,7 @@ import { getDisplayInstanceIcon } from '@/helpers/instance-icons'
 import { areLoadersCompatible, isVersionInRange } from '@/helpers/version-compatibility'
 import type { AppNotificationManager } from '@/providers/app-notifications'
 import type { AppPopupNotificationManager } from '@/providers/app-popup-notifications'
+import type { ContentInstallContext } from '@/providers/content-install'
 
 // Re-export types for external use
 export type { ClassificationResult, ModrinthLookupResult, ScanResult }
@@ -220,7 +224,7 @@ export function useDropImport(options: DropImportOptions) {
 	const compatibleModeGameDir = ref<string | null>(null)
 	const compatibleModeLauncherType = ref<string>('Generic')
 	const launcherZipTempDir = ref<string | null>(null)
-	const dropProcessingNotificationId = ref<number | null>(null)
+	const dropProcessingNotificationId = ref<string | number | null>(null)
 
 	// ── Batch drop state ─────────────────────────────────────────────────
 	const batchPhase = ref<BatchDropPhase>('idle')
@@ -697,7 +701,7 @@ export function useDropImport(options: DropImportOptions) {
 
 		const filePath = classification?.file_path ?? dropFilePath.value
 		const fileName =
-			filePath?.split(/[/\\]/).pop() ?? classification.base_path?.split(/[/\\]/).pop() ?? 'file'
+			filePath?.split(/[/\\]/).pop() ?? classification?.base_path?.split(/[/\\]/).pop() ?? 'file'
 		dropDebug('handleDropConfirm: routing decision', {
 			type,
 			isLauncherImport,
@@ -1469,9 +1473,9 @@ export function useDropImport(options: DropImportOptions) {
 					inst.name,
 					choice?.symlink ?? (Array.isArray(choices) ? false : choices),
 					resolvedInstancePath(inst, ctx),
-					inst.compatibleMode ? undefined : choice?.gameVersion,
-					inst.compatibleMode ? undefined : choice?.loader,
-					inst.compatibleMode ? undefined : choice?.loaderVersion,
+					inst.compatibleMode ? undefined : (choice?.gameVersion ?? undefined),
+					inst.compatibleMode ? undefined : (choice?.loader ?? undefined),
+					inst.compatibleMode ? undefined : (choice?.loaderVersion ?? undefined),
 					choice?.gameDirOverride ?? null,
 				)
 				await wait_for_install_job(job.job_id)
@@ -1534,9 +1538,9 @@ export function useDropImport(options: DropImportOptions) {
 					inst.name,
 					choice?.symlink ?? (Array.isArray(choices) ? false : choices),
 					resolvedInstancePath(inst, ctx),
-					inst.compatibleMode ? undefined : choice?.gameVersion,
-					inst.compatibleMode ? undefined : choice?.loader,
-					inst.compatibleMode ? undefined : choice?.loaderVersion,
+					inst.compatibleMode ? undefined : (choice?.gameVersion ?? undefined),
+					inst.compatibleMode ? undefined : (choice?.loader ?? undefined),
+					inst.compatibleMode ? undefined : (choice?.loaderVersion ?? undefined),
 					choice?.gameDirOverride ?? null,
 				)
 				await wait_for_install_job(job.job_id)

--- a/apps/app-frontend/src/composables/useDropImport.ts
+++ b/apps/app-frontend/src/composables/useDropImport.ts
@@ -559,6 +559,8 @@ export function useDropImport(options: DropImportOptions) {
 		return result
 	}
 
+	// ── Compatible mode ──────────────────────────────────────────────────
+
 	async function handleCompatibleModeConfirm(choice: 'compatible' | 'old-way' | 'cancel') {
 		if (choice === 'cancel') {
 			currentImportContext.value = null

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -43,13 +43,25 @@ export function serverSetupStatus(server: ServerInfoData): ServerSetupStatus | n
 }
 
 /**
- * Runs a modpack server install in the background: progress and log events are
- * tracked in the shared registry so any surface (wizard, servers list, detail
- * page) can render live state, and callers only await completion.
+ * [SERVER-DOWNLOAD-BRIDGE] Runs a modpack server install in the background.
+ *
+ * During the install, progress and log events are tracked in the shared
+ * `activeInstalls` registry so any surface (wizard, servers list, detail
+ * page) can render live state.
+ *
+ * Additionally, when a `DownloadManager` reference is provided, a synthetic
+ * install job is injected so the server download also appears in the global
+ * Downloads page (/downloads) and the sidebar download badge.
+ *
+ * NOTE: The download manager MUST be captured during Vue setup context and
+ * passed in — `injectDownloadManager()` only works inside synchronous setup
+ * scope.  After any `await` the injection context is lost and the call
+ * would throw.
  */
 export async function startModpackServerInstall(
 	serverId: string,
 	options: InstallModpackOptions,
+	downloadManager?: import('@/providers/download-manager').DownloadManager | null,
 ): Promise<void> {
 	if (activeInstalls[serverId]) {
 		throw new Error('This server already has an install running')
@@ -57,31 +69,193 @@ export async function startModpackServerInstall(
 	const entry: ActiveServerInstall = { progress: null, log: [] }
 	activeInstalls[serverId] = entry
 
+	// [SERVER-DOWNLOAD-BRIDGE] Create a synthetic job that mirrors this server
+	// install in the global Downloads page.  The job_id uses a `server-` prefix
+	// to avoid collisions with backend-tracked install jobs.
+	const syntheticJobId = `server-${serverId}`
+	const now = new Date().toISOString()
+
+	if (downloadManager) {
+		console.log(
+			`[SERVER-DOWNLOAD-BRIDGE] Creating synthetic job ${syntheticJobId} for server "${options.modpackTitle}"`,
+		)
+		downloadManager.addSyntheticJob({
+			job_id: syntheticJobId,
+			instance_id: null,
+			instance_deleted: false,
+			kind: 'create_instance',
+			status: 'running',
+			execution_mode: 'normal',
+			provider: options.modpackProjectId ? 'modrinth' : 'local',
+			target: { type: 'new_instance' },
+			phase: 'downloading_content',
+			details: { type: 'empty' },
+			created: now,
+			modified: now,
+			display: {
+				title: options.modpackTitle ?? 'Server',
+				icon: options.modpackIconUrl ?? null,
+			},
+			summary: {
+				files_completed: 0,
+				files_total: null,
+				bytes_downloaded: 0,
+				bytes_total: null,
+				speed_bytes_per_second: null,
+				eta_seconds: null,
+				source: null,
+				fallback_count: 0,
+			},
+			items: [],
+		})
+	} else {
+		console.warn(
+			`[SERVER-DOWNLOAD-BRIDGE] No download manager available — job ${syntheticJobId} will NOT appear in sidebar`,
+		)
+	}
+
+	// [SERVER-DOWNLOAD-BRIDGE] Listen for backend progress events and forward
+	// them to both the local `entry` (used by wizard UI) and the synthetic
+	// job (used by the global Downloads page).
+	let prevBytes = 0
+	let prevTime = performance.now()
+	let smoothedSpeed = 0
 	const unlistenProgress = await serverEventListener((id, payload) => {
 		if (id !== serverId || payload.event !== 'download_progress') return
 		entry.progress = { downloaded: payload.downloaded, total: payload.total ?? null }
+
+		const now2 = performance.now()
+		const dt = (now2 - prevTime) / 1000
+		if (dt > 0.3 && prevBytes > 0 && payload.downloaded >= prevBytes) {
+			const rawSpeed = (payload.downloaded - prevBytes) / dt
+			smoothedSpeed = smoothedSpeed === 0 ? rawSpeed : smoothedSpeed * 0.7 + rawSpeed * 0.3
+		}
+		prevBytes = payload.downloaded
+		prevTime = now2
+
+		const speed = smoothedSpeed > 100 ? smoothedSpeed : null
+		const total = payload.total ?? null
+		const eta = speed && total != null && total > payload.downloaded
+			? (total - payload.downloaded) / speed
+			: null
+
+		if (downloadManager) {
+			const ts = new Date().toISOString()
+			downloadManager.setSyntheticJob({
+				job_id: syntheticJobId,
+				instance_id: null,
+				instance_deleted: false,
+				kind: 'create_instance',
+				status: 'running',
+				execution_mode: 'normal',
+				provider: options.modpackProjectId ? 'modrinth' : 'local',
+				target: { type: 'new_instance' },
+				phase: 'downloading_content',
+				details: { type: 'empty' },
+				created: now,
+				modified: ts,
+				display: {
+					title: options.modpackTitle ?? 'Server',
+					icon: options.modpackIconUrl ?? null,
+				},
+				summary: {
+					files_completed: 0,
+					files_total: null,
+					bytes_downloaded: payload.downloaded,
+					bytes_total: total,
+					speed_bytes_per_second: speed,
+					eta_seconds: eta,
+					source: null,
+					fallback_count: 0,
+				},
+				items: [],
+			})
+		}
 	})
 	const unlistenLogs = await serverEventListener((id, payload) => {
 		if (id !== serverId || payload.event !== 'log') return
 		entry.log.push(payload.line)
 		if (entry.log.length > LOG_CAPACITY) entry.log.splice(0, entry.log.length - LOG_CAPACITY)
 	})
+
+	// [SERVER-DOWNLOAD-BRIDGE] Register a cancel handler so the Downloads page
+	// can abort the running server install when the user clicks Cancel.
+	let cancelled = false
+	if (downloadManager) {
+		downloadManager.onSyntheticCancel(syntheticJobId, async () => {
+			cancelled = true
+			console.log(`[SERVER-DOWNLOAD-BRIDGE] Cancelling server install ${serverId}`)
+			await servers.stop(serverId).catch(() => {})
+		})
+	}
+
+	let installSucceeded = false
 	try {
 		await servers.installModpack(serverId, options)
+		installSucceeded = true
 	} finally {
 		unlistenProgress()
 		unlistenLogs()
+		if (downloadManager) {
+			downloadManager.offSyntheticCancel(syntheticJobId)
+		}
+		// [SERVER-DOWNLOAD-BRIDGE] Mark the synthetic job as succeeded, failed,
+		// or cancelled so it transitions out of the active tab and into history.
+		if (downloadManager && !cancelled) {
+			const ts = new Date().toISOString()
+			console.log(
+				`[SERVER-DOWNLOAD-BRIDGE] Finalising synthetic job ${syntheticJobId}: ${installSucceeded ? 'succeeded' : 'failed'}`,
+			)
+			downloadManager.setSyntheticJob({
+				job_id: syntheticJobId,
+				instance_id: null,
+				instance_deleted: false,
+				kind: 'create_instance',
+				status: installSucceeded ? 'succeeded' : 'failed',
+				execution_mode: 'normal',
+				provider: options.modpackProjectId ? 'modrinth' : 'local',
+				target: { type: 'new_instance' },
+				phase: installSucceeded ? 'completed' : 'downloading_content',
+				details: { type: 'empty' },
+				created: now,
+				modified: ts,
+				finished: ts,
+				display: {
+					title: options.modpackTitle ?? 'Server',
+					icon: options.modpackIconUrl ?? null,
+				},
+				summary: {
+					files_completed: 0,
+					files_total: null,
+					bytes_downloaded: entry.progress?.downloaded ?? 0,
+					bytes_total: entry.progress?.total ?? null,
+					speed_bytes_per_second: null,
+					eta_seconds: null,
+					source: null,
+					fallback_count: 0,
+				},
+				items: [],
+			})
+		}
 		activeInstalls[serverId] = undefined
 		void refreshServerList()
 	}
 }
 
 /**
- * Resumes an interrupted or failed modpack install for a server created from a
- * modpack: re-resolves the pack file and launcher jar from the recorded source
- * project, then reruns the same background install.
+ * [SERVER-DOWNLOAD-BRIDGE] Resumes an interrupted or failed modpack install
+ * for a server created from a modpack: re-resolves the pack file and launcher
+ * jar from the recorded source project, then reruns the same background install.
+ *
+ * The optional `downloadManager` parameter is forwarded to
+ * `startModpackServerInstall` so the synthetic job appears in sidebar.
+ * See the note in `startModpackServerInstall` for why this must be passed
+ * explicitly.
  */
-export async function resumeModpackInstall(server: ServerInfoData): Promise<void> {
+export async function resumeModpackInstall(
+	server: ServerInfoData,
+	downloadManager?: import('@/providers/download-manager').DownloadManager | null,
+): Promise<void> {
 	const modpack = server.modpack
 	if (!modpack?.versionId) {
 		throw new Error('This server has no modpack source to resume from')
@@ -101,15 +275,19 @@ export async function resumeModpackInstall(server: ServerInfoData): Promise<void
 			`No server launcher available for ${server.serverType} on ${server.gameVersion}`,
 		)
 	}
-	await startModpackServerInstall(server.id, {
-		mrpackUrl: primaryFile.url,
-		mrpackSha1: primaryFile.hashes?.sha1,
-		jarUrl: jar.url,
-		jarFilename: jar.filename,
-		jarSha1: jar.sha1,
-		modpackProjectId: modpack.projectId,
-		modpackVersionId: modpack.versionId,
-		modpackTitle: modpack.title,
-		modpackIconUrl: modpack.iconUrl,
-	})
+	await startModpackServerInstall(
+		server.id,
+		{
+			mrpackUrl: primaryFile.url,
+			mrpackSha1: primaryFile.hashes?.sha1,
+			jarUrl: jar.url,
+			jarFilename: jar.filename,
+			jarSha1: jar.sha1,
+			modpackProjectId: modpack.projectId,
+			modpackVersionId: modpack.versionId,
+			modpackTitle: modpack.title,
+			modpackIconUrl: modpack.iconUrl,
+		},
+		downloadManager,
+	)
 }

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -1,0 +1,115 @@
+import type { Labrinth } from '@modrinth/api-client'
+import { reactive } from 'vue'
+
+import { get_version } from '@/helpers/cache.js'
+import { resolveServerLauncher } from '@/components/multiplayer/servers/server-flow-utils'
+import {
+	serverEventListener,
+	type InstallModpackOptions,
+	type ServerInfoData,
+	servers,
+} from '@/helpers/servers'
+
+import { refresh as refreshServerList } from './useServers'
+
+const LOG_CAPACITY = 500
+
+export interface ActiveServerInstall {
+	progress: { downloaded: number; total: number | null } | null
+	log: string[]
+}
+
+/**
+ * Why a server's start controls are replaced by download actions:
+ * - `installing`: files are transferring right now (this app session)
+ * - `interrupted`: the manifest was flagged mid-install and never finished
+ *   (app closed while downloading); resumable
+ * - `failed`: the last install attempt errored; retryable
+ */
+export type ServerSetupStatus = 'installing' | 'interrupted' | 'failed'
+
+/** Module-level singleton: install activity is global to the app. */
+const activeInstalls = reactive<Record<string, ActiveServerInstall>>({})
+
+export function activeInstallFor(serverId: string): ActiveServerInstall | null {
+	return activeInstalls[serverId] ?? null
+}
+
+export function serverSetupStatus(server: ServerInfoData): ServerSetupStatus | null {
+	if (activeInstalls[server.id]) return 'installing'
+	if (server.installState === 'incomplete') return 'interrupted'
+	if (server.installState === 'failed') return 'failed'
+	return null
+}
+
+/**
+ * Runs a modpack server install in the background: progress and log events are
+ * tracked in the shared registry so any surface (wizard, servers list, detail
+ * page) can render live state, and callers only await completion.
+ */
+export async function startModpackServerInstall(
+	serverId: string,
+	options: InstallModpackOptions,
+): Promise<void> {
+	if (activeInstalls[serverId]) {
+		throw new Error('This server already has an install running')
+	}
+	const entry: ActiveServerInstall = { progress: null, log: [] }
+	activeInstalls[serverId] = entry
+
+	const unlistenProgress = await serverEventListener((id, payload) => {
+		if (id !== serverId || payload.event !== 'download_progress') return
+		entry.progress = { downloaded: payload.downloaded, total: payload.total ?? null }
+	})
+	const unlistenLogs = await serverEventListener((id, payload) => {
+		if (id !== serverId || payload.event !== 'log') return
+		entry.log.push(payload.line)
+		if (entry.log.length > LOG_CAPACITY) entry.log.splice(0, entry.log.length - LOG_CAPACITY)
+	})
+	try {
+		await servers.installModpack(serverId, options)
+	} finally {
+		unlistenProgress()
+		unlistenLogs()
+		delete activeInstalls[serverId]
+		void refreshServerList()
+	}
+}
+
+/**
+ * Resumes an interrupted or failed modpack install for a server created from a
+ * modpack: re-resolves the pack file and launcher jar from the recorded source
+ * project, then reruns the same background install.
+ */
+export async function resumeModpackInstall(server: ServerInfoData): Promise<void> {
+	const modpack = server.modpack
+	if (!modpack?.versionId) {
+		throw new Error('This server has no modpack source to resume from')
+	}
+	const version = (await get_version(modpack.versionId)) as Labrinth.Versions.v2.Version
+	const primaryFile = version.files.find((file) => file.primary) ?? version.files[0]
+	if (!primaryFile?.url) {
+		throw new Error('Modpack has no downloadable file')
+	}
+	const jar = await resolveServerLauncher(
+		server.serverType,
+		server.gameVersion,
+		server.loaderVersion,
+	)
+	if (!jar) {
+		throw new Error(
+			`No server launcher available for ${server.serverType} on ${server.gameVersion}`,
+		)
+	}
+	await startModpackServerInstall(server.id, {
+		mrpackUrl: primaryFile.url,
+		mrpackSha1: primaryFile.hashes?.sha1,
+		jarUrl: jar.url,
+		jarFilename: jar.filename,
+		jarSha1: jar.sha1,
+		modpackProjectId: modpack.projectId,
+		modpackVersionId: modpack.versionId,
+		modpackTitle: modpack.title,
+		modpackIconUrl: modpack.iconUrl,
+	})
+}

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -1,11 +1,11 @@
 import type { Labrinth } from '@modrinth/api-client'
 import { reactive } from 'vue'
 
-import { get_version } from '@/helpers/cache.js'
 import { resolveServerLauncher } from '@/components/multiplayer/servers/server-flow-utils'
+import { get_version } from '@/helpers/cache.js'
 import {
-	serverEventListener,
 	type InstallModpackOptions,
+	serverEventListener,
 	type ServerInfoData,
 	servers,
 } from '@/helpers/servers'
@@ -29,7 +29,7 @@ export interface ActiveServerInstall {
 export type ServerSetupStatus = 'installing' | 'interrupted' | 'failed'
 
 /** Module-level singleton: install activity is global to the app. */
-const activeInstalls = reactive<Record<string, ActiveServerInstall>>({})
+const activeInstalls = reactive<Record<string, ActiveServerInstall | undefined>>({})
 
 export function activeInstallFor(serverId: string): ActiveServerInstall | null {
 	return activeInstalls[serverId] ?? null
@@ -71,7 +71,7 @@ export async function startModpackServerInstall(
 	} finally {
 		unlistenProgress()
 		unlistenLogs()
-		delete activeInstalls[serverId]
+		activeInstalls[serverId] = undefined
 		void refreshServerList()
 	}
 }

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -10,6 +10,7 @@ import {
 	servers,
 } from '@/helpers/servers'
 
+import { createServerDownloadBridge } from './server-download-bridge'
 import { refresh as refreshServerList } from './useServers'
 
 const LOG_CAPACITY = 500
@@ -71,44 +72,18 @@ export async function startModpackServerInstall(
 
 	// [SERVER-DOWNLOAD-BRIDGE] Create a synthetic job that mirrors this server
 	// install in the global Downloads page.  The job_id uses a `server-` prefix
-	// to avoid collisions with backend-tracked install jobs.
+	// to avoid collisions with backend-tracked install jobs.  The shared bridge
+	// centralises the snapshot shape used by every server download (modpack and
+	// vanilla) so they stay consistent in the sidebar.
 	const syntheticJobId = `server-${serverId}`
-	const now = new Date().toISOString()
-
-	if (downloadManager) {
-		console.log(
-			`[SERVER-DOWNLOAD-BRIDGE] Creating synthetic job ${syntheticJobId} for server "${options.modpackTitle}"`,
-		)
-		downloadManager.addSyntheticJob({
-			job_id: syntheticJobId,
-			instance_id: null,
-			instance_deleted: false,
-			kind: 'create_instance',
-			status: 'running',
-			execution_mode: 'normal',
-			provider: options.modpackProjectId ? 'modrinth' : 'local',
-			target: { type: 'new_instance' },
-			phase: 'downloading_content',
-			details: { type: 'empty' },
-			created: now,
-			modified: now,
-			display: {
+	const bridge = downloadManager
+		? createServerDownloadBridge(downloadManager, syntheticJobId, {
 				title: options.modpackTitle ?? 'Server',
 				icon: options.modpackIconUrl ?? null,
-			},
-			summary: {
-				files_completed: 0,
-				files_total: null,
-				bytes_downloaded: 0,
-				bytes_total: null,
-				speed_bytes_per_second: null,
-				eta_seconds: null,
-				source: null,
-				fallback_count: 0,
-			},
-			items: [],
-		})
-	} else {
+				provider: options.modpackProjectId ? 'modrinth' : 'local',
+			})
+		: null
+	if (!bridge) {
 		console.warn(
 			`[SERVER-DOWNLOAD-BRIDGE] No download manager available — job ${syntheticJobId} will NOT appear in sidebar`,
 		)
@@ -139,38 +114,7 @@ export async function startModpackServerInstall(
 			? (total - payload.downloaded) / speed
 			: null
 
-		if (downloadManager) {
-			const ts = new Date().toISOString()
-			downloadManager.setSyntheticJob({
-				job_id: syntheticJobId,
-				instance_id: null,
-				instance_deleted: false,
-				kind: 'create_instance',
-				status: 'running',
-				execution_mode: 'normal',
-				provider: options.modpackProjectId ? 'modrinth' : 'local',
-				target: { type: 'new_instance' },
-				phase: 'downloading_content',
-				details: { type: 'empty' },
-				created: now,
-				modified: ts,
-				display: {
-					title: options.modpackTitle ?? 'Server',
-					icon: options.modpackIconUrl ?? null,
-				},
-				summary: {
-					files_completed: 0,
-					files_total: null,
-					bytes_downloaded: payload.downloaded,
-					bytes_total: total,
-					speed_bytes_per_second: speed,
-					eta_seconds: eta,
-					source: null,
-					fallback_count: 0,
-				},
-				items: [],
-			})
-		}
+		bridge?.update({ downloaded: payload.downloaded, total }, speed, eta)
 	})
 	const unlistenLogs = await serverEventListener((id, payload) => {
 		if (id !== serverId || payload.event !== 'log') return
@@ -180,14 +124,10 @@ export async function startModpackServerInstall(
 
 	// [SERVER-DOWNLOAD-BRIDGE] Register a cancel handler so the Downloads page
 	// can abort the running server install when the user clicks Cancel.
-	let cancelled = false
-	if (downloadManager) {
-		downloadManager.onSyntheticCancel(syntheticJobId, async () => {
-			cancelled = true
-			console.log(`[SERVER-DOWNLOAD-BRIDGE] Cancelling server install ${serverId}`)
-			await servers.stop(serverId).catch(() => {})
-		})
-	}
+	bridge?.cancel(async () => {
+		console.log(`[SERVER-DOWNLOAD-BRIDGE] Cancelling server install ${serverId}`)
+		await servers.stop(serverId).catch(() => {})
+	})
 
 	let installSucceeded = false
 	try {
@@ -196,47 +136,9 @@ export async function startModpackServerInstall(
 	} finally {
 		unlistenProgress()
 		unlistenLogs()
-		if (downloadManager) {
-			downloadManager.offSyntheticCancel(syntheticJobId)
-		}
-		// [SERVER-DOWNLOAD-BRIDGE] Mark the synthetic job as succeeded, failed,
-		// or cancelled so it transitions out of the active tab and into history.
-		if (downloadManager && !cancelled) {
-			const ts = new Date().toISOString()
-			console.log(
-				`[SERVER-DOWNLOAD-BRIDGE] Finalising synthetic job ${syntheticJobId}: ${installSucceeded ? 'succeeded' : 'failed'}`,
-			)
-			downloadManager.setSyntheticJob({
-				job_id: syntheticJobId,
-				instance_id: null,
-				instance_deleted: false,
-				kind: 'create_instance',
-				status: installSucceeded ? 'succeeded' : 'failed',
-				execution_mode: 'normal',
-				provider: options.modpackProjectId ? 'modrinth' : 'local',
-				target: { type: 'new_instance' },
-				phase: installSucceeded ? 'completed' : 'downloading_content',
-				details: { type: 'empty' },
-				created: now,
-				modified: ts,
-				finished: ts,
-				display: {
-					title: options.modpackTitle ?? 'Server',
-					icon: options.modpackIconUrl ?? null,
-				},
-				summary: {
-					files_completed: 0,
-					files_total: null,
-					bytes_downloaded: entry.progress?.downloaded ?? 0,
-					bytes_total: entry.progress?.total ?? null,
-					speed_bytes_per_second: null,
-					eta_seconds: null,
-					source: null,
-					fallback_count: 0,
-				},
-				items: [],
-			})
-		}
+		// [SERVER-DOWNLOAD-BRIDGE] Mark the synthetic job as succeeded or failed
+		// so it transitions out of the active tab and into history.
+		bridge?.complete(installSucceeded, entry.progress ?? undefined)
 		activeInstalls[serverId] = undefined
 		void refreshServerList()
 	}

--- a/apps/app-frontend/src/composables/useServerLifecycle.ts
+++ b/apps/app-frontend/src/composables/useServerLifecycle.ts
@@ -1,9 +1,11 @@
-import { setEulaAccepted } from '@modrinth/server'
-import { ref, useTemplateRef } from 'vue'
+import { parseEula, setEulaAccepted } from '@modrinth/server'
+import { injectNotificationManager } from '@modrinth/ui'
+import { onScopeDispose, ref, useTemplateRef } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
-import type EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
-import { type ServerView, useServers } from '@/composables/useServers'
+import EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
+import { type ServerView, setServerExitReasonHandler, useServers } from '@/composables/useServers'
+import { resumeModpackInstall } from '@/composables/useServerInstalls'
 import { servers as serversApi } from '@/helpers/servers'
 
 /**
@@ -13,6 +15,7 @@ import { servers as serversApi } from '@/helpers/servers'
  */
 export function useServerLifecycle() {
 	const { startServer } = useServers()
+	const { handleError } = injectNotificationManager()
 
 	const eulaModal = useTemplateRef<ComponentExposed<typeof EulaModal>>('eulaModal')
 	const eulaText = ref('')
@@ -30,7 +33,25 @@ export function useServerLifecycle() {
 				// No eula.txt: a fresh start will generate it
 			}
 		}
-		await startServer(server.id)
+		await launchServer(server.id)
+	}
+
+	/**
+	 * Starts the server and, when the start itself fails over an unaccepted
+	 * EULA, falls back to the confirmation dialog instead of just the error.
+	 */
+	async function launchServer(serverId: string) {
+		const started = await startServer(serverId)
+		if (started) return
+		try {
+			const text = await serversApi.readFile(serverId, 'eula.txt')
+			if (parseEula(text).accepted) return
+			eulaText.value = text
+			pendingId = serverId
+			eulaModal.value?.show()
+		} catch {
+			// Start failed for a non-EULA reason; that error was already surfaced.
+		}
 	}
 
 	async function acceptEula() {
@@ -52,5 +73,36 @@ export function useServerLifecycle() {
 		eulaModal.value?.hide()
 	}
 
-	return { eulaModal, eulaText, tryStartServer, acceptEula, declineEula }
+	/**
+	 * Offers the EULA dialog after the server exited on its own over an
+	 * unaccepted EULA (detected from the process's final output). Accepting
+	 * writes `eula.txt` and restarts, matching the pre-start gate.
+	 */
+	async function offerEulaAfterExit(serverId: string) {
+		try {
+			const text = await serversApi.readFile(serverId, 'eula.txt')
+			if (parseEula(text).accepted) return
+			eulaText.value = text
+			pendingId = serverId
+			eulaModal.value?.show()
+		} catch {
+			// No eula.txt to show; the exit stays unexplained.
+		}
+	}
+
+	const unregisterExitReasonHandler = setServerExitReasonHandler((serverId, reason) => {
+		if (reason === 'eula') void offerEulaAfterExit(serverId)
+	})
+	onScopeDispose(unregisterExitReasonHandler)
+
+	/** Resumes or retries an interrupted/failed modpack download for this server. */
+	async function resumeInstall(server: ServerView) {
+		try {
+			await resumeModpackInstall(server)
+		} catch (error) {
+			handleError(error)
+		}
+	}
+
+	return { eulaModal, eulaText, tryStartServer, acceptEula, declineEula, resumeInstall }
 }

--- a/apps/app-frontend/src/composables/useServerLifecycle.ts
+++ b/apps/app-frontend/src/composables/useServerLifecycle.ts
@@ -104,5 +104,5 @@ export function useServerLifecycle() {
 		}
 	}
 
-	return { eulaModal, eulaText, tryStartServer, acceptEula, declineEula, resumeInstall }
+	return { eulaModal, eulaText, tryStartServer, acceptEula, declineEula, resumeInstall, offerEulaAfterExit }
 }

--- a/apps/app-frontend/src/composables/useServerLifecycle.ts
+++ b/apps/app-frontend/src/composables/useServerLifecycle.ts
@@ -46,25 +46,41 @@ export function useServerLifecycle() {
 		unregisterEulaListener?.()
 	})
 
-	/** Starts the server; if the EULA is unaccepted, shows the EULA modal first. */
+	/**
+	 * Starts the server, gating on the EULA file:
+	 * - eula.txt missing → code-create it with `eula=false`, then show the modal
+	 * - eula.txt present and `eula=false` → show the modal
+	 * - eula.txt present and `eula=true` → start directly
+	 */
 	async function tryStartServer(server: ServerView) {
-		// Always check the actual eula.txt file on the server
-		try {
-			const eulaTextContent = await serversApi.readFile(server.id, 'eula.txt')
-			const accepted = eulaTextContent.split('\n').some(line => line.trim() === 'eula=true')
-			
-			if (!accepted) {
-				// EULA not accepted, show modal
-				eulaText.value = eulaTextContent
-				pendingId = server.id
-				eulaModal.value?.show()
-				return
-			}
-		} catch {
-			// eula.txt doesn't exist yet, will be created by the server
+		const accepted = await ensureEula(server.id)
+		if (accepted) {
+			await launchServer(server.id)
+		} else {
+			pendingId = server.id
+			eulaModal.value?.show()
 		}
-		
-		await launchServer(server.id)
+	}
+
+	/**
+	 * Reads the server's eula.txt. When absent, writes a code-created
+	 * `eula=false` file so the acceptance prompt can be shown without booting
+	 * the server. Returns whether the EULA is already accepted.
+	 */
+	async function ensureEula(serverId: string): Promise<boolean> {
+		let text: string
+		try {
+			text = await serversApi.readFile(serverId, 'eula.txt')
+		} catch {
+			// eula.txt doesn't exist yet — code-create it with eula=false so the
+			// manual start gate can offer the prompt without starting the jar.
+			text = setEulaAccepted('', false)
+			await serversApi.writeFile(serverId, 'eula.txt', text).catch(() => {})
+		}
+		const doc = parseEula(text)
+		if (doc.accepted) return true
+		eulaText.value = text
+		return false
 	}
 
 	/**

--- a/apps/app-frontend/src/composables/useServerLifecycle.ts
+++ b/apps/app-frontend/src/composables/useServerLifecycle.ts
@@ -3,10 +3,10 @@ import { injectNotificationManager } from '@modrinth/ui'
 import { onScopeDispose, ref, useTemplateRef } from 'vue'
 import type { ComponentExposed } from 'vue-component-type-helpers'
 
-import EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
-import { type ServerView, setServerExitReasonHandler, useServers } from '@/composables/useServers'
+import type EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
 import { resumeModpackInstall } from '@/composables/useServerInstalls'
-import { servers as serversApi } from '@/helpers/servers'
+import { type ServerView, setServerExitReasonHandler, useServers } from '@/composables/useServers'
+import { serverEventListener,servers as serversApi } from '@/helpers/servers'
 
 /**
  * Shared "start with EULA gate" flow used by the servers overview and the
@@ -21,18 +21,38 @@ export function useServerLifecycle() {
 	const eulaText = ref('')
 	let pendingId = ''
 
+	// Listen for real-time EULA prompt detection from the Rust backend
+	let unregisterEulaListener: (() => void) | null = null
+	serverEventListener((serverId, payload) => {
+		if (payload.event === 'eula_required' && payload.server_id === pendingId) {
+			eulaText.value = payload.eula_text
+			eulaModal.value?.show()
+		}
+	}).then((unregister) => {
+		unregisterEulaListener = unregister
+	})
+	onScopeDispose(() => {
+		unregisterEulaListener?.()
+	})
+
 	/** Starts the server; if the EULA is unaccepted, shows the EULA modal first. */
 	async function tryStartServer(server: ServerView) {
-		if (!server.eulaAccepted && server.eulaExists) {
-			try {
-				eulaText.value = await serversApi.readFile(server.id, 'eula.txt')
+		// Always check the actual eula.txt file on the server
+		try {
+			const eulaTextContent = await serversApi.readFile(server.id, 'eula.txt')
+			const accepted = eulaTextContent.split('\n').some(line => line.trim() === 'eula=true')
+			
+			if (!accepted) {
+				// EULA not accepted, show modal
+				eulaText.value = eulaTextContent
 				pendingId = server.id
 				eulaModal.value?.show()
 				return
-			} catch {
-				// No eula.txt: a fresh start will generate it
 			}
+		} catch {
+			// eula.txt doesn't exist yet, will be created by the server
 		}
+		
 		await launchServer(server.id)
 	}
 
@@ -62,6 +82,7 @@ export function useServerLifecycle() {
 			await serversApi.writeFile(id, 'eula.txt', updated)
 			pendingId = ''
 			eulaModal.value?.hide()
+			// Start the server after accepting EULA
 			await startServer(id)
 		} catch (error) {
 			console.error(error)

--- a/apps/app-frontend/src/composables/useServerLifecycle.ts
+++ b/apps/app-frontend/src/composables/useServerLifecycle.ts
@@ -7,6 +7,7 @@ import type EulaModal from '@/components/multiplayer/servers/EulaModal.vue'
 import { resumeModpackInstall } from '@/composables/useServerInstalls'
 import { type ServerView, setServerExitReasonHandler, useServers } from '@/composables/useServers'
 import { serverEventListener,servers as serversApi } from '@/helpers/servers'
+import { injectDownloadManager } from '@/providers/download-manager'
 
 /**
  * Shared "start with EULA gate" flow used by the servers overview and the
@@ -16,6 +17,16 @@ import { serverEventListener,servers as serversApi } from '@/helpers/servers'
 export function useServerLifecycle() {
 	const { startServer } = useServers()
 	const { handleError } = injectNotificationManager()
+
+	// [SERVER-DOWNLOAD-BRIDGE] Capture the download manager once during Vue
+	// setup context.  See the note in `startModpackServerInstall` for why
+	// this must be done here and not later.
+	let downloadManager: ReturnType<typeof injectDownloadManager> | null = null
+	try {
+		downloadManager = injectDownloadManager()
+	} catch {
+		// Not inside a provider tree — server downloads will not appear in sidebar.
+	}
 
 	const eulaModal = useTemplateRef<ComponentExposed<typeof EulaModal>>('eulaModal')
 	const eulaText = ref('')
@@ -119,7 +130,9 @@ export function useServerLifecycle() {
 	/** Resumes or retries an interrupted/failed modpack download for this server. */
 	async function resumeInstall(server: ServerView) {
 		try {
-			await resumeModpackInstall(server)
+			// [SERVER-DOWNLOAD-BRIDGE] Pass the download manager captured
+			// during setup so the synthetic job appears in sidebar.
+			await resumeModpackInstall(server, downloadManager)
 		} catch (error) {
 			handleError(error)
 		}

--- a/apps/app-frontend/src/composables/useServers.ts
+++ b/apps/app-frontend/src/composables/useServers.ts
@@ -108,6 +108,7 @@ export function useServers() {
 	}
 
 	async function startServer(serverId: string) {
+		await ensureListener()
 		logLines[serverId] = []
 		const ok = await run(() => servers.start(serverId))
 		if (ok) await refresh()

--- a/apps/app-frontend/src/composables/useServers.ts
+++ b/apps/app-frontend/src/composables/useServers.ts
@@ -2,9 +2,26 @@ import { computeServerStatus, type ServerStatus } from '@modrinth/server'
 import { injectNotificationManager } from '@modrinth/ui'
 import { computed, reactive, ref } from 'vue'
 
-import { serverEventListener, type ServerInfoData, servers } from '@/helpers/servers'
+import { serverEventListener, type ServerExitReason, type ServerInfoData, servers } from '@/helpers/servers'
 
 const LOG_CAPACITY = 5000
+
+/** Reacts to a classified server self-exit, e.g. opening the EULA dialog. */
+type ServerExitReasonHandler = (serverId: string, reason: ServerExitReason) => void
+let exitReasonHandler: ServerExitReasonHandler | null = null
+
+/**
+ * Registers the single handler invoked when a server exits with a classified
+ * reason. Returns a disposer that only clears the handler while it is still
+ * the registered one.
+ */
+export function setServerExitReasonHandler(handler: ServerExitReasonHandler | null) {
+	const registered = handler
+	exitReasonHandler = handler
+	return () => {
+		if (exitReasonHandler === registered) exitReasonHandler = null
+	}
+}
 
 const serverList = ref<ServerInfoData[]>([])
 const logLines = reactive<Record<string, string[]>>({})
@@ -37,8 +54,11 @@ async function ensureListener() {
 		listenerPromise = serverEventListener((serverId, payload) => {
 			if (payload.event === 'log') {
 				void appendLog(serverId, payload.line)
-			} else if (payload.event === 'started' || payload.event === 'stopped') {
+			} else if (payload.event === 'started') {
 				void refresh()
+			} else if (payload.event === 'stopped') {
+				void refresh()
+				if (payload.reason) exitReasonHandler?.(serverId, payload.reason)
 			}
 		})
 	}

--- a/apps/app-frontend/src/helpers/gc/auto-selector.ts
+++ b/apps/app-frontend/src/helpers/gc/auto-selector.ts
@@ -1,4 +1,4 @@
-import { GC_STRATEGY_DEFINITIONS } from './strategies'
+import { GC_STRATEGY_DEFINITIONS } from './strategies.ts'
 import type { GcContext, GcResolution, ResolvedGcStrategyId } from './types'
 
 export function resolveAutoGcArgs(context: GcContext): string {
@@ -98,4 +98,4 @@ export function getResolvedStrategyName(strategyId: ResolvedGcStrategyId): strin
 
 // Re-exported from strategies so callers can keep importing from the
 // auto-selector module while the chain stays testable via `node --test`.
-export { buildGcCandidateChain } from './strategies'
+export { buildGcCandidateChain } from './strategies.ts'

--- a/apps/app-frontend/src/helpers/gc/index.ts
+++ b/apps/app-frontend/src/helpers/gc/index.ts
@@ -5,7 +5,7 @@ export {
 } from './auto-selector'
 export { collectGcContext } from './context'
 export { createGcPresets, getAutoResolution, getResolvedStrategyDisplayName } from './gc-presets'
-export { detectGcStrategy, GC_STRATEGY_DEFINITIONS, getStrategyBaseArgs } from './strategies'
+export { detectGcStrategy, GC_STRATEGY_DEFINITIONS, getStrategyBaseArgs } from './strategies.ts'
 export type {
 	GcContext,
 	GcResolution,

--- a/apps/app-frontend/src/helpers/import.js
+++ b/apps/app-frontend/src/helpers/import.js
@@ -36,6 +36,7 @@ export async function get_importable_instances(launcherType, basePath) {
 }
 
 /// Import an instance from a launcher type and base path
+/** @param {string|undefined} instancePath @param {string|undefined} gameVersion @param {string|undefined} loader @param {string|undefined} loaderVersion @param {string|null|undefined} gameDirOverride */
 export async function import_instance(
 	launcherType,
 	basePath,

--- a/apps/app-frontend/src/helpers/servers.ts
+++ b/apps/app-frontend/src/helpers/servers.ts
@@ -36,11 +36,13 @@ export interface ServerInfoData extends ServerManifestData {
 	port: number | null
 }
 
+export type ServerExitReason = 'eula'
+
 export type ServerEventPayload =
 	| { event: 'log'; line: string }
 	| { event: 'download_progress'; downloaded: number; total?: number }
 	| { event: 'started' }
-	| { event: 'stopped'; crashed: boolean }
+	| { event: 'stopped'; crashed: boolean; reason?: ServerExitReason }
 
 export interface PortProcessInfoData {
 	pid: number

--- a/apps/app-frontend/src/helpers/servers.ts
+++ b/apps/app-frontend/src/helpers/servers.ts
@@ -43,6 +43,7 @@ export type ServerEventPayload =
 	| { event: 'download_progress'; downloaded: number; total?: number }
 	| { event: 'started' }
 	| { event: 'stopped'; crashed: boolean; reason?: ServerExitReason }
+	| { event: 'eula_required'; server_id: string; eula_text: string }
 
 export interface PortProcessInfoData {
 	pid: number

--- a/apps/app-frontend/src/helpers/servers.ts
+++ b/apps/app-frontend/src/helpers/servers.ts
@@ -3,10 +3,10 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 
 export interface ModpackInfoData {
-	project_id: string
-	version_id: string
+	projectId: string
+	versionId: string
 	title: string
-	icon_url?: string
+	iconUrl?: string
 }
 
 export interface ServerManifestData {
@@ -18,6 +18,8 @@ export interface ServerManifestData {
 	jarName?: string
 	iconPath?: string
 	modpack?: ModpackInfoData
+	installState?: 'incomplete' | 'failed' | null
+	installError?: string | null
 	javaPath?: string
 	memoryMb?: number
 	jvmArgs: string[]

--- a/apps/app-frontend/src/helpers/servers.ts
+++ b/apps/app-frontend/src/helpers/servers.ts
@@ -2,6 +2,13 @@ import type { ServerTypeId } from '@modrinth/server'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 
+export interface ModpackInfoData {
+	project_id: string
+	version_id: string
+	title: string
+	icon_url?: string
+}
+
 export interface ServerManifestData {
 	id: string
 	name: string
@@ -10,6 +17,7 @@ export interface ServerManifestData {
 	loaderVersion?: string
 	jarName?: string
 	iconPath?: string
+	modpack?: ModpackInfoData
 	javaPath?: string
 	memoryMb?: number
 	jvmArgs: string[]
@@ -35,6 +43,18 @@ export type ServerEventPayload =
 export interface PortProcessInfoData {
 	pid: number
 	name?: string | null
+}
+
+export interface InstallModpackOptions {
+	mrpackUrl: string
+	mrpackSha1?: string
+	jarUrl: string
+	jarFilename: string
+	jarSha1?: string
+	modpackProjectId?: string
+	modpackVersionId?: string
+	modpackTitle?: string
+	modpackIconUrl?: string
 }
 
 const command = (name: string) => `plugin:servers|${name}`
@@ -73,6 +93,8 @@ export const servers = {
 			filename,
 			expectedSha1,
 		}),
+	installModpack: (serverId: string, options: InstallModpackOptions) =>
+		invoke<void>(command('servers_install_modpack'), { serverId, ...options }),
 	start: (
 		serverId: string,
 		options?: { javaPath?: string; memoryMb?: number; jvmArgs?: string[] },

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6392,6 +6392,9 @@
   "app.servers.status.starting": {
     "message": "Starting"
   },
+  "app.servers.wizard.background-hint": {
+    "message": "You can close this window — the download continues in the background."
+  },
   "app.servers.wizard.configure-heading": {
     "message": "Adjust the server settings, or finish to edit them later."
   },
@@ -6400,6 +6403,9 @@
   },
   "app.servers.wizard.done": {
     "message": "Server ready"
+  },
+  "app.servers.wizard.download-in-background": {
+    "message": "Download in background"
   },
   "app.servers.wizard.downloading": {
     "message": "Downloading server files..."

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -5990,11 +5990,14 @@
   "app.servers.eula.accept": {
     "message": "Accept and continue"
   },
+  "app.servers.eula.continue": {
+    "message": "Continue"
+  },
   "app.servers.eula.decline": {
     "message": "Cancel"
   },
   "app.servers.eula.description": {
-    "message": "The server must accept the Minecraft End User License Agreement before it can start. Review the notice below:"
+    "message": "By continuing, you agree to the Minecraft End User License Agreement (EULA)."
   },
   "app.servers.eula.title": {
     "message": "Minecraft EULA"
@@ -6371,6 +6374,9 @@
   "app.servers.status.crashed": {
     "message": "Crashed"
   },
+  "app.servers.status.downloading": {
+    "message": "Downloading"
+  },
   "app.servers.status.created": {
     "message": "Not set up"
   },
@@ -6451,6 +6457,15 @@
   },
   "app.servers.wizard.type-title": {
     "message": "Server type"
+  },
+  "app.servers.modpack.downloading": {
+    "message": "Downloading modpack files..."
+  },
+  "app.servers.modpack.preparing": {
+    "message": "Preparing server..."
+  },
+  "app.servers.modpack.done": {
+    "message": "Installation complete"
   },
   "app.settings.about.afdian": {
     "message": "Support on Afdian"

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -5798,6 +5798,18 @@
   "app.project.install-context.install-content-to-instance": {
     "message": "Install content to instance"
   },
+  "app.project.modpack-server.created-description": {
+    "message": "{name} is ready. Configure and start it in Multiplayer."
+  },
+  "app.project.modpack-server.created-title": {
+    "message": "Server created"
+  },
+  "app.project.modpack-server.open": {
+    "message": "Open server"
+  },
+  "app.project.modpack-server.start": {
+    "message": "Start server"
+  },
   "app.project.mcarchive.install": {
     "message": "Install"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6044,11 +6044,14 @@
 	"app.servers.eula.accept": {
 		"message": "同意并继续"
 	},
+	"app.servers.eula.continue": {
+		"message": "继续"
+	},
 	"app.servers.eula.decline": {
 		"message": "取消"
 	},
 	"app.servers.eula.description": {
-		"message": "服务器启动前需要同意 Minecraft 最终用户许可协议（EULA）。请查看以下内容："
+		"message": "继续即表示同意 Minecraft 最终用户许可协议 (EULA)。"
 	},
 	"app.servers.eula.title": {
 		"message": "Minecraft EULA"
@@ -6425,6 +6428,9 @@
 	"app.servers.status.crashed": {
 		"message": "已崩溃"
 	},
+	"app.servers.status.downloading": {
+		"message": "下载中"
+	},
 	"app.servers.status.created": {
 		"message": "未配置"
 	},
@@ -6523,6 +6529,9 @@
 	},
 	"app.servers.modpack.preparing": {
 		"message": "正在准备服务器..."
+	},
+	"app.servers.modpack.done": {
+		"message": "安装完成"
 	},
 	"app.servers.modpack.unsupported-loader-description": {
 		"message": "此整合包使用 {loader}，但 Axolotl 目前仅支持原版、Fabric 和 Quilt 整合包服务端。{loader} 支持即将推出。"

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6446,18 +6446,24 @@
 	"app.servers.status.starting": {
 		"message": "启动中"
 	},
-	"app.servers.wizard.configure-heading": {
-		"message": "调整服务器设置，或直接完成，稍后再编辑。"
-	},
+ 	"app.servers.wizard.background-hint": {
+ 		"message": "您可以关闭此窗口，下载将在后台继续进行。"
+ 	},
+ 	"app.servers.wizard.configure-heading": {
+ 		"message": "调整服务器设置，或直接完成，稍后再编辑。"
+ 	},
 	"app.servers.wizard.configure-title": {
 		"message": "配置"
 	},
 	"app.servers.wizard.done": {
 		"message": "服务器已就绪"
 	},
-	"app.servers.wizard.downloading": {
-		"message": "正在下载服务端文件…"
-	},
+ 	"app.servers.wizard.download-in-background": {
+ 		"message": "后台下载"
+ 	},
+ 	"app.servers.wizard.downloading": {
+ 		"message": "正在下载服务端文件…"
+ 	},
 	"app.servers.wizard.eula-wait": {
 		"message": "等待确认 EULA"
 	},

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -5852,6 +5852,18 @@
 	"app.project.install-context.install-content-to-instance": {
 		"message": "将内容安装到实例中"
 	},
+	"app.project.modpack-server.created-description": {
+		"message": "{name} 已就绪。请在多人游戏中配置并启动。"
+	},
+	"app.project.modpack-server.created-title": {
+		"message": "服务器已创建"
+	},
+	"app.project.modpack-server.open": {
+		"message": "打开服务器"
+	},
+	"app.project.modpack-server.start": {
+		"message": "开服"
+	},
 	"app.project.mcarchive.install": {
 		"message": "安装"
 	},
@@ -6493,6 +6505,30 @@
 	},
 	"app.servers.wizard.type-title": {
 		"message": "服务端类型"
+	},
+	"app.servers.modpack.background-hint": {
+		"message": "您可以关闭此窗口，下载将在后台继续进行。"
+	},
+	"app.servers.modpack.current-file": {
+		"message": "正在安装 {file}"
+	},
+	"app.servers.modpack.download-in-background": {
+		"message": "后台下载"
+	},
+	"app.servers.modpack.downloading": {
+		"message": "正在下载整合包文件..."
+	},
+	"app.servers.modpack.first-run-crashed": {
+		"message": "服务器在首次启动时崩溃。请检查所选 Java 版本是否兼容，然后重试。"
+	},
+	"app.servers.modpack.preparing": {
+		"message": "正在准备服务器..."
+	},
+	"app.servers.modpack.unsupported-loader-description": {
+		"message": "此整合包使用 {loader}，但 Axolotl 目前仅支持原版、Fabric 和 Quilt 整合包服务端。{loader} 支持即将推出。"
+	},
+	"app.servers.modpack.unsupported-loader-title": {
+		"message": "{loader} 服务端暂不支持"
 	},
 	"app.settings.about.afdian": {
 		"message": "在爱发电赞助"

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -6269,6 +6269,9 @@
   "app.servers.status.starting": {
     "message": "啟動中"
   },
+  "app.servers.wizard.background-hint": {
+    "message": "您可以關閉此視窗，下載將在背景繼續進行。"
+  },
   "app.servers.wizard.configure-heading": {
     "message": "調整伺服器設定，或直接完成，稍後再編輯。"
   },
@@ -6277,6 +6280,9 @@
   },
   "app.servers.wizard.done": {
     "message": "伺服器已就緒"
+  },
+  "app.servers.wizard.download-in-background": {
+    "message": "背景下載"
   },
   "app.servers.wizard.downloading": {
     "message": "正在下載伺服器端檔案…"

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -5873,11 +5873,14 @@
   "app.servers.eula.accept": {
     "message": "同意並繼續"
   },
+  "app.servers.eula.continue": {
+    "message": "繼續"
+  },
   "app.servers.eula.decline": {
     "message": "取消"
   },
   "app.servers.eula.description": {
-    "message": "伺服器啟動前需要同意 Minecraft 最終使用者授權條款（EULA）。請查看以下內容："
+    "message": "繼續即表示同意 Minecraft 最終使用者授權條款 (EULA)。"
   },
   "app.servers.eula.title": {
     "message": "Minecraft EULA"
@@ -6248,6 +6251,9 @@
   "app.servers.status.crashed": {
     "message": "已崩潰"
   },
+  "app.servers.status.downloading": {
+    "message": "下載中"
+  },
   "app.servers.status.created": {
     "message": "未設定"
   },
@@ -6331,6 +6337,9 @@
   },
   "app.servers.modpack.preparing": {
     "message": "正在準備伺服器..."
+  },
+  "app.servers.modpack.done": {
+    "message": "安裝完成"
   },
   "app.servers.modpack.current-file": {
     "message": "正在安裝 {file}"

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -5681,6 +5681,18 @@
   "app.project.install-context.install-content-to-instance": {
     "message": "將內容安裝至實例"
   },
+  "app.project.modpack-server.created-description": {
+    "message": "{name} 已就緒。請在多人遊戲中配置並啟動。"
+  },
+  "app.project.modpack-server.created-title": {
+    "message": "伺服器已建立"
+  },
+  "app.project.modpack-server.open": {
+    "message": "開啟伺服器"
+  },
+  "app.project.modpack-server.start": {
+    "message": "開服"
+  },
   "app.project.mcarchive.install": {
     "message": "安裝"
   },
@@ -6313,6 +6325,30 @@
   },
   "app.servers.wizard.type-title": {
     "message": "伺服器端類型"
+  },
+  "app.servers.modpack.downloading": {
+    "message": "正在下載整合包檔案..."
+  },
+  "app.servers.modpack.preparing": {
+    "message": "正在準備伺服器..."
+  },
+  "app.servers.modpack.current-file": {
+    "message": "正在安裝 {file}"
+  },
+  "app.servers.modpack.background-hint": {
+    "message": "您可以關閉此視窗，下載將在背景持續進行。"
+  },
+  "app.servers.modpack.first-run-crashed": {
+    "message": "伺服器在首次啟動時當機。請檢查所選 Java 版本是否相容，然後重試。"
+  },
+  "app.servers.modpack.download-in-background": {
+    "message": "背景下載"
+  },
+  "app.servers.modpack.unsupported-loader-title": {
+    "message": "{loader} 伺服器端暫不支援"
+  },
+  "app.servers.modpack.unsupported-loader-description": {
+    "message": "此整合包使用 {loader}，但 Axolotl 目前僅支援原版、Fabric 與 Quilt 整合包伺服器端。{loader} 支援即將推出。"
   },
   "app.settings.about.afdian": {
     "message": "在愛發電贊助"

--- a/apps/app-frontend/src/pages/Downloads.vue
+++ b/apps/app-frontend/src/pages/Downloads.vue
@@ -220,7 +220,11 @@
 								<ExternalIcon />{{ formatMessage(messages.openInstance) }}
 							</button>
 						</ButtonStyled>
-						<ButtonStyled type="transparent" size="small">
+						<ButtonStyled
+							v-if="job.items.length > 0 || job.error || job.rollback_error"
+							type="transparent"
+							size="small"
+						>
 							<button @click="toggleExpanded(job.job_id)">
 								<ChevronDownIcon :class="expanded.has(job.job_id) ? 'rotate-180' : ''" />
 								{{
@@ -875,12 +879,18 @@ function jobPercent(job: InstallJobSnapshot) {
 		return Math.min(99, (completedRequiredFiles(job) / total) * 100)
 	}
 	const progress = effectiveInstallProgress(job)
-	if (!hasDeterminateInstallProgress(progress)) return 0
-	return Math.min(99, Math.max(0, (progress.current / progress.total) * 100))
+	if (hasDeterminateInstallProgress(progress)) {
+		return Math.min(99, Math.max(0, (progress.current / progress.total) * 100))
+	}
+	if (job.summary.bytes_total && job.summary.bytes_total > 0) {
+		return Math.min(99, Math.max(0, (job.summary.bytes_downloaded / job.summary.bytes_total) * 100))
+	}
+	return 0
 }
 
 function hasDeterminateProgress(job: InstallJobSnapshot) {
-	return hasDeterminateInstallProgress(effectiveInstallProgress(job))
+	if (hasDeterminateInstallProgress(effectiveInstallProgress(job))) return true
+	return !!(job.summary.bytes_total && job.summary.bytes_total > 0)
 }
 
 function parallelPercent(job: InstallJobSnapshot) {

--- a/apps/app-frontend/src/pages/project/Index.vue
+++ b/apps/app-frontend/src/pages/project/Index.vue
@@ -210,6 +210,23 @@
 								{{ installButtonLabel }}
 							</button>
 						</ButtonStyled>
+						<Transition name="start-server">
+							<ButtonStyled
+								v-if="serverCapableModpack"
+								key="modpack-start-server"
+								size="large"
+								type="outlined"
+							>
+								<button
+									v-tooltip="formatMessage(messages.startServer)"
+									type="button"
+									@click="openModpackServerFlow"
+								>
+									<ServerIcon />
+									{{ formatMessage(messages.startServer) }}
+								</button>
+							</ButtonStyled>
+						</Transition>
 						<ButtonStyled size="large" circular type="transparent">
 							<OverflowMenu
 								:tooltip="`More options`"
@@ -366,6 +383,7 @@
 			@browse-modpacks="() => {}"
 			@create="serverInstallContent.handleServerModpackFlowCreate"
 		/>
+		<CreateModpackServerModal ref="modpackServerModal" @created="handleModpackServerCreated" />
 	</div>
 </template>
 
@@ -387,6 +405,7 @@ import {
 	PlusIcon,
 	ReportIcon,
 	SearchIcon,
+	ServerIcon,
 	SpinnerIcon,
 	StopCircleIcon,
 } from '@modrinth/assets'
@@ -402,6 +421,7 @@ import {
 	getLatestMatchingInstallVersion,
 	getTargetInstallPreferences,
 	injectNotificationManager,
+	injectPopupNotificationManager,
 	NavTabs,
 	OverflowMenu,
 	ProjectBackgroundGradient,
@@ -426,6 +446,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { SwapIcon } from '@/assets/icons/index.js'
 import BrowseInstanceSelector from '@/components/browse/BrowseInstanceSelector.vue'
+import CreateModpackServerModal from '@/components/multiplayer/servers/modpack/CreateModpackServerModal.vue'
 import ContextMenu from '@/components/ui/ContextMenu.vue'
 import InstanceIndicator from '@/components/ui/InstanceIndicator.vue'
 import {
@@ -477,6 +498,7 @@ import UpgradeProjectReturnBar from './UpgradeProjectReturnBar.vue'
 dayjs.extend(relativeTime)
 
 const { addNotification, handleError } = injectNotificationManager()
+const popupNotificationManager = injectPopupNotificationManager()
 const { install: installVersion } = injectContentInstall()
 const contentSelection = injectContentSelection()
 const route = useRoute()
@@ -565,7 +587,7 @@ const messages = defineMessages({
 	favoritesLoading: {
 		id: 'app.content-favorites.loading',
 		defaultMessage: 'Updating favorites…',
-	},
+},
 	viewDependents: {
 		id: 'project.actions.view-dependents',
 		defaultMessage: 'View dependents',
@@ -577,6 +599,22 @@ const messages = defineMessages({
 	viewModpacks: {
 		id: 'project.actions.view-modpacks',
 		defaultMessage: 'View modpacks',
+	},
+	startServer: {
+		id: 'app.project.modpack-server.start',
+		defaultMessage: 'Start server',
+	},
+	serverCreated: {
+		id: 'app.project.modpack-server.created-title',
+		defaultMessage: 'Server created',
+	},
+	serverCreatedDescription: {
+		id: 'app.project.modpack-server.created-description',
+		defaultMessage: '{name} is ready. Configure and start it in Multiplayer.',
+	},
+	openServer: {
+		id: 'app.project.modpack-server.open',
+		defaultMessage: 'Open server',
 	},
 })
 
@@ -600,6 +638,39 @@ const favoritePending = computed(() =>
 const favoriteSaved = computed(() =>
 	data.value ? contentFavorites.isFavorite('modrinth', data.value.id) : false,
 )
+
+const serverCapableModpack = computed(
+	() => data.value?.project_type === 'modpack' && data.value.server_side !== 'unsupported',
+)
+const modpackServerModal = ref()
+
+async function openModpackServerFlow() {
+	if (!data.value) return
+	let targetVersion = versions.value[0]
+	if (!targetVersion) {
+		const versionId = data.value.versions[0]
+		targetVersion = versionId ? await get_version(versionId, 'bypass').catch(() => null) : null
+	}
+	if (!targetVersion) return
+	modpackServerModal.value?.show(data.value, targetVersion)
+}
+
+function handleModpackServerCreated(serverId) {
+	popupNotificationManager.addPopupNotification({
+		title: formatMessage(messages.serverCreated),
+		text: formatMessage(messages.serverCreatedDescription, { name: data.value?.title ?? '' }),
+		type: 'success',
+		buttons: [
+			{
+				label: formatMessage(messages.openServer),
+				color: 'brand',
+				action: () => {
+					void router.push(`/multiplayer/servers/${encodeURIComponent(serverId)}`)
+				},
+			},
+		],
+	})
+}
 
 async function toggleFavorite() {
 	if (!data.value || !favoriteSupported.value || favoritePending.value) return
@@ -1339,6 +1410,35 @@ const handleOptionsClick = (args) => {
 	width: 100%;
 	padding: 1rem;
 	margin-left: calc(300px + 1rem);
+}
+
+.button-group {
+	display: flex;
+	flex-wrap: wrap;
+	flex-direction: row;
+	gap: 0.5rem;
+}
+
+.start-server-enter-active {
+	transition:
+		opacity 0.28s ease,
+		transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.start-server-enter-from {
+	opacity: 0;
+	transform: translateY(6px) scale(0.96);
+}
+
+.start-server-leave-active {
+	transition:
+		opacity 0.16s ease,
+		transform 0.16s ease;
+}
+
+.start-server-leave-to {
+	opacity: 0;
+	transform: translateY(4px) scale(0.97);
 }
 
 .stats {

--- a/apps/app-frontend/src/providers/download-manager.ts
+++ b/apps/app-frontend/src/providers/download-manager.ts
@@ -44,6 +44,29 @@ export interface DownloadManager {
 	skipMissingContent: (jobId: string) => Promise<void>
 	remove: (jobId: string) => Promise<void>
 	clearHistory: () => Promise<void>
+	/**
+	 * Insert a synthetic job created on the frontend (e.g. a server download
+	 * that does not go through the backend install-pipeline). The job is kept
+	 * in-memory and will disappear on refresh — callers must update it via
+	 * `setSyntheticJob` to keep it alive.
+	 */
+	addSyntheticJob: (job: InstallJobSnapshot) => void
+	/**
+	 * Replace a synthetic job (identified by `job_id`) with a fresh snapshot.
+	 * This is a no-op for backend-tracked jobs.
+	 */
+	setSyntheticJob: (job: InstallJobSnapshot) => void
+	/**
+	 * Register a cancel handler for a synthetic job.  When `cancel()` is
+	 * called with this jobId the handler is invoked *before* the job is
+	 * removed from the list, allowing the caller to abort the underlying
+	 * operation (e.g. stop a server install).
+	 */
+	onSyntheticCancel: (jobId: string, handler: () => void | Promise<void>) => void
+	/**
+	 * Unregister a previously registered cancel handler.
+	 */
+	offSyntheticCancel: (jobId: string) => void
 	dispose: () => void
 }
 
@@ -210,7 +233,12 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 			return null
 		})
 		if (page && !disposed) {
-			jobs.value = page.jobs
+			const activeSynthetics = jobs.value.filter(
+				(job) => syntheticIds.has(job.job_id) && activeStatuses.has(job.status),
+			)
+			jobs.value = [...page.jobs, ...activeSynthetics].sort((a, b) =>
+				b.created.localeCompare(a.created),
+			)
 			const seenInstances = new Set<string>()
 			for (const job of page.jobs) {
 				if (job.status !== 'succeeded') continue
@@ -261,6 +289,23 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 	}
 
 	async function cancel(jobId: string) {
+		if (syntheticIds.has(jobId)) {
+			// Remove the ID *before* removing the job from the list so that any
+			// in-flight progress listener callback that calls setSyntheticJob
+			// will see the missing ID and become a no-op, preventing the job
+			// from being re-inserted.
+			syntheticIds.delete(jobId)
+			const handler = syntheticCancelHandlers.get(jobId)
+			if (handler) {
+				try {
+					await handler()
+				} catch {
+					// Handler errors are non-fatal; still remove the job from the list.
+				}
+			}
+			jobs.value = jobs.value.filter((job) => job.job_id !== jobId)
+			return
+		}
 		const job = await download_job_cancel(jobId)
 		await reconcileJob(job)
 	}
@@ -308,6 +353,27 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 	const activeJobs = computed(() => jobs.value.filter((job) => activeStatuses.has(job.status)))
 	const historyJobs = computed(() => jobs.value.filter((job) => !activeStatuses.has(job.status)))
 
+	const syntheticIds = new Set<string>()
+	const syntheticCancelHandlers = new Map<string, () => void | Promise<void>>()
+
+	function addSyntheticJob(job: InstallJobSnapshot) {
+		syntheticIds.add(job.job_id)
+		jobs.value = [job, ...jobs.value].sort((a, b) => b.created.localeCompare(a.created))
+	}
+
+	function setSyntheticJob(job: InstallJobSnapshot) {
+		if (!syntheticIds.has(job.job_id)) return
+		setJob(job)
+	}
+
+	function onSyntheticCancel(jobId: string, handler: () => void | Promise<void>) {
+		syntheticCancelHandlers.set(jobId, handler)
+	}
+
+	function offSyntheticCancel(jobId: string) {
+		syntheticCancelHandlers.delete(jobId)
+	}
+
 	return {
 		jobs,
 		legacyDownloads,
@@ -323,11 +389,16 @@ export function createDownloadManager(handleError: (error: unknown) => void): Do
 		skipMissingContent,
 		remove,
 		clearHistory,
+		addSyntheticJob,
+		setSyntheticJob,
+		onSyntheticCancel,
+		offSyntheticCancel,
 		dispose() {
 			disposed = true
 			initializing = false
 			pendingInitialUpdates.length = 0
 			pendingRequestUpdatesByJob.clear()
+			syntheticCancelHandlers.clear()
 			if (requestFlushTimer !== null) {
 				clearTimeout(requestFlushTimer)
 				requestFlushTimer = null

--- a/apps/app/build.rs
+++ b/apps/app/build.rs
@@ -757,6 +757,7 @@ fn main() {
                         "servers_read_file",
                         "servers_write_file",
                         "servers_download_file",
+                        "servers_install_modpack",
                         "servers_start",
                         "servers_send_command",
                         "servers_stop",

--- a/apps/app/src/api/servers.rs
+++ b/apps/app/src/api/servers.rs
@@ -14,6 +14,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             servers_read_file,
             servers_write_file,
             servers_download_file,
+            servers_install_modpack,
             servers_start,
             servers_send_command,
             servers_stop,
@@ -105,6 +106,35 @@ pub async fn servers_download_file(
     expected_sha1: Option<String>,
 ) -> Result<()> {
     Ok(servers::download_file(server_id, url, filename, expected_sha1).await?)
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn servers_install_modpack(
+    server_id: &str,
+    mrpack_url: &str,
+    mrpack_sha1: Option<String>,
+    jar_url: &str,
+    jar_filename: &str,
+    jar_sha1: Option<String>,
+    modpack_project_id: Option<String>,
+    modpack_version_id: Option<String>,
+    modpack_title: Option<String>,
+    modpack_icon_url: Option<String>,
+) -> Result<()> {
+    Ok(servers::install_modpack(
+        server_id,
+        mrpack_url,
+        mrpack_sha1,
+        jar_url,
+        jar_filename,
+        jar_sha1,
+        modpack_project_id,
+        modpack_version_id,
+        modpack_title,
+        modpack_icon_url,
+    )
+    .await?)
 }
 
 #[tauri::command]

--- a/apps/app/src/lightweight_mode.rs
+++ b/apps/app/src/lightweight_mode.rs
@@ -376,6 +376,8 @@ fn destroy_lightweight_host_window(app: &AppHandle) {
 
 fn create_main_window(app: &AppHandle, route: &str) -> Result<(), String> {
     if app.get_webview_window(MAIN_WINDOW_LABEL).is_none() {
+        // Only reassigned on non-macOS platforms to strip window decorations.
+        #[cfg_attr(target_os = "macos", allow(unused_mut))]
         let mut builder = WebviewWindowBuilder::new(
             app,
             MAIN_WINDOW_LABEL,

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -196,6 +196,8 @@ async fn initialize_state(app: tauri::AppHandle) -> api::Result<()> {
         .allow_directory(state.directories.caches_dir().join("icons"), true)?;
     app.asset_protocol_scope()
         .allow_directory(state.directories.instances_dir(), true)?;
+    app.asset_protocol_scope()
+        .allow_directory(state.directories.servers_dir(), true)?;
     app.fs_scope()
         .allow_directory(state.directories.instances_dir(), true)?;
     app.asset_protocol_scope()

--- a/packages/app-lib/src/api/servers.rs
+++ b/packages/app-lib/src/api/servers.rs
@@ -7,11 +7,13 @@ mod lifecycle;
 mod logs;
 mod manage;
 mod manifest;
+mod modpack;
 mod ports;
 
 pub use self::files::{download_file, read_file, write_file};
 pub use self::lifecycle::{kill, send_command, start, stop};
 pub use self::logs::{clear_log, get_log_buffer};
 pub use self::manage::{create, delete, get, list, set_icon, update_settings};
-pub use self::manifest::{ServerInfo, ServerManifest};
+pub use self::manifest::{ModpackInfo, ServerInfo, ServerManifest};
+pub use self::modpack::install_modpack;
 pub use self::ports::{PortProcessInfo, kill_port_process, port_process};

--- a/packages/app-lib/src/api/servers/files.rs
+++ b/packages/app-lib/src/api/servers/files.rs
@@ -38,8 +38,26 @@ pub async fn download_file(
     expected_sha1: Option<String>,
 ) -> Result<()> {
     let dir = server_path(server_id).await?;
-    let destination = safe_join(&dir, filename)?;
+    download_to_dir(server_id, &dir, url, filename, expected_sha1).await
+}
+
+/// Downloads a URL into a nested, relative path inside the server directory
+/// (for example `mods/sodium.jar`), creating parent directories as needed.
+/// The relative path is validated against traversal; a plain filename behaves
+/// identically to [`download_file`].
+pub(super) async fn download_to_dir(
+    server_id: &str,
+    dir: &Path,
+    url: &str,
+    rel_path: &str,
+    expected_sha1: Option<String>,
+) -> Result<()> {
+    let destination = safe_relative_join(dir, rel_path)?;
     let partial = destination.with_extension("part");
+
+    if let Some(parent) = destination.parent() {
+        io::create_dir_all(parent).await?;
+    }
 
     let client = reqwest::Client::builder()
         .user_agent(crate::launcher_user_agent())
@@ -83,7 +101,7 @@ pub async fn download_file(
         if !actual.eq_ignore_ascii_case(expected) {
             let _ = tokio::fs::remove_file(&partial).await;
             return Err(ErrorKind::NetworkError(format!(
-                "Download checksum mismatch for {filename}: expected {expected}, got {actual}"
+                "Download checksum mismatch for {rel_path}: expected {expected}, got {actual}"
             ))
             .as_error());
         }
@@ -125,6 +143,27 @@ fn safe_join(dir: &Path, file: &str) -> Result<PathBuf> {
     Ok(dir.join(file))
 }
 
+/// Joins a relative path that may contain `/` separators but never escapes the
+/// server directory (no `..`, empty segments, or absolute/Windows roots).
+pub(super) fn safe_relative_join(dir: &Path, rel: &str) -> Result<PathBuf> {
+    let is_windows_drive_root =
+        rel.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+            && rel.as_bytes().first().is_some_and(u8::is_ascii_alphabetic);
+    if rel.is_empty()
+        || Path::new(rel).is_absolute()
+        || is_windows_drive_root
+        || rel.starts_with('/')
+        || rel.starts_with('\\')
+        || rel.split(['/', '\\']).any(|segment| {
+            segment.is_empty() || segment == ".." || segment == "."
+        })
+    {
+        return Err(ErrorKind::InputError(format!("Invalid file path: {rel}"))
+            .as_error());
+    }
+    Ok(dir.join(rel))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,5 +176,25 @@ mod tests {
         assert!(safe_join(dir, "/etc/passwd").is_err());
         assert!(safe_join(dir, "a//b").is_err());
         assert!(safe_join(dir, "").is_err());
+    }
+
+    #[test]
+    fn safe_relative_join_allows_nested_paths() {
+        let dir = Path::new("/tmp/servers/a");
+        assert_eq!(
+            safe_relative_join(dir, "mods/sodium.jar").unwrap(),
+            dir.join("mods/sodium.jar")
+        );
+        assert_eq!(
+            safe_relative_join(dir, "config/foo/bar.toml").unwrap(),
+            dir.join("config/foo/bar.toml")
+        );
+        assert!(safe_relative_join(dir, "mods/../secret").is_err());
+        assert!(safe_relative_join(dir, "../secret").is_err());
+        assert!(safe_relative_join(dir, "/etc/passwd").is_err());
+        assert!(safe_relative_join(dir, "C:/windows/system32").is_err());
+        assert!(safe_relative_join(dir, "mods//double.jar").is_err());
+        assert!(safe_relative_join(dir, "mods/./dot.jar").is_err());
+        assert!(safe_relative_join(dir, "").is_err());
     }
 }

--- a/packages/app-lib/src/api/servers/lifecycle.rs
+++ b/packages/app-lib/src/api/servers/lifecycle.rs
@@ -12,10 +12,10 @@ use tokio::process::{Child, ChildStdin, Command};
 
 use crate::event::ServerPayloadType;
 use crate::event::emit::emit_server;
-use crate::state::clear_log_buffer;
+use crate::state::{clear_log_buffer, get_log_buffer};
 use crate::{ErrorKind, Result};
 
-use super::logs::stream_server_output;
+use super::logs::{analyze_exit_reason, stream_server_output};
 use super::manifest::{
     read_manifest, resolve_jar_name, server_path, write_manifest,
 };
@@ -89,22 +89,22 @@ async fn start_inner(
     for arg in jvm_args.unwrap_or_else(|| manifest.jvm_args.clone()) {
         command.arg(arg);
     }
-	command.arg("-jar").arg(&jar_name).arg("nogui");
-	command.current_dir(&dir);
-	// Dynamic-loader injection variables (Steam overlays, debugging tools,
-	// stale shell exports) lengthen every dyld failure message the JVM
-	// produces, which is exactly what trips the JNA < 5.13 macOS assertion;
-	// they have no business affecting a managed server either.
-	for variable in [
-		"DYLD_LIBRARY_PATH",
-		"DYLD_FALLBACK_LIBRARY_PATH",
-		"DYLD_FRAMEWORK_PATH",
-		"DYLD_FALLBACK_FRAMEWORK_PATH",
-		"DYLD_INSERT_LIBRARIES",
-	] {
-		command.env_remove(variable);
-	}
-	command.stdout(std::process::Stdio::piped());
+    command.arg("-jar").arg(&jar_name).arg("nogui");
+    command.current_dir(&dir);
+    // Dynamic-loader injection variables (Steam overlays, debugging tools,
+    // stale shell exports) lengthen every dyld failure message the JVM
+    // produces, which is exactly what trips the JNA < 5.13 macOS assertion;
+    // they have no business affecting a managed server either.
+    for variable in [
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FALLBACK_LIBRARY_PATH",
+        "DYLD_FRAMEWORK_PATH",
+        "DYLD_FALLBACK_FRAMEWORK_PATH",
+        "DYLD_INSERT_LIBRARIES",
+    ] {
+        command.env_remove(variable);
+    }
+    command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
     command.stdin(std::process::Stdio::piped());
     command.kill_on_drop(true);
@@ -235,12 +235,23 @@ async fn monitor_server_process(
             .map(|status| !status.success() && !stop_requested && eula_accepted)
             .unwrap_or(false);
 
+        // Classify self-exits from the tail of the console output so the UI
+        // can react (e.g. offer the EULA dialog). User-requested stops and
+        // unmatched exits stay unclassified. The brief settle wait lets the
+        // output-stream tasks flush their final lines into the buffer first.
+        let reason = if stop_requested {
+            None
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            analyze_exit_reason(&get_log_buffer(&server_id))
+        };
+
         if let Ok(mut manifest) = read_manifest(&dir).await {
             manifest.last_exit_crashed = crashed;
             let _ = write_manifest(&dir, &manifest).await;
         }
 
-        emit_server(&server_id, ServerPayloadType::Stopped { crashed })
+        emit_server(&server_id, ServerPayloadType::Stopped { crashed, reason })
             .await
             .ok();
         return;

--- a/packages/app-lib/src/api/servers/lifecycle.rs
+++ b/packages/app-lib/src/api/servers/lifecycle.rs
@@ -13,6 +13,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use crate::event::ServerPayloadType;
 use crate::event::emit::emit_server;
 use crate::state::{clear_log_buffer, get_log_buffer};
+use crate::util::io::IOError;
 use crate::{ErrorKind, Result};
 
 use super::logs::{analyze_exit_reason, stream_server_output};
@@ -83,6 +84,14 @@ async fn start_inner(
     let memory = memory_mb
         .or(manifest.memory_mb)
         .unwrap_or(DEFAULT_MEMORY_MB);
+
+    // Ensure eula.txt exists (create with eula=false if missing)
+    let eula_path = dir.join("eula.txt");
+    if !eula_path.exists() {
+        tokio::fs::write(&eula_path, "eula=false\n")
+            .await
+            .map_err(|e| IOError::with_path(e, &eula_path))?;
+    }
 
     let mut command = Command::new(&java);
     command.arg(format!("-Xmx{memory}M"));

--- a/packages/app-lib/src/api/servers/lifecycle.rs
+++ b/packages/app-lib/src/api/servers/lifecycle.rs
@@ -89,9 +89,22 @@ async fn start_inner(
     for arg in jvm_args.unwrap_or_else(|| manifest.jvm_args.clone()) {
         command.arg(arg);
     }
-    command.arg("-jar").arg(&jar_name).arg("nogui");
-    command.current_dir(&dir);
-    command.stdout(std::process::Stdio::piped());
+	command.arg("-jar").arg(&jar_name).arg("nogui");
+	command.current_dir(&dir);
+	// Dynamic-loader injection variables (Steam overlays, debugging tools,
+	// stale shell exports) lengthen every dyld failure message the JVM
+	// produces, which is exactly what trips the JNA < 5.13 macOS assertion;
+	// they have no business affecting a managed server either.
+	for variable in [
+		"DYLD_LIBRARY_PATH",
+		"DYLD_FALLBACK_LIBRARY_PATH",
+		"DYLD_FRAMEWORK_PATH",
+		"DYLD_FALLBACK_FRAMEWORK_PATH",
+		"DYLD_INSERT_LIBRARIES",
+	] {
+		command.env_remove(variable);
+	}
+	command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
     command.stdin(std::process::Stdio::piped());
     command.kill_on_drop(true);

--- a/packages/app-lib/src/api/servers/logs.rs
+++ b/packages/app-lib/src/api/servers/logs.rs
@@ -17,32 +17,54 @@ pub async fn clear_log(server_id: &str) -> Result<()> {
 }
 
 pub(super) async fn stream_server_output(
-    server_id: String,
-    reader: impl tokio::io::AsyncRead + Unpin,
+	server_id: String,
+	reader: impl tokio::io::AsyncRead + Unpin,
 ) {
-    let mut buf_reader = BufReader::new(reader);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        match buf_reader.read_line(&mut line).await {
-            Ok(0) | Err(_) => break,
-            Ok(_) => {
-                let trimmed = line.trim_end_matches(['\r', '\n']);
-                let cleaned = strip_ansi(trimmed);
-                if cleaned.is_empty() {
-                    continue;
-                }
-                push_log_line(&server_id, cleaned.clone());
-                emit_server(
-                    &server_id,
-                    ServerPayloadType::Log { line: cleaned },
-                )
-                .await
-                .ok();
-            }
-        }
-    }
+	let mut buf_reader = BufReader::new(reader);
+	let mut line = String::new();
+	let mut jna_hint_emitted = false;
+	loop {
+		line.clear();
+		match buf_reader.read_line(&mut line).await {
+			Ok(0) | Err(_) => break,
+			Ok(_) => {
+				let trimmed = line.trim_end_matches(['\r', '\n']);
+				let cleaned = strip_ansi(trimmed);
+				if cleaned.is_empty() {
+					continue;
+				}
+				push_log_line(&server_id, cleaned.clone());
+				emit_server(&server_id, ServerPayloadType::Log { line: cleaned })
+					.await
+					.ok();
+				if !jna_hint_emitted && is_jna_macos_assertion(trimmed) {
+					jna_hint_emitted = true;
+					for hint in JNA_CRASH_HINT_LINES {
+						push_log_line(&server_id, hint.to_string());
+						emit_server(&server_id, ServerPayloadType::Log { line: hint.to_string() })
+							.await
+							.ok();
+					}
+				}
+			}
+		}
+	}
 }
+
+/// Matches the native abort of the known JNA (< 5.13.0) macOS bug (JNA issue
+/// #1452): a failed library load overflows JNA's fixed error buffer and the
+/// JVM dies with SIGABRT before any Java-level exception can be reported.
+fn is_jna_macos_assertion(line: &str) -> bool {
+	line.contains("Assertion failed:")
+		&& line.contains("snprintf() output has been truncated")
+		&& line.contains("dispatch.c")
+}
+
+const JNA_CRASH_HINT_LINES: [&str; 3] = [
+	"[Axolotl] This crash matches a known JNA bug on macOS (java-native-access#1452):",
+	"[Axolotl] mods bundling JNA below 5.13.0 abort when a native library fails to load.",
+	"[Axolotl] Update or remove the affected mod, or ask the modpack author to bump JNA to 5.13.0+.",
+];
 
 /// Removes ANSI escape sequences (SGR colors, cursor control, OSC titles) that
 /// servers emit when they assume an interactive terminal is attached.
@@ -94,9 +116,19 @@ mod tests {
             "[16:02:30 INFO]: /mspt: View server tick times"
         );
 
-        assert_eq!(strip_ansi("\u{1b}]0;Server console\u{7}ready"), "ready");
-        assert_eq!(strip_ansi("\u{1b}]0;Server console\u{1b}\\done"), "done");
-        assert_eq!(strip_ansi("plain text stays"), "plain text stays");
-        assert_eq!(strip_ansi("h\u{e9}llo \u{1b}[31mred"), "h\u{e9}llo red");
-    }
+		assert_eq!(strip_ansi("\u{1b}]0;Server console\u{7}ready"), "ready");
+		assert_eq!(strip_ansi("\u{1b}]0;Server console\u{1b}\\done"), "done");
+		assert_eq!(strip_ansi("plain text stays"), "plain text stays");
+		assert_eq!(strip_ansi("h\u{e9}llo \u{1b}[31mred"), "h\u{e9}llo red");
+	}
+
+	#[test]
+	fn detects_jna_macos_assertion() {
+		let line = "Assertion failed: (count <= len && \"snprintf() output has been truncated\"), function LOAD_ERROR, file dispatch.c, line 74.";
+		assert!(is_jna_macos_assertion(line));
+		assert!(!is_jna_macos_assertion(
+			"Assertion failed: something else, file other.c, line 1."
+		));
+		assert!(!is_jna_macos_assertion("regular log output"));
+	}
 }

--- a/packages/app-lib/src/api/servers/logs.rs
+++ b/packages/app-lib/src/api/servers/logs.rs
@@ -1,10 +1,10 @@
-//! Console output buffering and streaming for running servers.
+//! Console output buffering and streaming for servers.
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::Result;
-use crate::event::ServerPayloadType;
 use crate::event::emit::emit_server;
+use crate::event::{ExitReason, ServerPayloadType};
 use crate::state::{clear_log_buffer, push_log_line};
 
 pub async fn get_log_buffer(server_id: &str) -> Result<Vec<String>> {
@@ -17,53 +17,83 @@ pub async fn clear_log(server_id: &str) -> Result<()> {
 }
 
 pub(super) async fn stream_server_output(
-	server_id: String,
-	reader: impl tokio::io::AsyncRead + Unpin,
+    server_id: String,
+    reader: impl tokio::io::AsyncRead + Unpin,
 ) {
-	let mut buf_reader = BufReader::new(reader);
-	let mut line = String::new();
-	let mut jna_hint_emitted = false;
-	loop {
-		line.clear();
-		match buf_reader.read_line(&mut line).await {
-			Ok(0) | Err(_) => break,
-			Ok(_) => {
-				let trimmed = line.trim_end_matches(['\r', '\n']);
-				let cleaned = strip_ansi(trimmed);
-				if cleaned.is_empty() {
-					continue;
-				}
-				push_log_line(&server_id, cleaned.clone());
-				emit_server(&server_id, ServerPayloadType::Log { line: cleaned })
-					.await
-					.ok();
-				if !jna_hint_emitted && is_jna_macos_assertion(trimmed) {
-					jna_hint_emitted = true;
-					for hint in JNA_CRASH_HINT_LINES {
-						push_log_line(&server_id, hint.to_string());
-						emit_server(&server_id, ServerPayloadType::Log { line: hint.to_string() })
-							.await
-							.ok();
-					}
-				}
-			}
-		}
-	}
+    let mut buf_reader = BufReader::new(reader);
+    let mut line = String::new();
+    let mut jna_hint_emitted = false;
+    loop {
+        line.clear();
+        match buf_reader.read_line(&mut line).await {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let trimmed = line.trim_end_matches(['\r', '\n']);
+                let cleaned = strip_ansi(trimmed);
+                if cleaned.is_empty() {
+                    continue;
+                }
+                push_log_line(&server_id, cleaned.clone());
+                emit_server(
+                    &server_id,
+                    ServerPayloadType::Log { line: cleaned },
+                )
+                .await
+                .ok();
+                if !jna_hint_emitted && is_jna_macos_assertion(trimmed) {
+                    jna_hint_emitted = true;
+                    for hint in JNA_CRASH_HINT_LINES {
+                        push_log_line(&server_id, hint.to_string());
+                        emit_server(
+                            &server_id,
+                            ServerPayloadType::Log {
+                                line: hint.to_string(),
+                            },
+                        )
+                        .await
+                        .ok();
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Matches the native abort of the known JNA (< 5.13.0) macOS bug (JNA issue
 /// #1452): a failed library load overflows JNA's fixed error buffer and the
 /// JVM dies with SIGABRT before any Java-level exception can be reported.
 fn is_jna_macos_assertion(line: &str) -> bool {
-	line.contains("Assertion failed:")
-		&& line.contains("snprintf() output has been truncated")
-		&& line.contains("dispatch.c")
+    line.contains("Assertion failed:")
+        && line.contains("snprintf() output has been truncated")
+        && line.contains("dispatch.c")
+}
+
+/// How many lines at the end of a server's output are inspected when
+/// classifying why it exited.
+const EXIT_ANALYSIS_TAIL_LINES: usize = 50;
+
+/// Classifies why a server exited on its own by scanning the tail of its
+/// console output, newest lines first. Returns `None` when nothing matches:
+/// no guess is better than a wrong one, and unmatched exits simply behave as
+/// before.
+pub(super) fn analyze_exit_reason(lines: &[String]) -> Option<ExitReason> {
+    lines
+        .iter()
+        .rev()
+        .take(EXIT_ANALYSIS_TAIL_LINES)
+        .find_map(|line| is_eula_refusal(line).then_some(ExitReason::Eula))
+}
+
+/// Matches the vanilla server's refusal to boot before the EULA has been
+/// accepted; the process then writes `eula.txt` and exits immediately.
+fn is_eula_refusal(line: &str) -> bool {
+    line.contains("need to agree to the EULA")
 }
 
 const JNA_CRASH_HINT_LINES: [&str; 3] = [
-	"[Axolotl] This crash matches a known JNA bug on macOS (java-native-access#1452):",
-	"[Axolotl] mods bundling JNA below 5.13.0 abort when a native library fails to load.",
-	"[Axolotl] Update or remove the affected mod, or ask the modpack author to bump JNA to 5.13.0+.",
+    "[Axolotl] This crash matches a known JNA bug on macOS (java-native-access#1452):",
+    "[Axolotl] mods bundling JNA below 5.13.0 abort when a native library fails to load.",
+    "[Axolotl] Update or remove the affected mod, or ask the modpack author to bump JNA to 5.13.0+.",
 ];
 
 /// Removes ANSI escape sequences (SGR colors, cursor control, OSC titles) that
@@ -116,19 +146,50 @@ mod tests {
             "[16:02:30 INFO]: /mspt: View server tick times"
         );
 
-		assert_eq!(strip_ansi("\u{1b}]0;Server console\u{7}ready"), "ready");
-		assert_eq!(strip_ansi("\u{1b}]0;Server console\u{1b}\\done"), "done");
-		assert_eq!(strip_ansi("plain text stays"), "plain text stays");
-		assert_eq!(strip_ansi("h\u{e9}llo \u{1b}[31mred"), "h\u{e9}llo red");
-	}
+        assert_eq!(strip_ansi("\u{1b}]0;Server console\u{7}ready"), "ready");
+        assert_eq!(strip_ansi("\u{1b}]0;Server console\u{1b}\\done"), "done");
+        assert_eq!(strip_ansi("plain text stays"), "plain text stays");
+        assert_eq!(strip_ansi("h\u{e9}llo \u{1b}[31mred"), "h\u{e9}llo red");
+    }
 
-	#[test]
-	fn detects_jna_macos_assertion() {
-		let line = "Assertion failed: (count <= len && \"snprintf() output has been truncated\"), function LOAD_ERROR, file dispatch.c, line 74.";
-		assert!(is_jna_macos_assertion(line));
-		assert!(!is_jna_macos_assertion(
-			"Assertion failed: something else, file other.c, line 1."
-		));
-		assert!(!is_jna_macos_assertion("regular log output"));
-	}
+    #[test]
+    fn detects_jna_macos_assertion() {
+        let line = "Assertion failed: (count <= len && \"snprintf() output has been truncated\"), function LOAD_ERROR, file dispatch.c, line 74.";
+        assert!(is_jna_macos_assertion(line));
+        assert!(!is_jna_macos_assertion(
+            "Assertion failed: something else, file other.c, line 1."
+        ));
+        assert!(!is_jna_macos_assertion("regular log output"));
+    }
+
+    #[test]
+    fn classifies_eula_refusal_from_output_tail() {
+        let eula_line = "[15:26:09] [main/INFO]: You need to agree to the EULA in order to run the server. Go to eula.txt for more info.".to_string();
+        let mut lines = vec![
+            "[15:26:09] [main/INFO]: Starting minecraft server version 26.2"
+                .to_string(),
+            eula_line.clone(),
+        ];
+        assert_eq!(analyze_exit_reason(&lines), Some(ExitReason::Eula));
+
+        // Detected even when buried under later shutdown chatter.
+        lines.push(
+            "[16:44:23] [Server thread/INFO]: Stopped IO worker!".to_string(),
+        );
+        assert_eq!(analyze_exit_reason(&lines), Some(ExitReason::Eula));
+
+        // A normal shutdown matches nothing and stays unclassified.
+        let normal = vec![
+            "[16:44:18] [Server thread/INFO]: Stopping the server".to_string(),
+            "[16:44:23] [Server thread/INFO]: Stopped IO worker!".to_string(),
+        ];
+        assert_eq!(analyze_exit_reason(&normal), None);
+        assert_eq!(analyze_exit_reason(&[]), None);
+
+        // Only the tail is inspected; ancient history does not classify a
+        // much-later exit.
+        let mut old = vec![eula_line];
+        old.resize(EXIT_ANALYSIS_TAIL_LINES + 10, "noise".to_string());
+        assert_eq!(analyze_exit_reason(&old), None);
+    }
 }

--- a/packages/app-lib/src/api/servers/manage.rs
+++ b/packages/app-lib/src/api/servers/manage.rs
@@ -86,6 +86,8 @@ pub async fn create(
         memory_mb,
         icon_path: None,
         modpack: None,
+        install_state: None,
+        install_error: None,
         jvm_args: Vec::new(),
         created_at: Utc::now(),
         last_started_at: None,

--- a/packages/app-lib/src/api/servers/manage.rs
+++ b/packages/app-lib/src/api/servers/manage.rs
@@ -85,6 +85,7 @@ pub async fn create(
         java_path,
         memory_mb,
         icon_path: None,
+        modpack: None,
         jvm_args: Vec::new(),
         created_at: Utc::now(),
         last_started_at: None,

--- a/packages/app-lib/src/api/servers/manifest.rs
+++ b/packages/app-lib/src/api/servers/manifest.rs
@@ -18,10 +18,14 @@ const DEFAULT_JAR_NAME: &str = "server.jar";
 /// Executable launcher jar downloaded from Fabric Meta; must match the
 /// filename used by the frontend's `resolveServerJar('fabric')`.
 const FABRIC_SERVER_JAR_NAME: &str = "fabric-server.jar";
+/// Executable launcher jar downloaded from Quilt Meta; must match the
+/// filename used by the frontend's `resolveServerJar('quilt')`.
+const QUILT_SERVER_JAR_NAME: &str = "quilt-server.jar";
 
 pub(super) fn type_default_jar_name(server_type: &str) -> Option<String> {
     match server_type {
         "fabric" => Some(FABRIC_SERVER_JAR_NAME.to_string()),
+        "quilt" => Some(QUILT_SERVER_JAR_NAME.to_string()),
         _ => None,
     }
 }
@@ -53,6 +57,8 @@ pub struct ServerManifest {
     pub memory_mb: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modpack: Option<ModpackInfo>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub jvm_args: Vec<String>,
     pub created_at: DateTime<Utc>,
@@ -60,6 +66,19 @@ pub struct ServerManifest {
     pub last_started_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub last_exit_crashed: bool,
+}
+
+/// Identifies a modpack a server was created from. Populated by
+/// [`super::modpack::install_modpack`] so the UI can badge and link servers
+/// back to their source project.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ModpackInfo {
+    pub project_id: String,
+    pub version_id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -186,6 +205,7 @@ mod tests {
             java_path: None,
             memory_mb: Some(2048),
             icon_path: None,
+            modpack: None,
             jvm_args: Vec::new(),
             created_at: Utc::now(),
             last_started_at: None,
@@ -209,12 +229,16 @@ mod tests {
             java_path: None,
             memory_mb: None,
             icon_path: None,
+            modpack: None,
             jvm_args: Vec::new(),
             created_at: Utc::now(),
             last_started_at: None,
             last_exit_crashed: false,
         };
         assert_eq!(resolve_jar_name(&manifest), FABRIC_SERVER_JAR_NAME);
+
+        manifest.server_type = "quilt".to_string();
+        assert_eq!(resolve_jar_name(&manifest), QUILT_SERVER_JAR_NAME);
 
         manifest.server_type = "vanilla".to_string();
         assert_eq!(resolve_jar_name(&manifest), DEFAULT_JAR_NAME);

--- a/packages/app-lib/src/api/servers/manifest.rs
+++ b/packages/app-lib/src/api/servers/manifest.rs
@@ -59,6 +59,10 @@ pub struct ServerManifest {
     pub icon_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modpack: Option<ModpackInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_state: Option<InstallState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_error: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub jvm_args: Vec<String>,
     pub created_at: DateTime<Utc>,
@@ -66,6 +70,17 @@ pub struct ServerManifest {
     pub last_started_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub last_exit_crashed: bool,
+}
+
+/// Tracks whether a modpack server has finished materializing. `Incomplete`
+/// is written when an install starts (and left behind if the app exits
+/// mid-download); `Failed` records an install error so the UI can offer a
+/// retry. Both clear once the install succeeds.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallState {
+    Incomplete,
+    Failed,
 }
 
 /// Identifies a modpack a server was created from. Populated by
@@ -206,6 +221,8 @@ mod tests {
             memory_mb: Some(2048),
             icon_path: None,
             modpack: None,
+            install_state: None,
+            install_error: None,
             jvm_args: Vec::new(),
             created_at: Utc::now(),
             last_started_at: None,
@@ -230,6 +247,8 @@ mod tests {
             memory_mb: None,
             icon_path: None,
             modpack: None,
+            install_state: None,
+            install_error: None,
             jvm_args: Vec::new(),
             created_at: Utc::now(),
             last_started_at: None,

--- a/packages/app-lib/src/api/servers/modpack.rs
+++ b/packages/app-lib/src/api/servers/modpack.rs
@@ -7,9 +7,10 @@
 //! server overrides are applied, and the loader's server launcher jar is placed
 //! next to them so the regular `servers.start` flow can boot it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -34,13 +35,22 @@ use crate::{ErrorKind, Result};
 
 use super::files::download_to_dir;
 use super::manifest::{
-    ModpackInfo, read_manifest, server_path, write_manifest,
+    InstallState, ModpackInfo, read_manifest, server_path, write_manifest,
 };
 
 const MRPACK_MANIFEST_ENTRY: &str = "modrinth.index.json";
 const MRPACK_FILENAME: &str = "pack.mrpack";
 const OVERRIDES_DIR: &str = "overrides";
 const SERVER_OVERRIDES_DIR: &str = "server/overrides";
+/// Top-level override folders that only a Minecraft client reads. Modpacks
+/// ship them for players; a dedicated server never loads them, so they are
+/// dropped right after overrides are extracted.
+const CLIENT_ONLY_OVERRIDE_DIRS: &[&str] = &["shaderpacks"];
+/// Index file path prefixes that only a Minecraft client ever reads,
+/// following ATLauncher's classification of Modrinth pack files by location.
+/// Datapacks are deliberately absent because servers load those.
+const CLIENT_ONLY_INDEX_PREFIXES: &[&str] =
+    &["shaderpacks/", "resourcepacks/", "texturepacks/"];
 /// How many modpack files download at once. Bounded by the global download
 /// semaphore, which also leaves headroom for concurrent instance installs.
 const MODPACK_DOWNLOAD_CONCURRENCY: usize = 8;
@@ -92,6 +102,53 @@ struct MrpackEnv {
     server: Option<String>,
 }
 
+/// Fabric metadata embedded in a mod jar. Only identity and dependency
+/// information are modeled; this is the same signal Fabric Loader uses to
+/// resolve mods at runtime.
+#[derive(Clone, Deserialize)]
+struct ModMetadata {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    provides: Vec<String>,
+    // Modeled as raw JSON: most mods use an object keyed by mod id, but
+    // non-standard shapes (plain lists) exist and must not fail parsing.
+    #[serde(default)]
+    depends: Option<serde_json::Value>,
+}
+
+impl ModMetadata {
+    /// Upper bound on how many bytes of `fabric.mod.json` are read, so a
+    /// bloated or malicious entry cannot balloon memory.
+    const MAX_READ_BYTES: u64 = 1024 * 1024;
+
+    fn owned_ids(&self) -> impl Iterator<Item = &str> {
+        self.id
+            .iter()
+            .map(String::as_str)
+            .chain(self.provides.iter().map(String::as_str))
+    }
+
+    fn hard_dependencies(&self) -> Vec<&str> {
+        match self.depends.as_ref().and_then(|value| value.as_object()) {
+            Some(dependencies) => dependencies
+                .iter()
+                .filter_map(|(id, spec)| {
+                    let optional = spec
+                        .as_object()
+                        .and_then(|object| object.get("optional"))
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false);
+                    (!optional).then_some(id.as_str())
+                })
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+}
+
 /// Installs a modpack into an existing managed server.
 ///
 /// `mrpack_url` / `mrpack_sha1` identify the `.mrpack` archive to download;
@@ -99,6 +156,11 @@ struct MrpackEnv {
 /// launcher jar that boots the modpack. The optional `modpack_*` fields are
 /// recorded on the manifest so the UI can badge and link the server back to
 /// its source project.
+///
+/// The manifest tracks the install while it runs: it is flagged `incomplete`
+/// up front (so an interrupted download is resumable from the servers list),
+/// cleared on success alongside a best-effort modpack icon fetch, and set to
+/// `failed` with the error message when the install errors out.
 #[allow(clippy::too_many_arguments)]
 pub async fn install_modpack(
     server_id: &str,
@@ -114,6 +176,84 @@ pub async fn install_modpack(
 ) -> Result<()> {
     let dir = server_path(server_id).await?;
     let mut manifest = read_manifest(&dir).await?;
+    manifest.install_state = Some(InstallState::Incomplete);
+    manifest.install_error = None;
+    // Record the source pack before any bytes move so an interrupted install
+    // still carries everything the resume flow needs.
+    if let (Some(project_id), Some(version_id), Some(title)) =
+        (&modpack_project_id, &modpack_version_id, &modpack_title)
+    {
+        manifest.modpack = Some(ModpackInfo {
+            project_id: project_id.clone(),
+            version_id: version_id.clone(),
+            title: title.clone(),
+            icon_url: modpack_icon_url.clone(),
+        });
+    }
+    write_manifest(&dir, &manifest).await?;
+    drop(manifest);
+
+    let result = run_modpack_install(
+        server_id,
+        &dir,
+        mrpack_url,
+        mrpack_sha1.as_deref(),
+        jar_url,
+        jar_filename,
+        jar_sha1.as_deref(),
+    )
+    .await;
+
+    let mut manifest = read_manifest(&dir).await?;
+    match result {
+        Ok(()) => {
+            manifest.jar_name = Some(jar_filename.to_string());
+            if manifest.icon_path.is_none() {
+                if let Some(icon_url) = modpack_icon_url.as_deref() {
+                    match download_icon(&dir, icon_url).await {
+                        Ok(icon_path) => {
+                            manifest.icon_path =
+                                Some(icon_path.to_string_lossy().into_owned());
+                        }
+                        Err(error) => {
+                            log(
+                                server_id,
+                                &format!(
+                                    "Failed to download modpack icon: {error}"
+                                ),
+                            )
+                            .await
+                            .ok();
+                        }
+                    }
+                }
+            }
+            manifest.install_state = None;
+            manifest.install_error = None;
+            write_manifest(&dir, &manifest).await?;
+            Ok(())
+        }
+        Err(error) => {
+            manifest.install_state = Some(InstallState::Failed);
+            manifest.install_error = Some(error.to_string());
+            write_manifest(&dir, &manifest).await?;
+            Err(error)
+        }
+    }
+}
+
+/// Downloads and unpacks the modpack contents. Manifest bookkeeping lives in
+/// [`install_modpack`] so this function stays focused on file transfer.
+#[allow(clippy::too_many_arguments)]
+async fn run_modpack_install(
+    server_id: &str,
+    dir: &Path,
+    mrpack_url: &str,
+    mrpack_sha1: Option<&str>,
+    jar_url: &str,
+    jar_filename: &str,
+    jar_sha1: Option<&str>,
+) -> Result<()> {
     let state = State::get().await?;
 
     log(server_id, "Downloading modpack archive").await?;
@@ -122,7 +262,7 @@ pub async fn install_modpack(
         &state,
         mrpack_url,
         &dir.join(MRPACK_FILENAME),
-        mrpack_sha1,
+        mrpack_sha1.map(str::to_string),
         ResourceClass::Modpack,
         AggregateProgress::new(0),
     )
@@ -133,15 +273,26 @@ pub async fn install_modpack(
     let base_folder = base_folder(&manifest_entry);
     let index = parse_index(&archive_path, &manifest_entry).await?;
 
-    let installable_files: Vec<&MrpackFile> = index
+    let (installable_files, excluded_files): (
+        Vec<&MrpackFile>,
+        Vec<&MrpackFile>,
+    ) = index
         .files
         .iter()
-        .filter(|file| is_server_installable(file))
-        .collect();
+        .partition(|file| is_server_installable(file));
     let total_bytes: u64 = installable_files
         .iter()
         .filter_map(|file| file.file_size)
         .sum();
+
+    let skipped = index.files.len() - installable_files.len();
+    if skipped > 0 {
+        log(
+            server_id,
+            &format!("Skipping {skipped} client-only modpack file(s)"),
+        )
+        .await?;
+    }
 
     log(
         server_id,
@@ -165,7 +316,7 @@ pub async fn install_modpack(
 
     let progress = AggregateProgress::new(total_bytes);
     let state_ref = state.clone();
-    let dir_ref = dir.clone();
+    let dir_ref = dir.to_path_buf();
     let server_id_ref = server_id.to_string();
     let num_files = files.len();
     loading_try_for_each_concurrent(
@@ -207,37 +358,70 @@ pub async fn install_modpack(
     extract_archive_subdir(
         archive_path.clone(),
         format!("{base_folder}{OVERRIDES_DIR}/"),
-        dir.clone(),
+        dir.to_path_buf(),
     )
     .await?;
     extract_archive_subdir(
         archive_path,
         format!("{base_folder}{SERVER_OVERRIDES_DIR}/"),
-        dir.clone(),
+        dir.to_path_buf(),
     )
     .await?;
+    remove_client_only_dirs(server_id, dir).await?;
+    let unavailable_ids =
+        fetch_excluded_mod_ids(server_id, &state, &excluded_files).await?;
+    prune_uninstallable_mods(server_id, dir, &unavailable_ids).await?;
 
     log(
         &server_id,
         &format!("Downloading server launcher ({jar_filename})"),
     )
     .await?;
-    download_to_dir(&server_id, &dir, jar_url, jar_filename, jar_sha1).await?;
-
-    manifest.jar_name = Some(jar_filename.to_string());
-    if let (Some(project_id), Some(version_id), Some(title)) =
-        (modpack_project_id, modpack_version_id, modpack_title)
-    {
-        manifest.modpack = Some(ModpackInfo {
-            project_id,
-            version_id,
-            title,
-            icon_url: modpack_icon_url,
-        });
-    }
-    write_manifest(&dir, &manifest).await?;
+    download_to_dir(
+        &server_id,
+        dir,
+        jar_url,
+        jar_filename,
+        jar_sha1.map(str::to_string),
+    )
+    .await?;
 
     Ok(())
+}
+
+/// Fetches the modpack icon into the server directory and returns its path.
+async fn download_icon(dir: &Path, icon_url: &str) -> Result<PathBuf> {
+    let extension = icon_url
+        .split(['?', '#'])
+        .next()
+        .and_then(|path| path.rsplit('.').next())
+        .map(str::to_ascii_lowercase)
+        .filter(|ext| {
+            matches!(
+                ext.as_str(),
+                "png" | "jpg" | "jpeg" | "gif" | "webp" | "avif"
+            )
+        })
+        .unwrap_or_else(|| "png".to_string());
+    let destination = dir.join(format!("icon.{extension}"));
+
+    let client = reqwest::Client::builder()
+        .user_agent(crate::launcher_user_agent())
+        .build()
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?;
+    let response = client
+        .get(icon_url)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())?;
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?;
+    tokio::fs::write(&destination, &bytes)
+        .await
+        .map_err(|e| IOError::with_path(e, &destination))?;
+    Ok(destination)
 }
 
 /// Downloads a single file through the shared launcher download engine
@@ -308,8 +492,282 @@ async fn download_with_engine(
 }
 
 fn is_server_installable(file: &MrpackFile) -> bool {
-    file.env.as_ref().and_then(|env| env.server.as_deref())
-        != Some("unsupported")
+    if file.env.as_ref().and_then(|env| env.server.as_deref())
+        == Some("unsupported")
+    {
+        return false;
+    }
+    let path = file.path.replace('\\', "/");
+    !CLIENT_ONLY_INDEX_PREFIXES
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}
+
+/// Removes client-only folders (see [`CLIENT_ONLY_OVERRIDE_DIRS`]) that came
+/// along with the modpack's overrides; the `env` filtering applied to files
+/// listed in `modrinth.index.json` does not cover override contents.
+async fn remove_client_only_dirs(server_id: &str, dir: &Path) -> Result<()> {
+    for folder in CLIENT_ONLY_OVERRIDE_DIRS {
+        let path = dir.join(folder);
+        if !path.is_dir() {
+            continue;
+        }
+        tokio::fs::remove_dir_all(&path)
+            .await
+            .map_err(|e| IOError::with_path(e, &path))?;
+        log(
+            server_id,
+            &format!("Removed client-only {folder} folder from overrides"),
+        )
+        .await
+        .ok();
+    }
+    Ok(())
+}
+
+/// Temporarily downloads the client-side mods excluded from the server
+/// install, purely to learn their mod IDs from embedded metadata so installed
+/// mods hard-depending on them can be excluded too (pack authors sometimes
+/// mark a client UI mod as required on both sides while marking its
+/// client-side dependency as unsupported). Failures are logged and skipped:
+/// an unreadable mod simply keeps its dependents.
+async fn fetch_excluded_mod_ids(
+    server_id: &str,
+    state: &State,
+    excluded_files: &[&MrpackFile],
+) -> Result<HashSet<String>> {
+    let candidates: Vec<(String, String, Option<String>)> = excluded_files
+        .iter()
+        .filter_map(|file| {
+            let path = file.path.replace('\\', "/");
+            if !path.starts_with("mods/")
+                || !path.to_ascii_lowercase().ends_with(".jar")
+            {
+                return None;
+            }
+            file.downloads.first().map(|url| {
+                (
+                    path.rsplit('/').next().unwrap_or(&path).to_string(),
+                    url.clone(),
+                    file.hashes.get("sha1").cloned(),
+                )
+            })
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    log(
+        server_id,
+        &format!("Inspecting {} client-side mod(s)", candidates.len()),
+    )
+    .await?;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| {
+        ErrorKind::FSError(format!("Failed to create temporary directory: {e}"))
+    })?;
+    let mut unavailable = HashSet::new();
+    for (filename, url, sha1) in candidates {
+        let destination = temp_dir.path().join(&filename);
+        match download_metadata_jar(state, &url, &destination, sha1).await {
+            Ok(()) => match read_mod_metadata(&destination) {
+                Some(metadata) => {
+                    unavailable
+                        .extend(metadata.owned_ids().map(str::to_string));
+                }
+                None => {
+                    log(
+						server_id,
+						&format!("Could not read metadata of client-side mod {filename}"),
+					)
+					.await
+					.ok();
+                }
+            },
+            Err(error) => {
+                log(
+					server_id,
+					&format!("Failed to download client-side mod {filename} for inspection: {error}"),
+				)
+				.await
+				.ok();
+            }
+        }
+    }
+    Ok(unavailable)
+}
+
+/// Downloads a single jar for metadata inspection without touching the
+/// server's progress reporting.
+async fn download_metadata_jar(
+    state: &State,
+    url: &str,
+    destination: &Path,
+    sha1: Option<String>,
+) -> Result<()> {
+    let mut request = DownloadRequest::new(url, ResourceClass::Modpack);
+    if let Some(sha1) = &sha1 {
+        request = request.with_integrity(Integrity::sha1(sha1.clone()));
+    }
+    download_to_path(
+        request,
+        destination,
+        &state.download_semaphore,
+        &state.pool,
+        None,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Removes mods that cannot run on a dedicated server: those declaring
+/// themselves client-only in their Fabric metadata, and transitively any mod
+/// whose hard dependencies point to a removed or excluded mod. Left in place,
+/// such mods crash the server during dependency resolution.
+async fn prune_uninstallable_mods(
+    server_id: &str,
+    dir: &Path,
+    unavailable_ids: &HashSet<String>,
+) -> Result<()> {
+    let mods_dir = dir.join("mods");
+    if !mods_dir.is_dir() {
+        return Ok(());
+    }
+
+    let metas = collect_mod_metadata(mods_dir).await?;
+    for (path, reason) in compute_prune_plan(&metas, unavailable_ids) {
+        log(
+            server_id,
+            &format!(
+                "Removed mod {} ({reason})",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            ),
+        )
+        .await
+        .ok();
+        tokio::fs::remove_file(&path)
+            .await
+            .map_err(|e| IOError::with_path(e, &path))?;
+    }
+    Ok(())
+}
+
+/// Walks the mods directory recursively and reads each jar's embedded Fabric
+/// metadata. Jars without readable metadata are skipped entirely: only an
+/// explicit declaration justifies a removal.
+async fn collect_mod_metadata(
+    mods_dir: PathBuf,
+) -> Result<Vec<(PathBuf, ModMetadata)>> {
+    tokio::task::spawn_blocking(move || {
+        let mut found = Vec::new();
+        let mut pending = vec![mods_dir];
+        while let Some(current) = pending.pop() {
+            let Ok(entries) = std::fs::read_dir(&current) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    pending.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("jar"))
+                {
+                    if let Some(metadata) = read_mod_metadata(&path) {
+                        found.push((path, metadata));
+                    }
+                }
+            }
+        }
+        found
+    })
+    .await
+    .map_err(|e| {
+        ErrorKind::FSError(format!("Failed to scan installed mods: {e}"))
+            .as_error()
+    })
+}
+
+/// Reads a jar's embedded `fabric.mod.json`.
+fn read_mod_metadata(path: &Path) -> Option<ModMetadata> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut archive = zip::ZipArchive::new(file).ok()?;
+    let mut entry = archive.by_name("fabric.mod.json").ok()?;
+    let mut contents = Vec::new();
+    entry
+        .by_ref()
+        .take(ModMetadata::MAX_READ_BYTES)
+        .read_to_end(&mut contents)
+        .ok()?;
+    serde_json::from_slice(&contents).ok()
+}
+
+/// Plans which installed mods must be removed. Seeds are mods declaring
+/// themselves client-only plus every excluded mod's ID that no local mod
+/// owns; removal then cascades through hard `depends` edges until stable.
+/// Returns paths with a human-readable reason for each removal.
+fn compute_prune_plan(
+    metas: &[(PathBuf, ModMetadata)],
+    unavailable_ids: &HashSet<String>,
+) -> Vec<(PathBuf, String)> {
+    let locally_owned: HashSet<&str> = metas
+        .iter()
+        .flat_map(|(_, metadata)| metadata.owned_ids())
+        .collect();
+    let mut removed: HashSet<String> = unavailable_ids
+        .iter()
+        .filter(|id| !locally_owned.contains(id.as_str()))
+        .cloned()
+        .collect();
+
+    let mut planned = vec![false; metas.len()];
+    let mut reasons: Vec<Option<String>> = vec![None; metas.len()];
+    for (index, (_, metadata)) in metas.iter().enumerate() {
+        if metadata.environment.as_deref() == Some("client") {
+            planned[index] = true;
+            reasons[index] = Some("client-only".to_string());
+        }
+    }
+
+    loop {
+        let mut changed = false;
+        for index in 0..metas.len() {
+            if planned[index] {
+                continue;
+            }
+            let missing = metas[index]
+                .1
+                .hard_dependencies()
+                .into_iter()
+                .find(|dependency| removed.contains(*dependency));
+            if let Some(missing) = missing {
+                planned[index] = true;
+                reasons[index] = Some(format!("requires {missing}"));
+                changed = true;
+                for id in metas[index].1.owned_ids() {
+                    removed.insert(id.to_string());
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    metas
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| planned[*index])
+        .map(|(index, (path, _))| {
+            (
+                path.clone(),
+                reasons[index]
+                    .clone()
+                    .unwrap_or_else(|| "unusable on servers".to_string()),
+            )
+        })
+        .collect()
 }
 
 /// Locates the `modrinth.index.json` entry inside the archive, tolerating packs
@@ -385,6 +843,7 @@ async fn log(server_id: &str, line: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn server_only_files_are_installable() {
@@ -415,8 +874,247 @@ mod tests {
     }
 
     #[test]
+    fn client_only_paths_are_skipped() {
+        let base = MrpackFile {
+            path: String::new(),
+            hashes: HashMap::new(),
+            env: None,
+            downloads: vec!["https://example.com/a.zip".to_string()],
+            file_size: Some(10),
+        };
+
+        assert!(!is_server_installable(&MrpackFile {
+            path: "shaderpacks/fancy.zip".to_string(),
+            ..base.clone()
+        }));
+        assert!(!is_server_installable(&MrpackFile {
+            path: "resourcepacks/fancy.zip".to_string(),
+            ..base.clone()
+        }));
+        assert!(!is_server_installable(&MrpackFile {
+            path: r"texturepacks\fancy.zip".to_string(),
+            ..base.clone()
+        }));
+        // Datapacks stay: dedicated servers load them.
+        assert!(is_server_installable(&MrpackFile {
+            path: "datapacks/data.zip".to_string(),
+            ..base.clone()
+        }));
+    }
+
+    #[test]
     fn base_folder_derivation() {
         assert_eq!(base_folder("modrinth.index.json"), "");
         assert_eq!(base_folder("my-pack/modrinth.index.json"), "my-pack/");
+    }
+
+    /// Helper: create a minimal JAR (ZIP) with the given entry contents.
+    fn create_jar(path: &Path, entries: &[(&str, &str)]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        for (name, contents) in entries {
+            zip.start_file(*name, zip::write::FileOptions::<()>::default())
+                .unwrap();
+            zip.write_all(contents.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    #[tokio::test]
+    async fn client_declared_mod_jars_are_pruned() {
+        let dir = tempfile::tempdir().unwrap();
+        let mods = dir.path().join("mods");
+        let versioned = mods.join("1.21");
+        tokio::fs::create_dir_all(&versioned).await.unwrap();
+
+        create_jar(
+            &mods.join("fancymenu.jar"),
+            &[(
+                "fabric.mod.json",
+                r#"{"environment": "client", "id": "fancymenu"}"#,
+            )],
+        );
+        create_jar(
+            &versioned.join("nested-client.jar"),
+            &[("fabric.mod.json", r#"{"environment": "client"}"#)],
+        );
+        create_jar(
+            &mods.join("server-mod.jar"),
+            &[("fabric.mod.json", r#"{"environment": "*"}"#)],
+        );
+        create_jar(&mods.join("no-metadata.jar"), &[("some.file", "data")]);
+        std::fs::write(mods.join("corrupt.jar"), b"not a zip").unwrap();
+        std::fs::write(mods.join("readme.txt"), "keep me").unwrap();
+
+        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new())
+            .await
+            .unwrap();
+
+        assert!(!mods.join("fancymenu.jar").exists());
+        assert!(!versioned.join("nested-client.jar").exists());
+        assert!(mods.join("server-mod.jar").exists());
+        assert!(mods.join("no-metadata.jar").exists());
+        assert!(mods.join("corrupt.jar").exists());
+        assert!(mods.join("readme.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn mods_requiring_excluded_dependencies_are_pruned() {
+        let dir = tempfile::tempdir().unwrap();
+        let mods = dir.path().join("mods");
+        tokio::fs::create_dir_all(&mods).await.unwrap();
+
+        create_jar(
+            &mods.join("fancymenu.jar"),
+            &[(
+                "fabric.mod.json",
+                r#"{"id": "fancymenu", "depends": {"fabric-api": ">=0.9", "melody": ">=1.0"}}"#,
+            )],
+        );
+        create_jar(
+            &mods.join("konkrete.jar"),
+            &[(
+                "fabric.mod.json",
+                r#"{"id": "konkrete", "depends": {"fancymenu": "*"}}"#,
+            )],
+        );
+        create_jar(
+            &mods.join("optional-dependent.jar"),
+            &[(
+                "fabric.mod.json",
+                r#"{"id": "optional-dependent", "depends": {"melody": {"optional": true}}}"#,
+            )],
+        );
+        create_jar(
+            &mods.join("list-depends.jar"),
+            &[(
+                "fabric.mod.json",
+                r#"{"id": "list-depends", "depends": ["nonstandard"]}"#,
+            )],
+        );
+        create_jar(
+            &mods.join("plain.jar"),
+            &[("fabric.mod.json", r#"{"id": "plain"}"#)],
+        );
+
+        // Simulates melody having been excluded from the server install by
+        // its env mark: only its mod ID is known (via fetch_excluded_mod_ids),
+        // the jar itself never lands on disk.
+        let unavailable = HashSet::from(["melody".to_string()]);
+        prune_uninstallable_mods("test-server", dir.path(), &unavailable)
+            .await
+            .unwrap();
+
+        assert!(!mods.join("fancymenu.jar").exists());
+        assert!(!mods.join("konkrete.jar").exists());
+        assert!(mods.join("optional-dependent.jar").exists());
+        assert!(mods.join("list-depends.jar").exists());
+        assert!(mods.join("plain.jar").exists());
+    }
+
+    fn meta(
+        path: &str,
+        id: &str,
+        depends: serde_json::Value,
+    ) -> (PathBuf, ModMetadata) {
+        (
+            PathBuf::from(path),
+            serde_json::from_value(serde_json::json!({
+                "id": id,
+                "depends": depends,
+            }))
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn prune_plan_cascades_through_hard_dependencies() {
+        let metas = vec![
+            meta(
+                "a.jar",
+                "consumer",
+                serde_json::json!({"missing-lib": ">=1.0"}),
+            ),
+            meta("b.jar", "middleman", serde_json::json!({"consumer": "*"})),
+            meta("c.jar", "unrelated", serde_json::json!({"fabric-api": "*"})),
+        ];
+        let plan = compute_prune_plan(
+            &metas,
+            &HashSet::from(["missing-lib".to_string()]),
+        );
+
+        let removed: Vec<&str> = plan
+            .iter()
+            .map(|(path, _)| path.to_str().unwrap())
+            .collect();
+        assert_eq!(removed, vec!["a.jar", "b.jar"]);
+        assert!(plan[0].1.contains("missing-lib"));
+    }
+
+    #[test]
+    fn prune_plan_respects_local_provides() {
+        let metas = vec![
+            meta("shim.jar", "melody-shim", serde_json::json!({})),
+            meta("ui.jar", "ui", serde_json::json!({"melody": ">=1.0"})),
+        ];
+        // A local mod provides the "missing" dependency, so the dependent stays.
+        let mut shim = metas[0].1.clone();
+        shim.provides = vec!["melody".to_string()];
+        let metas = vec![("shim.jar".into(), shim), metas[1].clone()];
+        assert!(
+            compute_prune_plan(&metas, &HashSet::from(["melody".to_string()]))
+                .is_empty()
+        );
+
+        // Once the provider itself is removed, the dependent goes with it.
+        let mut provider = metas[0].1.clone();
+        provider.provides = vec!["melody".to_string()];
+        provider.depends = Some(serde_json::json!({"removed-core": "*"}));
+        let metas = vec![("provider.jar".into(), provider), metas[1].clone()];
+        let plan = compute_prune_plan(
+            &metas,
+            &HashSet::from(["melody".to_string(), "removed-core".to_string()]),
+        );
+        assert_eq!(plan.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn client_only_override_dirs_are_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let shaders = dir.path().join("shaderpacks");
+        tokio::fs::create_dir_all(shaders.join("Complementary"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            shaders.join("Complementary.zip"),
+            b"not really a shader",
+        )
+        .await
+        .unwrap();
+        let mods = dir.path().join("mods");
+        tokio::fs::create_dir_all(&mods).await.unwrap();
+
+        remove_client_only_dirs("test-server", dir.path())
+            .await
+            .unwrap();
+
+        assert!(!shaders.exists());
+        assert!(mods.exists());
+    }
+
+    #[tokio::test]
+    async fn missing_client_only_dirs_are_tolerated() {
+        let dir = tempfile::tempdir().unwrap();
+        remove_client_only_dirs("test-server", dir.path())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_mods_dir_is_tolerated_when_pruning() {
+        let dir = tempfile::tempdir().unwrap();
+        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new())
+            .await
+            .unwrap();
     }
 }

--- a/packages/app-lib/src/api/servers/modpack.rs
+++ b/packages/app-lib/src/api/servers/modpack.rs
@@ -1,0 +1,422 @@
+//! Modpack server installation: materializing an `.mrpack` (files, overrides,
+//! and the server launcher) into a managed server directory.
+//!
+//! The flow mirrors what a modpack client install does, but lands in the
+//! dedicated servers folder: the archive is downloaded and unpacked, every file
+//! listed in `modrinth.index.json` is fetched to its target path, client and
+//! server overrides are applied, and the loader's server launcher jar is placed
+//! next to them so the regular `servers.start` flow can boot it.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures::stream::{self, StreamExt};
+use serde::Deserialize;
+
+use crate::State;
+use crate::api::pack::archive_util::{
+    extract_archive_subdir, read_archive_entry_to_string,
+};
+use crate::api::pack::detect::decode_zip_entry_name;
+use crate::event::ServerPayloadType;
+use crate::event::emit::emit_server;
+use crate::event::emit::loading_try_for_each_concurrent;
+use crate::util::fetch::{
+    DownloadRequest, FetchProgressFn, Integrity, ResourceClass,
+    download_to_path,
+};
+use crate::util::io::IOError;
+use crate::{ErrorKind, Result};
+
+use super::files::download_to_dir;
+use super::manifest::{
+    ModpackInfo, read_manifest, server_path, write_manifest,
+};
+
+const MRPACK_MANIFEST_ENTRY: &str = "modrinth.index.json";
+const MRPACK_FILENAME: &str = "pack.mrpack";
+const OVERRIDES_DIR: &str = "overrides";
+const SERVER_OVERRIDES_DIR: &str = "server/overrides";
+/// How many modpack files download at once. Bounded by the global download
+/// semaphore, which also leaves headroom for concurrent instance installs.
+const MODPACK_DOWNLOAD_CONCURRENCY: usize = 8;
+
+/// Shared aggregate progress across concurrent file downloads, rendered as one
+/// smooth bar: completed bytes plus the in-flight file's partial bytes, kept
+/// monotonic so the UI never regresses.
+#[derive(Clone)]
+struct AggregateProgress {
+    bytes_done: Arc<AtomicU64>,
+    reported: Arc<AtomicU64>,
+    total: u64,
+}
+
+impl AggregateProgress {
+    fn new(total: u64) -> Self {
+        Self {
+            bytes_done: Arc::new(AtomicU64::new(0)),
+            reported: Arc::new(AtomicU64::new(0)),
+            total,
+        }
+    }
+}
+
+/// `modrinth.index.json` document; only the fields the server installer needs
+/// are modeled. `env` marks files that are client-only, server-only, or both.
+#[derive(Deserialize)]
+struct MrpackIndex {
+    #[serde(default)]
+    files: Vec<MrpackFile>,
+}
+
+#[derive(Deserialize, Clone)]
+struct MrpackFile {
+    path: String,
+    #[serde(default)]
+    hashes: HashMap<String, String>,
+    #[serde(default)]
+    env: Option<MrpackEnv>,
+    #[serde(default)]
+    downloads: Vec<String>,
+    #[serde(default)]
+    file_size: Option<u64>,
+}
+
+#[derive(Deserialize, Clone)]
+struct MrpackEnv {
+    #[serde(default)]
+    server: Option<String>,
+}
+
+/// Installs a modpack into an existing managed server.
+///
+/// `mrpack_url` / `mrpack_sha1` identify the `.mrpack` archive to download;
+/// `jar_url` / `jar_filename` / `jar_sha1` describe the loader's server
+/// launcher jar that boots the modpack. The optional `modpack_*` fields are
+/// recorded on the manifest so the UI can badge and link the server back to
+/// its source project.
+#[allow(clippy::too_many_arguments)]
+pub async fn install_modpack(
+    server_id: &str,
+    mrpack_url: &str,
+    mrpack_sha1: Option<String>,
+    jar_url: &str,
+    jar_filename: &str,
+    jar_sha1: Option<String>,
+    modpack_project_id: Option<String>,
+    modpack_version_id: Option<String>,
+    modpack_title: Option<String>,
+    modpack_icon_url: Option<String>,
+) -> Result<()> {
+    let dir = server_path(server_id).await?;
+    let mut manifest = read_manifest(&dir).await?;
+    let state = State::get().await?;
+
+    log(server_id, "Downloading modpack archive").await?;
+    download_with_engine(
+        server_id,
+        &state,
+        mrpack_url,
+        &dir.join(MRPACK_FILENAME),
+        mrpack_sha1,
+        ResourceClass::Modpack,
+        AggregateProgress::new(0),
+    )
+    .await?;
+    let archive_path = dir.join(MRPACK_FILENAME);
+
+    let manifest_entry = find_manifest_entry(&archive_path).await?;
+    let base_folder = base_folder(&manifest_entry);
+    let index = parse_index(&archive_path, &manifest_entry).await?;
+
+    let installable_files: Vec<&MrpackFile> = index
+        .files
+        .iter()
+        .filter(|file| is_server_installable(file))
+        .collect();
+    let total_bytes: u64 = installable_files
+        .iter()
+        .filter_map(|file| file.file_size)
+        .sum();
+
+    log(
+        server_id,
+        &format!("Downloading {} modpack file(s)", installable_files.len()),
+    )
+    .await?;
+
+    let files: Vec<(String, String, Option<String>, u64)> = installable_files
+        .iter()
+        .filter_map(|file| {
+            file.downloads.first().map(|url| {
+                (
+                    file.path.clone(),
+                    url.clone(),
+                    file.hashes.get("sha1").cloned(),
+                    file.file_size.unwrap_or(0),
+                )
+            })
+        })
+        .collect();
+
+    let progress = AggregateProgress::new(total_bytes);
+    let state_ref = state.clone();
+    let dir_ref = dir.clone();
+    let server_id_ref = server_id.to_string();
+    let num_files = files.len();
+    loading_try_for_each_concurrent(
+        stream::iter(files).map(Ok::<_, crate::Error>),
+        Some(MODPACK_DOWNLOAD_CONCURRENCY),
+        None,
+        0.0,
+        num_files,
+        None,
+        move |(path, url, sha1, size)| {
+            let server_id = server_id_ref.clone();
+            let dir = dir_ref.clone();
+            let state = state_ref.clone();
+            let progress = progress.clone();
+            async move {
+                log(&server_id, &format!("Downloading {path}")).await?;
+                let destination = dir.join(&path);
+                if let Some(parent) = destination.parent() {
+                    crate::util::io::create_dir_all(parent).await?;
+                }
+                download_with_engine(
+                    &server_id,
+                    &state,
+                    &url,
+                    &destination,
+                    sha1,
+                    ResourceClass::Modpack,
+                    progress.clone(),
+                )
+                .await?;
+                progress.bytes_done.fetch_add(size, Ordering::Relaxed);
+                Ok(())
+            }
+        },
+    )
+    .await?;
+
+    log(&server_id, "Applying modpack overrides").await?;
+    extract_archive_subdir(
+        archive_path.clone(),
+        format!("{base_folder}{OVERRIDES_DIR}/"),
+        dir.clone(),
+    )
+    .await?;
+    extract_archive_subdir(
+        archive_path,
+        format!("{base_folder}{SERVER_OVERRIDES_DIR}/"),
+        dir.clone(),
+    )
+    .await?;
+
+    log(
+        &server_id,
+        &format!("Downloading server launcher ({jar_filename})"),
+    )
+    .await?;
+    download_to_dir(&server_id, &dir, jar_url, jar_filename, jar_sha1).await?;
+
+    manifest.jar_name = Some(jar_filename.to_string());
+    if let (Some(project_id), Some(version_id), Some(title)) =
+        (modpack_project_id, modpack_version_id, modpack_title)
+    {
+        manifest.modpack = Some(ModpackInfo {
+            project_id,
+            version_id,
+            title,
+            icon_url: modpack_icon_url,
+        });
+    }
+    write_manifest(&dir, &manifest).await?;
+
+    Ok(())
+}
+
+/// Downloads a single file through the shared launcher download engine
+/// (mirrors, retries, integrity, range-segmented multi-connection transfer for
+/// large files, background-friendly concurrency) instead of a bespoke HTTP
+/// client. Progress is reported as server events through the shared aggregate.
+async fn download_with_engine(
+    server_id: &str,
+    state: &State,
+    url: &str,
+    destination: &Path,
+    sha1: Option<String>,
+    resource: ResourceClass,
+    progress: AggregateProgress,
+) -> Result<()> {
+    let mut request = DownloadRequest::new(url, resource);
+    if let Some(sha1) = &sha1 {
+        request = request.with_integrity(Integrity::sha1(sha1.clone()));
+    }
+    request = request.with_segmented_download(true);
+
+    let server_id = server_id.to_string();
+    let progress = progress.clone();
+    let mut progress_fn: Box<FetchProgressFn<'_>> = Box::new(
+        move |downloaded: u64,
+              file_total: u64|
+              -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            let server_id = server_id.clone();
+            let progress = progress.clone();
+            Box::pin(async move {
+                let current = progress
+                    .bytes_done
+                    .load(Ordering::Relaxed)
+                    .saturating_add(downloaded);
+                let shown = progress
+                    .reported
+                    .fetch_max(current, Ordering::Relaxed)
+                    .max(current);
+                emit_server(
+                    &server_id,
+                    ServerPayloadType::DownloadProgress {
+                        downloaded: shown,
+                        total: if progress.total > 0 {
+                            Some(progress.total)
+                        } else if file_total > 0 {
+                            Some(file_total)
+                        } else {
+                            None
+                        },
+                    },
+                )
+                .await
+                .ok();
+                Ok(())
+            })
+        },
+    );
+
+    download_to_path(
+        request,
+        destination,
+        &state.download_semaphore,
+        &state.pool,
+        Some(progress_fn.as_mut()),
+    )
+    .await?;
+    Ok(())
+}
+
+fn is_server_installable(file: &MrpackFile) -> bool {
+    file.env.as_ref().and_then(|env| env.server.as_deref())
+        != Some("unsupported")
+}
+
+/// Locates the `modrinth.index.json` entry inside the archive, tolerating packs
+/// whose contents are nested under a single base folder.
+async fn find_manifest_entry(archive_path: &Path) -> Result<String> {
+    let archive_path = archive_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&archive_path)
+            .map_err(|error| IOError::with_path(error, &archive_path))?;
+        let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+            ErrorKind::InputError(format!(
+                "Modpack archive is invalid: {error}"
+            ))
+            .as_error()
+        })?;
+        for index in 0..archive.len() {
+            let entry = archive.by_index_raw(index).map_err(|error| {
+                ErrorKind::InputError(format!(
+                    "Failed to read modpack archive entry: {error}"
+                ))
+                .as_error()
+            })?;
+            let name =
+                decode_zip_entry_name(entry.name_raw()).replace('\\', "/");
+            if name == MRPACK_MANIFEST_ENTRY
+                || name.ends_with(&format!("/{MRPACK_MANIFEST_ENTRY}"))
+            {
+                return Ok(name);
+            }
+        }
+        Err(ErrorKind::InputError(
+            "Modpack archive is missing modrinth.index.json".to_string(),
+        )
+        .as_error())
+    })
+    .await?
+}
+
+fn base_folder(manifest_entry: &str) -> String {
+    manifest_entry
+        .strip_suffix(MRPACK_MANIFEST_ENTRY)
+        .unwrap_or_default()
+        .to_string()
+}
+
+async fn parse_index(
+    archive_path: &Path,
+    manifest_entry: &str,
+) -> Result<MrpackIndex> {
+    let contents = read_archive_entry_to_string(
+        archive_path.to_path_buf(),
+        manifest_entry.to_string(),
+    )
+    .await?;
+    serde_json::from_str(&contents).map_err(|error| {
+        ErrorKind::InputError(format!(
+            "Failed to parse modrinth.index.json: {error}"
+        ))
+        .as_error()
+    })
+}
+
+async fn log(server_id: &str, line: &str) -> Result<()> {
+    emit_server(
+        server_id,
+        ServerPayloadType::Log {
+            line: line.to_string(),
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_only_files_are_installable() {
+        let installable = MrpackFile {
+            path: "mods/a.jar".to_string(),
+            hashes: HashMap::new(),
+            env: None,
+            downloads: vec!["https://example.com/a.jar".to_string()],
+            file_size: Some(10),
+        };
+        assert!(is_server_installable(&installable));
+
+        let optional = MrpackFile {
+            env: Some(MrpackEnv {
+                server: Some("optional".to_string()),
+            }),
+            ..installable.clone()
+        };
+        assert!(is_server_installable(&optional));
+
+        let client_only = MrpackFile {
+            env: Some(MrpackEnv {
+                server: Some("unsupported".to_string()),
+            }),
+            ..installable.clone()
+        };
+        assert!(!is_server_installable(&client_only));
+    }
+
+    #[test]
+    fn base_folder_derivation() {
+        assert_eq!(base_folder("modrinth.index.json"), "");
+        assert_eq!(base_folder("my-pack/modrinth.index.json"), "my-pack/");
+    }
+}

--- a/packages/app-lib/src/api/servers/modpack.rs
+++ b/packages/app-lib/src/api/servers/modpack.rs
@@ -193,6 +193,15 @@ pub async fn install_modpack(
     write_manifest(&dir, &manifest).await?;
     drop(manifest);
 
+    // Set the icon path early so the server shows the modpack icon immediately
+    if let Some(icon_url) = modpack_icon_url.as_deref() {
+        if let Ok(icon_path) = download_icon(&dir, icon_url).await {
+            let mut manifest = read_manifest(&dir).await?;
+            manifest.icon_path = Some(icon_path.to_string_lossy().into_owned());
+            write_manifest(&dir, &manifest).await?;
+        }
+    }
+
     let result = run_modpack_install(
         server_id,
         &dir,
@@ -208,6 +217,7 @@ pub async fn install_modpack(
     match result {
         Ok(()) => {
             manifest.jar_name = Some(jar_filename.to_string());
+            // Icon was already downloaded at the start; only download if still missing
             if manifest.icon_path.is_none() {
                 if let Some(icon_url) = modpack_icon_url.as_deref() {
                     match download_icon(&dir, icon_url).await {
@@ -370,13 +380,38 @@ async fn run_modpack_install(
     remove_client_only_dirs(server_id, dir).await?;
     let unavailable_ids =
         fetch_excluded_mod_ids(server_id, &state, &excluded_files).await?;
-    prune_uninstallable_mods(server_id, dir, &unavailable_ids).await?;
+
+    // Build a set of mod IDs that are explicitly marked as server-installable in the modpack index
+    let explicitly_server_installable: HashSet<String> = installable_files
+        .iter()
+        .filter_map(|file| {
+            let path = file.path.replace('\\', "/");
+            if path.starts_with("mods/") && path.to_ascii_lowercase().ends_with(".jar") {
+                Some(path.rsplit('/').next().unwrap_or(&path).to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    prune_uninstallable_mods(server_id, dir, &unavailable_ids, &explicitly_server_installable).await?;
 
     log(
         &server_id,
         &format!("Downloading server launcher ({jar_filename})"),
     )
     .await?;
+
+    // Create eula.txt with eula=false if it doesn't exist
+    let eula_path = dir.join("eula.txt");
+    if !eula_path.exists() {
+        tokio::fs::write(&eula_path, "eula=false\n")
+            .await
+            .map_err(|e| IOError::with_path(e, &eula_path))?;
+        log(server_id, "Created eula.txt with eula=false")
+            .await
+            .ok();
+    }
     download_to_dir(
         &server_id,
         dir,
@@ -625,10 +660,15 @@ async fn download_metadata_jar(
 /// themselves client-only in their Fabric metadata, and transitively any mod
 /// whose hard dependencies point to a removed or excluded mod. Left in place,
 /// such mods crash the server during dependency resolution.
+///
+/// Mods that are explicitly marked as server-installable in the modpack index
+/// (via `env.server != "unsupported"`) are never pruned, even if their own
+/// metadata declares them as client-only. This respects the pack author's intent.
 async fn prune_uninstallable_mods(
     server_id: &str,
     dir: &Path,
     unavailable_ids: &HashSet<String>,
+    explicitly_server_installable: &HashSet<String>,
 ) -> Result<()> {
     let mods_dir = dir.join("mods");
     if !mods_dir.is_dir() {
@@ -636,7 +676,7 @@ async fn prune_uninstallable_mods(
     }
 
     let metas = collect_mod_metadata(mods_dir).await?;
-    for (path, reason) in compute_prune_plan(&metas, unavailable_ids) {
+    for (path, reason) in compute_prune_plan(&metas, unavailable_ids, explicitly_server_installable) {
         log(
             server_id,
             &format!(
@@ -710,6 +750,7 @@ fn read_mod_metadata(path: &Path) -> Option<ModMetadata> {
 fn compute_prune_plan(
     metas: &[(PathBuf, ModMetadata)],
     unavailable_ids: &HashSet<String>,
+    explicitly_server_installable: &HashSet<String>,
 ) -> Vec<(PathBuf, String)> {
     let locally_owned: HashSet<&str> = metas
         .iter()
@@ -723,7 +764,18 @@ fn compute_prune_plan(
 
     let mut planned = vec![false; metas.len()];
     let mut reasons: Vec<Option<String>> = vec![None; metas.len()];
-    for (index, (_, metadata)) in metas.iter().enumerate() {
+    for (index, (path, metadata)) in metas.iter().enumerate() {
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
+        // Skip pruning if this mod is explicitly marked as server-installable in the modpack index
+        let is_explicitly_allowed = metadata
+            .id
+            .as_ref()
+            .map(|id| explicitly_server_installable.contains(id))
+            .unwrap_or(false)
+            || explicitly_server_installable.contains(&filename.to_string());
+        if is_explicitly_allowed {
+            continue;
+        }
         if metadata.environment.as_deref() == Some("client") {
             planned[index] = true;
             reasons[index] = Some("client-only".to_string());
@@ -946,7 +998,7 @@ mod tests {
         std::fs::write(mods.join("corrupt.jar"), b"not a zip").unwrap();
         std::fs::write(mods.join("readme.txt"), "keep me").unwrap();
 
-        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new())
+        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new(), &HashSet::new())
             .await
             .unwrap();
 
@@ -1001,7 +1053,7 @@ mod tests {
         // its env mark: only its mod ID is known (via fetch_excluded_mod_ids),
         // the jar itself never lands on disk.
         let unavailable = HashSet::from(["melody".to_string()]);
-        prune_uninstallable_mods("test-server", dir.path(), &unavailable)
+        prune_uninstallable_mods("test-server", dir.path(), &unavailable, &HashSet::new())
             .await
             .unwrap();
 
@@ -1041,6 +1093,7 @@ mod tests {
         let plan = compute_prune_plan(
             &metas,
             &HashSet::from(["missing-lib".to_string()]),
+            &HashSet::new(),
         );
 
         let removed: Vec<&str> = plan
@@ -1062,7 +1115,7 @@ mod tests {
         shim.provides = vec!["melody".to_string()];
         let metas = vec![("shim.jar".into(), shim), metas[1].clone()];
         assert!(
-            compute_prune_plan(&metas, &HashSet::from(["melody".to_string()]))
+            compute_prune_plan(&metas, &HashSet::from(["melody".to_string()]), &HashSet::new())
                 .is_empty()
         );
 
@@ -1074,6 +1127,7 @@ mod tests {
         let plan = compute_prune_plan(
             &metas,
             &HashSet::from(["melody".to_string(), "removed-core".to_string()]),
+            &HashSet::new(),
         );
         assert_eq!(plan.len(), 2);
     }
@@ -1113,7 +1167,7 @@ mod tests {
     #[tokio::test]
     async fn missing_mods_dir_is_tolerated_when_pruning() {
         let dir = tempfile::tempdir().unwrap();
-        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new())
+        prune_uninstallable_mods("test-server", dir.path(), &HashSet::new(), &HashSet::new())
             .await
             .unwrap();
     }

--- a/packages/app-lib/src/event/mod.rs
+++ b/packages/app-lib/src/event/mod.rs
@@ -317,6 +317,7 @@ pub enum ServerPayloadType {
         #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<ExitReason>,
     },
+    #[allow(dead_code)]
     EulaRequired {
         server_id: String,
         eula_text: String,

--- a/packages/app-lib/src/event/mod.rs
+++ b/packages/app-lib/src/event/mod.rs
@@ -291,6 +291,15 @@ pub struct ServerPayload {
     pub event: ServerPayloadType,
 }
 
+/// Classifies why a server process exited on its own, derived from the tail
+/// of its console output so the UI can react (e.g. offer the EULA dialog)
+/// instead of just reporting a dead process.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExitReason {
+    Eula,
+}
+
 #[derive(Serialize, Clone, Debug)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum ServerPayloadType {
@@ -305,6 +314,8 @@ pub enum ServerPayloadType {
     Started,
     Stopped {
         crashed: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<ExitReason>,
     },
 }
 

--- a/packages/app-lib/src/event/mod.rs
+++ b/packages/app-lib/src/event/mod.rs
@@ -317,6 +317,10 @@ pub enum ServerPayloadType {
         #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<ExitReason>,
     },
+    EulaRequired {
+        server_id: String,
+        eula_text: String,
+    },
 }
 
 #[derive(Serialize, Clone)]

--- a/packages/app-lib/src/install/events.rs
+++ b/packages/app-lib/src/install/events.rs
@@ -1069,8 +1069,10 @@ mod tests {
     use crate::install::model::{
         InstallJobEventKind, InstallJobExecutionMode, InstallJobKind,
         InstallJobStatus, InstallPauseReason, InstallPhaseDetails,
-        InstallPhaseId, InstallProgress, MissingModpackContentState,
+        InstallPhaseId, MissingModpackContentState,
     };
+    #[cfg(not(feature = "tauri"))]
+    use crate::install::model::InstallProgress;
     use crate::state::{InstanceLink, ModLoader};
 
     #[cfg(not(feature = "tauri"))]

--- a/packages/app-lib/src/state/instances/commands/sync_content_files.rs
+++ b/packages/app-lib/src/state/instances/commands/sync_content_files.rs
@@ -637,6 +637,7 @@ mod tests {
     /// external `.minecraft` root must have its content scanned from that root,
     /// not from the (empty) managed instance folder. This is the split-brain
     /// the content page empty-state used to hit.
+    #[cfg(not(feature = "tauri"))]
     #[tokio::test]
     async fn content_scan_uses_game_dir_override() {
         crate::event::EventState::init().await.unwrap();

--- a/packages/modrinth-content-management/tests/install.rs
+++ b/packages/modrinth-content-management/tests/install.rs
@@ -683,6 +683,7 @@ mod tests {
                 target: ResolutionPreferences::default(),
                 existing_project_ids: Vec::new(),
                 excluded_project_ids: Vec::new(),
+                force_project_ids: Vec::new(),
             },
         )
         .await
@@ -777,6 +778,7 @@ mod tests {
                 },
                 existing_project_ids: Vec::new(),
                 excluded_project_ids: Vec::new(),
+                force_project_ids: Vec::new(),
             },
         )
         .await

--- a/packages/server/src/server-types.ts
+++ b/packages/server/src/server-types.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.ts'
 
 const FABRIC_META_URL = 'https://meta.fabricmc.net/v2'
+const QUILT_META_URL = 'https://meta.quiltmc.org/v3'
 const PAPER_API_URL = 'https://fill.papermc.io/v3'
 const PAPER_PROJECT = 'paper'
 
@@ -79,6 +80,23 @@ export function fabricLoaderVersionsForGameUrl(gameVersion: string): string {
 	return `${FABRIC_META_URL}/versions/loader/${gameVersion}`
 }
 
+/** URL of the Quilt server launcher jar for a specific game/loader/installer combination. */
+export function quiltServerJarUrl(
+	gameVersion: string,
+	loaderVersion: string,
+	installerVersion: string,
+): string {
+	return `${QUILT_META_URL}/versions/loader/${gameVersion}/${loaderVersion}/${installerVersion}/server/jar`
+}
+
+export function quiltInstallerVersionsUrl(): string {
+	return `${QUILT_META_URL}/versions/installer`
+}
+
+export function quiltLoaderVersionsForGameUrl(gameVersion: string): string {
+	return `${QUILT_META_URL}/versions/loader/${gameVersion}`
+}
+
 export function paperBuildsUrl(gameVersion: string): string {
 	return `${PAPER_API_URL}/projects/${PAPER_PROJECT}/versions/${gameVersion}/builds`
 }
@@ -103,6 +121,13 @@ export function resolveServerJar(
 			return {
 				url: fabricServerJarUrl(input.gameVersion, input.loaderVersion, input.installerVersion),
 				filename: 'fabric-server.jar',
+			}
+		}
+		case 'quilt': {
+			if (!input.loaderVersion || !input.installerVersion) return null
+			return {
+				url: quiltServerJarUrl(input.gameVersion, input.loaderVersion, input.installerVersion),
+				filename: 'quilt-server.jar',
 			}
 		}
 		case 'paper': {

--- a/packages/ui/src/composables/use-batch-drop.ts
+++ b/packages/ui/src/composables/use-batch-drop.ts
@@ -11,7 +11,7 @@ export type BatchDropPhase =
 	| 'cancelled'
 
 export type BatchDropScanState = 'pending' | 'scanning' | 'done' | 'skipped' | 'error'
-export type BatchDropInstallState = 'queued' | 'processing' | 'success' | 'failed' | 'cancelled'
+export type BatchDropInstallState = 'queued' | 'processing' | 'success' | 'failed' | 'cancelled' | 'skipped'
 export type BatchDropResultStatus = 'success' | 'failed' | 'skipped' | 'cancelled'
 
 export interface BatchDropItem {

--- a/packages/ui/src/composables/use-instance-context.ts
+++ b/packages/ui/src/composables/use-instance-context.ts
@@ -1,10 +1,10 @@
-import { computed } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 export interface InstanceContext {
-	isInInstance: boolean
-	instanceId: string | null
-	currentPage: string | null
+	isInInstance: ComputedRef<boolean>
+	instanceId: ComputedRef<string | null>
+	currentPage: ComputedRef<string | null>
 }
 
 export function useInstanceContext(): InstanceContext {

--- a/packages/ui/src/layouts/shared/console/components/LogViewport.vue
+++ b/packages/ui/src/layouts/shared/console/components/LogViewport.vue
@@ -115,29 +115,43 @@ function estimateHeight(item: ViewportLine): number {
 }
 
 // 高度前缀和缓存：lines/wrap/fontSize 变化时重建（O(n)），滚动时二分查找（O(log n)）
+// 总高度必须是响应式的：普通变量 + 无依赖 computed 会缓存过期值，
+// 清空控制台后模板不再读取它，重启后 spacer 会以旧高度渲染（底部空白）。
 let heightPrefix: number[] | null = null
-let heightTotal = 0
+const heightTotal = ref(0)
 
 function rebuildHeights() {
 	const n = props.lines.length
 	if (!props.wrap) {
 		heightPrefix = null
-		heightTotal = n * lineHeightPx.value
+		heightTotal.value = n * lineHeightPx.value
 		return
 	}
-	heightPrefix = new Array(n)
+	const prefix = new Array<number>(n)
 	let acc = 0
 	for (let i = 0; i < n; i++) {
-		heightPrefix[i] = acc
+		prefix[i] = acc
 		acc += estimateHeight(props.lines[i]!)
 	}
-	heightTotal = acc
+	heightPrefix = prefix
+	heightTotal.value = acc
 }
 
 watch(
 	() => [props.lines, props.wrap, props.fontSize] as const,
-	() => {
+	([lines], previous) => {
 		rebuildHeights()
+		// A fresh stream after an empty console (clear, restart, initial
+		// hydration) always resumes bottom-following.
+		if (previous && previous[0].length === 0 && lines.length > 0) {
+			stickToBottom.value = true
+		}
+		if (lines.length === 0) {
+			// Reset the virtual window state along with the DOM scroll position;
+			// browsers may clamp silently without firing a scroll event.
+			scrollTop.value = 0
+			if (viewportRef.value) viewportRef.value.scrollTop = 0
+		}
 		if (stickToBottom.value) {
 			nextTick(scrollToBottom)
 		}
@@ -145,7 +159,7 @@ watch(
 	{ immediate: true },
 )
 
-const totalHeight = computed(() => heightTotal)
+const totalHeight = computed(() => heightTotal.value)
 
 // 虚拟窗口：可见行 + 上下缓冲
 const WINDOW_BUFFER = 15

--- a/packages/ui/src/layouts/shared/console/layout.vue
+++ b/packages/ui/src/layouts/shared/console/layout.vue
@@ -90,7 +90,7 @@
 		</div>
 
 		<div
-			class="relative min-h-0 flex-1 overflow-hidden rounded-[20px] border border-solid border-surface-4"
+			class="relative min-h-0 flex-1 overflow-hidden rounded-[20px]"
 		>
 			<LogViewport
 				ref="viewportRef"

--- a/packages/ui/src/layouts/shared/console/layout.vue
+++ b/packages/ui/src/layouts/shared/console/layout.vue
@@ -23,6 +23,15 @@
 				</ButtonStyled>
 			</div>
 		</div>
+		<CollapsibleAdmonition
+			v-if="ctx.crashAnalysis?.value && !isFullscreen"
+			type="critical"
+			:header="crashHeader"
+			:items="crashItems"
+			dismissible
+			@dismiss="ctx.onDismissCrash?.()"
+		/>
+
 		<div class="flex items-center gap-2">
 			<StyledInput
 				v-model="searchQuery"
@@ -103,23 +112,19 @@
 			</Transition>
 		</div>
 
-		<div
+		<StyledInput
 			v-if="showCommandInput"
-			class="rounded-[20px] border border-solid border-surface-4 bg-surface-3 p-4"
-		>
-			<StyledInput
-				v-model="commandInput"
-				v-tooltip="commandDisabled ? commandDisabledTooltip : undefined"
-				:icon="TerminalSquareIcon"
-				:placeholder="commandPlaceholder"
-				:disabled="commandDisabled"
-				wrapper-class="w-full"
-				input-class="!h-10"
-				autocomplete="off"
-				:spellcheck="false"
-				@keydown.enter="submitCommand"
-			/>
-		</div>
+			v-model="commandInput"
+			v-tooltip="commandDisabled ? commandDisabledTooltip : undefined"
+			:icon="TerminalSquareIcon"
+			:placeholder="commandPlaceholder"
+			:disabled="commandDisabled"
+			wrapper-class="w-full"
+			input-class="!h-9"
+			autocomplete="off"
+			:spellcheck="false"
+			@keydown.enter="submitCommand"
+		/>
 	</div>
 	<ShareModal
 		ref="shareModal"
@@ -584,6 +589,40 @@ const localCrashItems = computed<CollapsibleAdmonitionItem[]>(() => {
 	return items
 })
 
+const crashHeader = computed(() => {
+	const analysis = ctx.crashAnalysis?.value
+	const findings = analysis?.findings.length ?? 0
+	return formatMessage(consoleMessages.crashHeader, { findings })
+})
+
+const crashItems = computed<CollapsibleAdmonitionItem[]>(() => {
+	const analysis = ctx.crashAnalysis?.value
+	if (!analysis) return []
+	return analysis.findings.map((finding) => {
+		const copy = localFindingCopy[finding.id as keyof typeof localFindingCopy]
+		const title = copy
+			? formatMessage(copy.title)
+			: formatMessage(consoleMessages.fallbackFindingTitle, { finding: finding.id })
+		const action = copy
+			? formatMessage(copy.action)
+			: formatMessage(consoleMessages.fallbackFindingAction)
+		const evidence = finding.evidence.map((item) => `${item.filename}:${item.line} - ${item.text}`)
+		const mods = analysis.mods.map((mod) => {
+			const identity = mod.name || mod.id || mod.file_name
+			const modId = mod.id && mod.id !== identity ? ` (${mod.id})` : ''
+			return formatMessage(consoleMessages.matchedMod, {
+				identity,
+				modId,
+				fileName: mod.file_name,
+			})
+		})
+		return {
+			title,
+			descriptions: [action, ...mods, ...evidence],
+		}
+	})
+})
+
 const viewportRef = ref<InstanceType<typeof LogViewport> | null>(null)
 const shareModal = ref<InstanceType<typeof ShareModal> | null>(null)
 const deleteModal = ref<InstanceType<typeof NewModal> | null>(null)
@@ -701,7 +740,20 @@ function submitCommand() {
 	if (!command || commandDisabled.value || !ctx.sendCommand) return
 	ctx.sendCommand(command)
 	commandInput.value = ''
+	// The user just interacted with the console: pin the view to the bottom
+	// so the command echo and its response are visible immediately.
+	viewportRef.value?.scrollToBottom()
 }
+
+// Re-pins the viewport to the bottom (and re-enables bottom-following).
+// Exposed so hosts can react to external events such as a server starting.
+function scrollToBottom() {
+	viewportRef.value?.scrollToBottom()
+}
+
+defineExpose({
+	scrollToBottom,
+})
 
 const showDelete = computed(() => !isLiveSource.value && ctx.onDelete != null)
 


### PR DESCRIPTION
<img width="1310" height="835" alt="截屏2026-08-24 下午6 13 28" src="https://github.com/user-attachments/assets/d1681c92-918f-46a6-bced-0c8b296382b4" />
<img width="1292" height="815" alt="截屏2026-08-24 下午6 13 55" src="https://github.com/user-attachments/assets/25c12fb5-d7fd-42f1-8fe4-5359b3c8a39f" />
<img width="1277" height="813" alt="截屏2026-08-24 下午6 15 00" src="https://github.com/user-attachments/assets/42137390-9b8b-4542-b381-644d7a975044" />
<img width="1301" height="817" alt="截屏2026-08-24 下午6 14 40" src="https://github.com/user-attachments/assets/92aecb27-3c12-49ef-97be-3f5613933f58" />

## Sourcery 摘要

支持一键创建和后台安装整合包服务器，并提供持久化安装恢复机制和改进的服务器生命周期处理。

新功能：
- 支持从项目页面一键创建整合包服务器，并提供引导式设置、Java 和内存配置、自动下载、首次运行初始化以及 EULA 处理。
- 支持后台安装，并提供进度显示、重试/继续操作、持久化安装状态、整合包元数据和服务器通知。
- 安装可直接运行的整合包服务器内容，为 Vanilla、Fabric 和 Quilt 提供加载器启动器，同时过滤仅客户端文件和不兼容的模组。

错误修复：
- 改进服务器 EULA 检测，并在服务器接受 EULA 前退出时支持恢复。
- 修复重启服务器或重新填充日志时的控制台大小、重置行为和底部跟随问题。
- 为嵌套服务器文件下载添加安全保护，并移除可能触发 JVM/JNA 故障的 macOS 动态加载器环境变量。

改进：
- 更新服务器列表和详情控件，使下载中、已中断和设置失败状态的显示保持一致。
- 优化服务器控制台布局，并移除崩溃弹窗中的 AI 分析操作。
- 扩展服务器生命周期事件，加入分类后的退出原因，并添加 Quilt 启动器支持。

构建：
- 通过 Tauri 命令接口暴露整合包服务器安装命令。

测试：
- 增加对安全嵌套路径、EULA 和 JNA 退出检测、Quilt JAR 解析，以及整合包文件过滤和依赖项清理的测试覆盖。

杂项：
- 移除已废弃的兼容模式导入处理代码，并调整垃圾回收辅助模块的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持从项目页面一键创建模组包服务器，并以更可靠的方式在后台完成安装。

新功能：
- 支持从项目页面一键创建模组包服务器，并引导配置服务器类型、Java、内存、加载器版本、安装过程、首次运行初始化和 EULA 接受。
- 支持在后台安装模组包，提供进度和日志、持久化元数据、可恢复的失败处理，以及链接到所创建服务器的通知。
- 使用 Vanilla、Fabric 和 Quilt 启动器安装可直接运行服务器的模组包内容，同时排除仅限客户端的文件和不兼容的依赖项。

错误修复：
- 改进 EULA 检测，并在服务器因未接受 EULA 而退出时支持恢复。
- 修复服务器重启和日志刷新过程中控制台重置、尺寸、虚拟化高度以及跟随底部行为的问题。
- 防止嵌套服务器文件下载使用不安全路径，并缓解与 macOS JNA 相关的 JVM 故障。

增强功能：
- 统一服务器列表和详情页在安装中断、安装失败以及正在安装时的状态，并扩展服务器生命周期退出分类。
- 改进服务器控制台布局，并以内联方式展示崩溃分析，同时移除崩溃模态框中的 AI 分析操作。
- 添加 Quilt 服务器启动器解析，并支持在服务器清单中持久化模组包来源和安装状态。

构建：
- 通过 Tauri 命令接口公开模组包服务器安装操作。

测试：
- 增加对安全嵌套路径、EULA 和 JNA 退出检测、Quilt 启动器解析，以及模组包过滤和依赖项裁剪的测试覆盖。

日常维护：
- 移除已弃用的兼容模式导入处理，并修正垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持一键创建模组包服务器，并通过可恢复的安装流程和改进的服务器生命周期处理，实现可靠的后台安装。

新功能：
- 支持从项目页面一键创建模组包服务器，并引导配置服务器类型、Java、内存、加载器、初始化方式和 EULA 处理。
- 支持在后台安装模组包，提供进度和日志、持久化元数据、可恢复的失败处理，以及链接到已创建服务器的通知。
- 支持安装可运行的 Vanilla、Fabric 和 Quilt 模组包服务器，同时过滤仅客户端文件和不兼容的依赖项。

错误修复：
- 改进 EULA 检测，并在服务器于接受 EULA 前退出时支持恢复。
- 修复服务器重启和日志刷新过程中的控制台大小、重置、虚拟化以及底部跟随行为。
- 防止不安全的嵌套服务器下载路径，并缓解 macOS 上与 JNA 相关的 JVM 故障。

增强功能：
- 统一服务器列表和详情视图中的服务器安装状态与控件，包括下载中、已中断和失败状态。
- 改进服务器控制台布局，并在界面中直接显示崩溃分析。
- 扩展服务器生命周期事件，增加分类的退出原因，并添加 Quilt 启动器支持。

构建：
- 通过 Tauri 命令接口提供模组包服务器安装功能。

测试：
- 增加对嵌套路径安全性、EULA 和 JNA 退出检测、Quilt 启动器解析、模组包文件过滤以及依赖项清理的测试覆盖。

杂项：
- 移除已弃用的兼容模式导入处理，并调整垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持一键创建整合包服务器，并通过可靠的后台安装和改进的服务器生命周期处理提升使用体验。

新功能：
- 支持从项目页面一键创建整合包服务器，提供引导式配置、后台安装、首次运行初始化和 EULA 处理。
- 支持安装可运行的 Vanilla、Fabric 和 Quilt 整合包服务器，并持久化源元数据和可恢复的下载状态。

错误修复：
- 改进 EULA 退出检测和恢复机制，确保嵌套服务器文件下载的安全性，并提升服务器控制台大小调整、重置和底部跟随行为的稳定性。
- 通过清理动态加载器环境变量，缓解已知的 macOS JNA 相关 JVM 崩溃问题，并在控制台中提供可操作的提示。

增强功能：
- 统一服务器列表和详情页对下载中断及安装失败状态的操作控件，包括继续和重试操作。
- 扩展服务器生命周期事件，添加分类的退出原因；增加 Quilt 启动器解析，并在控制台中内联显示崩溃分析结果。

构建：
- 通过 Tauri 命令接口公开整合包服务器安装操作。

测试：
- 扩展对嵌套路径验证、EULA 和 JNA 退出检测、Quilt 启动器解析，以及整合包客户端文件过滤和依赖清理的测试覆盖范围。

杂项：
- 移除已弃用的兼容模式导入处理，并修正垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持一键创建整合包服务器，并通过可靠的后台安装机制和改进的服务器生命周期管理提升使用体验。

新功能：
- 可从项目页面一键创建整合包服务器，并提供引导式配置和服务器设置。
- 在后台运行整合包服务器安装，支持进度报告、元数据持久化、通知和失败后恢复。
- 安装可运行的 Vanilla、Fabric 和 Quilt 服务器内容，同时过滤仅客户端文件和不兼容的依赖项。

错误修复：
- 改进 EULA 检测，并在服务器接受 EULA 前退出时支持恢复。
- 稳定服务器控制台的大小调整、重置、滚动和日志刷新行为。
- 防止嵌套服务器文件下载使用不安全路径，并减少与 macOS JNA 相关的 JVM 崩溃。

改进：
- 统一服务器列表和详情视图中的安装状态与恢复控件，并扩展服务器退出原因的处理。
- 改进服务器控制台展示，加入内联崩溃分析，并添加 Quilt 启动器支持。

构建：
- 通过 Tauri 命令接口提供整合包服务器安装功能。

测试：
- 扩展对嵌套路径安全性、EULA 和 JNA 退出检测、Quilt 启动器解析，以及整合包过滤和依赖项清理的测试覆盖范围。

杂项：
- 移除已弃用的兼容模式导入处理，并调整垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持一键创建整合包服务器，并提供可靠的后台安装、恢复和生命周期处理。

新功能：
- 支持从项目页面一键创建整合包服务器，并提供引导式配置、后台安装和首次运行设置。
- 安装可运行的 Vanilla、Fabric 和 Quilt 整合包服务器，同时保留源元数据，并过滤仅客户端内容或不兼容内容。
- 通过 Tauri 服务器 API 提供整合包安装功能，支持可恢复的进度跟踪和失败状态记录。

错误修复：
- 改进 EULA 检测，并在服务器接受许可前退出时支持恢复；同时增强嵌套服务器文件下载，防止不安全路径。
- 稳定服务器控制台在重启和日志刷新过程中的尺寸调整、重置、虚拟化和底部跟随行为。
- 通过移除冲突的动态加载器环境变量，缓解已知的 macOS JNA 相关 JVM 故障。

增强功能：
- 统一服务器列表和详情页中针对下载中断及安装失败状态的操作控件，包括继续和重试操作。
- 扩展服务器生命周期退出分类，添加 Quilt 启动器支持，并在控制台中内嵌显示崩溃分析结果。

构建：
- 在 Tauri 命令接口中注册整合包服务器安装命令。

测试：
- 扩展对嵌套路径验证、EULA 和 JNA 退出检测、Quilt 启动器解析，以及整合包过滤和依赖裁剪的测试覆盖。

杂项：
- 移除已弃用的兼容模式导入处理，并调整垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持一键创建整合包服务器，并提供可靠的后台安装、恢复机制以及改进的服务器生命周期处理。

新功能：
- 支持从项目页面一键创建整合包服务器，并提供引导式配置和后台安装。
- 支持安装可运行的 Vanilla、Fabric 和 Quilt 整合包服务器，同时保留源元数据，并过滤仅客户端内容和不兼容的依赖项。
- 提供可恢复和可重试的安装状态，以及进度、日志、通知和服务器详情控制。

错误修复：
- 改进 EULA 检测，并在服务器接受协议前退出时提供恢复机制。
- 稳定服务器控制台在重启和日志刷新过程中的尺寸调整、重置、虚拟化和底部跟随行为。
- 防止服务器文件下载使用不安全路径，并缓解已知的 macOS JNA 相关 JVM 崩溃问题。

增强功能：
- 扩展服务器生命周期事件，增加分类的退出原因，并添加 Quilt 启动器解析。
- 改进服务器列表和详情视图中的服务器状态展示及控制台崩溃分析。

构建：
- 通过 Tauri 命令接口提供整合包服务器安装功能。

测试：
- 扩展对嵌套路径安全性、EULA 和 JNA 退出检测、Quilt 启动器解析、整合包过滤以及依赖项清理的测试覆盖范围。

日常维护：
- 移除已弃用的兼容模式导入处理，并调整垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持一键创建整合包服务器，并提供可靠的后台安装、恢复机制以及更完善的服务器生命周期处理。

新功能：
- 在项目页面中支持一键创建整合包服务器，并引导配置服务器名称、Java、内存、加载器兼容性、安装流程和初始服务器设置。
- 支持在后台安装整合包服务器，提供进度和日志记录、持久化源元数据、通知，以及可恢复或可重试的失败处理。
- 安装可运行的 Vanilla、Fabric 和 Quilt 服务器内容，同时过滤仅限客户端的文件以及不兼容的模组和依赖项。

错误修复：
- 改进 EULA 检测机制，并在服务器于接受协议前退出时支持恢复。
- 稳定服务器控制台在重启和日志刷新过程中的大小调整、重置、虚拟化以及底部跟随行为。
- 加强嵌套服务器文件下载的安全路径校验，并减少与 macOS JNA 相关的 JVM 故障。

增强功能：
- 统一服务器列表和详情页面针对安装中、已中断和失败安装状态的显示与控制，并扩展服务器退出原因处理。
- 改进服务器控制台展示，支持内联崩溃分析，并添加 Quilt 启动器支持。

构建：
- 通过 Tauri 命令接口提供整合包服务器安装功能。

测试：
- 扩展对嵌套路径验证、EULA 和 JNA 退出检测、Quilt 启动器解析、整合包过滤以及依赖项清理的测试覆盖范围。

杂项：
- 移除已弃用的兼容模式导入处理，并调整垃圾回收辅助工具的导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable one-click modpack server creation with reliable background installation, recovery, and improved server lifecycle handling.

New Features:
- Add one-click modpack server creation from project pages with guided setup for server name, Java, memory, loader compatibility, installation, and initial server configuration.
- Support background modpack server installation with progress and logs, persisted source metadata, notifications, and resumable or retryable failures.
- Install runnable Vanilla, Fabric, and Quilt server content while filtering client-only files and incompatible mods and dependencies.

Bug Fixes:
- Improve EULA detection and recovery when a server exits before the agreement is accepted.
- Stabilize server console sizing, reset, virtualization, and bottom-following behavior across restarts and log refreshes.
- Harden nested server file downloads against unsafe paths and reduce macOS JNA-related JVM failures.

Enhancements:
- Unify server list and detail states and controls for active, interrupted, and failed installations, and expand server exit-reason handling.
- Improve server console presentation with inline crash analysis and add Quilt launcher support.

Build:
- Expose modpack server installation through the Tauri command interface.

Tests:
- Expand coverage for nested path validation, EULA and JNA exit detection, Quilt launcher resolution, modpack filtering, and dependency pruning.

Chores:
- Remove deprecated compatibility-mode import handling and adjust garbage-collection helper imports.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>