### PR TITLE
fix(server): 修复启动后显示cmd (#373)

### DIFF
--- a/packages/app-lib/src/api/logs/crash_analysis.rs
+++ b/packages/app-lib/src/api/logs/crash_analysis.rs
@@ -931,6 +931,7 @@ async fn collect_windows_crash_events(
     );
     let output = Command::new("powershell.exe")
         .args(["-NoProfile", "-NonInteractive", "-Command", &command])
+        .creation_flags(0x0800_0000)
         .output()
         .await;
     let Ok(output) = output else {

--- a/packages/app-lib/src/api/servers/ports.rs
+++ b/packages/app-lib/src/api/servers/ports.rs
@@ -95,9 +95,13 @@ async fn process_name(pid: u32) -> Option<String> {
 }
 
 #[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+#[cfg(target_os = "windows")]
 async fn port_listener_pids(port: u16) -> Result<Vec<u32>> {
     let output = Command::new("netstat")
         .args(["-ano", "-p", "tcp"])
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .map_err(|e| {
@@ -130,6 +134,7 @@ async fn port_listener_pids(port: u16) -> Result<Vec<u32>> {
 async fn force_terminate_pid(pid: u32) -> Result<()> {
     let output = Command::new("taskkill")
         .args(["/F", "/PID", &pid.to_string()])
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .map_err(|e| {
@@ -151,6 +156,7 @@ async fn force_terminate_pid(pid: u32) -> Result<()> {
 async fn process_name(pid: u32) -> Option<String> {
     let output = Command::new("tasklist")
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .ok()?;

--- a/packages/app-lib/src/util/symlink.rs
+++ b/packages/app-lib/src/util/symlink.rs
@@ -224,6 +224,7 @@ fn create_link_elevated_blocking(
     );
     let status = Command::new("powershell")
         .args(["-NoProfile", "-NonInteractive", "-Command", &command])
+        .creation_flags(0x0800_0000)
         .status()
         .map_err(|error| {
             std::io::Error::other(format!(


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 启动 PowerShell 和系统进程管理命令时，防止 Windows 命令窗口出现。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 启动 PowerShell 和系统进程管理命令时，防止 Windows 命令窗口出现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Windows command windows from appearing when launching PowerShell and system process-management commands.

</details>

</details>