### PR TITLE
fix(server): 修复服务器的文件板块无法正常加载文件

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -45,6 +45,10 @@ async fn initialize_state(app: tauri::AppHandle) -> api::Result<()> {
         .allow_directory(state.directories.instances_dir(), true)?;
     app.fs_scope()
         .allow_directory(state.directories.instances_dir(), true)?;
+    app.asset_protocol_scope()
+        .allow_directory(state.directories.servers_dir(), true)?;
+    app.fs_scope()
+        .allow_directory(state.directories.servers_dir(), true)?;
 
     Ok(())
 }


### PR DESCRIPTION
[错误] 服务器的文件板块无法正常加载文件
Fixes #361

## Sourcery 总结

错误修复：
- 通过在资产和文件系统作用域中授予应用访问服务器目录的权限，修复服务器文件加载问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix server file loading by granting the application access to the servers directory through the asset and filesystem scopes.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 通过在资产和文件系统作用域中授予应用访问服务器目录的权限，修复服务器文件加载问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix server file loading by granting the application access to the servers directory through the asset and filesystem scopes.

</details>

</details>