### PR TITLE
feat(app): 实现整合包开服版本选择

### DIFF
--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -167,7 +167,11 @@ export function createModpackServerFlowContext(
 		availableGameVersions.value = gameVersion ? [gameVersion] : []
 		loaderSupported.value = SUPPORTED_MODPACK_LOADERS.includes(loader.type)
 
-		name.value = packProject.title
+		// Default the server name to `<modpack title> <version number>` so different
+		// versions of the same modpack produce distinct server names instead of
+		// colliding.  A short uid is appended only if a name collision remains
+		// (see beginInstall), mirroring the direct-server id style.
+		name.value = `${packProject.title} ${packVersion.version_number ?? ''}`.trim()
 		selectedLoaderVersion.value = ''
 		loaderVersions.value = []
 	}
@@ -264,8 +268,24 @@ export function createModpackServerFlowContext(
 			}
 
 			if (!createdServer.value) {
+				// Ensure the chosen name is unique among existing servers.  When it
+				// collides we append a short uid (mirroring the direct-server id
+				// style) so duplicate modpack versions stay distinguishable; if the
+				// name is free, no suffix is added.
+				let finalName = name.value.trim()
+				try {
+					const existing = await servers.list()
+					const taken = new Set(existing.map((server) => server.name.trim().toLowerCase()))
+					if (taken.has(finalName.toLowerCase())) {
+						const uid = Math.random().toString(36).slice(2, 6)
+						finalName = `${finalName} ${uid}`
+					}
+				} catch {
+					// Best-effort uniqueness; the backend id already disambiguates.
+				}
+
 				const manifest = await servers.create({
-					name: name.value,
+					name: finalName,
 					serverType: serverType.value,
 					gameVersion: selectedGameVersion.value,
 					loaderVersion: needsLoaderVersion.value ? selectedLoaderVersion.value : undefined,
@@ -318,27 +338,27 @@ export function createModpackServerFlowContext(
 					throw new Error('Modpack has no downloadable file')
 				}
 
-			// The download runs through the shared background runner, so closing
-			// the wizard keeps it going; progress renders from the shared registry.
-			dispatched = true
-			installPhase.value = 'downloading'
-			// [SERVER-DOWNLOAD-BRIDGE] Pass the download manager reference
-			// captured during setup so the synthetic job appears in sidebar.
-			await startModpackServerInstall(
-				serverId,
-				{
-					mrpackUrl: primaryFile.url,
-					mrpackSha1: primaryFile.hashes?.sha1,
-					jarUrl: jar.url,
-					jarFilename: jar.filename,
-					jarSha1: jar.sha1,
-					modpackProjectId: project.value.id,
-					modpackVersionId: version.value.id,
-					modpackTitle: modpackTitle.value,
-					modpackIconUrl: modpackIconUrl.value,
-				},
-				downloadManager,
-			)
+				// The download runs through the shared background runner, so closing
+				// the wizard keeps it going; progress renders from the shared registry.
+				dispatched = true
+				installPhase.value = 'downloading'
+				// [SERVER-DOWNLOAD-BRIDGE] Pass the download manager reference
+				// captured during setup so the synthetic job appears in sidebar.
+				await startModpackServerInstall(
+					serverId,
+					{
+						mrpackUrl: primaryFile.url,
+						mrpackSha1: primaryFile.hashes?.sha1,
+						jarUrl: jar.url,
+						jarFilename: jar.filename,
+						jarSha1: jar.sha1,
+						modpackProjectId: project.value.id,
+						modpackVersionId: version.value.id,
+						modpackTitle: `${modpackTitle.value} ${modpackVersionNumber.value}`.trim(),
+						modpackIconUrl: modpackIconUrl.value,
+					},
+					downloadManager,
+				)
 				if (isStale()) return
 
 				// Modpack installation complete, no auto-start.

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -5915,6 +5915,9 @@
   "app.project.versions.already-installed": {
     "message": "Already installed"
   },
+  "app.project.versions.start-server": {
+    "message": "Create server"
+  },
   "app.restarting": {
     "message": "Restarting..."
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -5969,6 +5969,9 @@
   "app.project.versions.already-installed": {
     "message": "已安装"
   },
+  "app.project.versions.start-server": {
+    "message": "开服"
+  },
   "app.restarting": {
     "message": "正在重启……"
   },

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -5798,6 +5798,9 @@
   "app.project.versions.already-installed": {
     "message": "已安裝"
   },
+  "app.project.versions.start-server": {
+    "message": "開服"
+  },
   "app.restarting": {
     "message": "正在重新啟動..."
   },

--- a/apps/app-frontend/src/pages/project/Index.vue
+++ b/apps/app-frontend/src/pages/project/Index.vue
@@ -337,6 +337,7 @@
 					:translations="translations"
 					:translation-mode="translationMode"
 					:translation-style="translationStyle"
+					:start-server="(version) => openModpackServerFlow(version)"
 				/>
 			</template>
 			<template v-else> Project data couldn't not be loaded. </template>
@@ -644,15 +645,18 @@ const serverCapableModpack = computed(
 )
 const modpackServerModal = ref()
 
-async function openModpackServerFlow() {
+async function openModpackServerFlow(targetVersion) {
 	if (!data.value) return
-	let targetVersion = versions.value[0]
-	if (!targetVersion) {
-		const versionId = data.value.versions[0]
-		targetVersion = versionId ? await get_version(versionId, 'bypass').catch(() => null) : null
+	let version = targetVersion
+	if (!version) {
+		version = versions.value[0]
+		if (!version) {
+			const versionId = data.value.versions[0]
+			version = versionId ? await get_version(versionId, 'bypass').catch(() => null) : null
+		}
 	}
-	if (!targetVersion) return
-	modpackServerModal.value?.show(data.value, targetVersion)
+	if (!version) return
+	modpackServerModal.value?.show(data.value, version)
 }
 
 function handleModpackServerCreated(serverId) {

--- a/apps/app-frontend/src/pages/project/Versions.vue
+++ b/apps/app-frontend/src/pages/project/Versions.vue
@@ -30,6 +30,14 @@
 						<CheckIcon v-else />
 					</button>
 				</ButtonStyled>
+				<ButtonStyled v-if="serverCapable && startServer" circular type="transparent">
+					<button
+						v-tooltip="formatMessage(messages.startServer)"
+						@click.stop="() => startServer(version)"
+					>
+						<ServerIcon />
+					</button>
+				</ButtonStyled>
 				<ButtonStyled circular type="transparent">
 					<OverflowMenu
 						v-if="false"
@@ -72,7 +80,13 @@
 </template>
 
 <script setup>
-import { CheckIcon, DownloadIcon, ExternalIcon, MoreVerticalIcon } from '@modrinth/assets'
+import {
+	CheckIcon,
+	DownloadIcon,
+	ExternalIcon,
+	MoreVerticalIcon,
+	ServerIcon,
+} from '@modrinth/assets'
 import {
 	ButtonStyled,
 	commonMessages,
@@ -82,7 +96,7 @@ import {
 	ProjectPageVersions,
 	useVIntl,
 } from '@modrinth/ui'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { SwapIcon } from '@/assets/icons/index.js'
@@ -101,9 +115,13 @@ const messages = defineMessages({
 		id: 'app.project.versions.add-to-another-instance',
 		defaultMessage: 'Add to another instance',
 	},
+	startServer: {
+		id: 'app.project.versions.start-server',
+		defaultMessage: 'Create server',
+	},
 })
 
-defineProps({
+const props = defineProps({
 	project: {
 		type: Object,
 		default: () => {},
@@ -132,7 +150,15 @@ defineProps({
 		type: String,
 		default: null,
 	},
+	startServer: {
+		type: Function,
+		default: null,
+	},
 })
+
+const serverCapable = computed(
+	() => props.project?.project_type === 'modpack' && props.project?.server_side !== 'unsupported',
+)
 
 const { handleError } = injectNotificationManager()
 const route = useRoute()


### PR DESCRIPTION
## Sourcery 总结

支持创建特定版本的整合包服务器，并为其设置不同的服务器名称。

新功能：
- 允许用户直接从项目版本列表中兼容的整合包版本启动服务器。

错误修复：
- 防止由不同整合包版本创建的服务器共享相同的默认名称；如果仍然存在名称冲突，则添加简短后缀。

改进：
- 在创建的服务器安装元数据和显示名称中包含所选的整合包版本。

杂项：
- 为整合包版本服务器创建操作添加本地化文本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持用户为选定的项目版本创建模组包服务器，并使用能够区分版本的命名方式。

新功能：
- 添加按版本区分的操作，可直接从兼容的模组包项目版本创建服务器。

错误修复：
- 防止从不同模组包版本创建的服务器获得相同的默认名称，同时使用短后缀解决剩余的名称冲突。

改进：
- 在服务器名称和安装元数据中包含所选的模组包版本。

杂项：
- 为模组包服务器创建操作添加本地化文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable users to create modpack servers for a chosen project version with distinct version-aware naming.

New Features:
- Add a version-specific action for creating servers directly from compatible modpack project versions.

Bug Fixes:
- Prevent servers created from different modpack versions from receiving identical default names, while resolving remaining name conflicts with a short suffix.

Enhancements:
- Include the selected modpack version in the server name and installation metadata.

Chores:
- Add localized text for the modpack server creation action.

</details>

</details>