### PR TITLE
feat(更新功能): 在debian使用pkexec+apt进行更新

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -135,9 +135,12 @@ import {
 	exportErrorLogs,
 	getOS,
 	getUpdateSize,
+	isAptLinux,
 	isDev,
 	isElevated,
 	isNetworkMetered,
+	installAptUpdate,
+	restartApp,
 	setRestartAfterPendingUpdate,
 } from '@/helpers/utils.js'
 import { start_join_server, start_join_singleplayer_world } from '@/helpers/worlds.ts'
@@ -306,6 +309,7 @@ const onboardingReplay = ref(false)
 const nativeDecorations = ref(false)
 
 const os = ref('')
+const aptLinux = ref(false)
 const isDevEnvironment = ref(false)
 
 /**
@@ -942,6 +946,7 @@ async function setupApp() {
 	if (defaultPageRoute && defaultPageRoute !== '/') await router.push(defaultPageRoute)
 
 	os.value = await getOS()
+	aptLinux.value = await isAptLinux().catch(() => false)
 	const dev = await isDev()
 	isDevEnvironment.value = dev
 	pendingUpdateAnnouncementVersion.value = pending_update_toast_for_version
@@ -1665,6 +1670,10 @@ const updatePopupMessages = defineMessages({
 		id: 'app.update-popup.reload',
 		defaultMessage: 'Reload to update',
 	},
+	aptUpdate: {
+		id: 'app.update-popup.apt-update',
+		defaultMessage: 'Update',
+	},
 	download: {
 		id: 'app.update-popup.download',
 		defaultMessage: 'Download ({size})',
@@ -1725,7 +1734,28 @@ function showDelayedUpdatePopup() {
 		return
 	}
 
-	if (metered.value && !finishedDownloading.value) {
+	if (aptLinux.value && !finishedDownloading.value) {
+		// Debian and derivatives: the update installs through the package
+		// manager with a single pkexec prompt, so there is no download size.
+		addPopupNotification({
+			title: formatMessage(updatePopupMessages.updateAvailable),
+			text: formatMessage(updatePopupMessages.linuxBody, { version: update.version }),
+			type: 'info',
+			autoCloseMs: null,
+			buttons: [
+				{
+					label: formatMessage(updatePopupMessages.aptUpdate),
+					action: () => downloadAvailableAppUpdate(),
+					color: 'brand',
+				},
+				{
+					label: formatMessage(updatePopupMessages.changelog),
+					action: () => openAppUpdateChangelog(),
+					keepOpen: true,
+				},
+			],
+		})
+	} else if (metered.value && !finishedDownloading.value) {
 		addPopupNotification({
 			title: formatMessage(updatePopupMessages.updateAvailable),
 			text: formatMessage(updatePopupMessages.meteredBody, { version: update.version }),
@@ -1811,6 +1841,21 @@ async function performUpdateCheck() {
 	console.log(`Update ${update.version} is available.`)
 
 	metered.value = await isNetworkMetered()
+	if (aptLinux.value) {
+		// Debian and derivatives update through apt; the pkexec prompt is the
+		// single authorization for the whole repo setup + package install.
+		console.log('apt-managed system; updating through apt')
+		if (!metered.value) {
+			console.log('Starting apt update')
+			downloadUpdate(update)
+		} else {
+			console.log(`Metered connection detected, not auto-updating via apt.`)
+			markAppUpdateActionable(update.version)
+			scheduleDelayedUpdatePopup()
+		}
+		return 'available'
+	}
+
 	if (!metered.value) {
 		console.log('Starting download of update')
 		downloadUpdate(update)
@@ -1852,6 +1897,10 @@ async function downloadUpdate(versionToDownload, source = getUpdateSource()) {
 		return
 	}
 
+	if (aptLinux.value) {
+		return installAptUpdateForVersion(versionToDownload)
+	}
+
 	if (downloading.value || appUpdateDownload.progress.value !== 0) {
 		console.error(`Update ${versionToDownload.version} already downloading`)
 		return
@@ -1891,6 +1940,29 @@ async function downloadUpdate(versionToDownload, source = getUpdateSource()) {
 	}
 }
 
+// Debian and derivatives update through apt with a single pkexec prompt.
+// The package is installed directly, so there is no separate download step.
+async function installAptUpdateForVersion(versionToDownload) {
+	if (downloading.value) {
+		console.error(`Update ${versionToDownload.version} already installing`)
+		return
+	}
+
+	console.log(`Installing update ${versionToDownload.version} via apt`)
+	downloading.value = true
+	try {
+		await installAptUpdate(versionToDownload.version)
+		downloading.value = false
+		finishedDownloading.value = true
+		console.log('Finished installing via apt!')
+		markAppUpdateActionable(versionToDownload.version, 'downloaded')
+		scheduleDelayedUpdatePopup()
+	} catch (error) {
+		downloading.value = false
+		handleError(error)
+	}
+}
+
 // Any download failure falls back to the next update source in line
 // (miawa → cnb → github): re-check there and download its installer, so a
 // broken mirror never strands users on an outdated build.
@@ -1923,6 +1995,18 @@ async function retryUpdateFromNextSource(failedSource, originalError) {
 
 async function installUpdate() {
 	restarting.value = true
+
+	if (aptLinux.value) {
+		// The apt package was already installed by pkexec; just relaunch into
+		// the new version.
+		try {
+			await restartApp()
+		} catch (e) {
+			restarting.value = false
+			handleError(e)
+		}
+		return
+	}
 
 	try {
 		await setRestartAfterPendingUpdate(true)

--- a/apps/app-frontend/src/helpers/utils.js
+++ b/apps/app-frontend/src/helpers/utils.js
@@ -35,6 +35,15 @@ export async function setRestartAfterPendingUpdate(should_restart) {
 	return await invoke('set_restart_after_pending_update', { shouldRestart: should_restart })
 }
 
+// Debian and its derivatives update through apt with a single pkexec prompt
+export async function isAptLinux() {
+	return await invoke('is_apt_linux')
+}
+
+export async function installAptUpdate(version) {
+	return await invoke('install_apt_update', { version })
+}
+
 // One of 'Windows', 'Linux', 'MacOS'
 export async function getOS() {
 	return await invoke('plugin:utils|get_os')

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -7730,6 +7730,9 @@
   "app.update-popup.download": {
     "message": "Download ({size})"
   },
+  "app.update-popup.apt-update": {
+    "message": "Update"
+  },
   "app.update-popup.download-complete": {
     "message": "Download complete"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -7739,6 +7739,9 @@
   "app.update-popup.download": {
     "message": "下载（{size}）"
   },
+  "app.update-popup.apt-update": {
+    "message": "更新"
+  },
   "app.update-popup.download-complete": {
     "message": "下载完成"
   },

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -682,6 +682,8 @@ fn main() {
             enqueue_update_for_installation,
             remove_enqueued_update,
             set_restart_after_pending_update,
+            is_apt_linux,
+            install_apt_update,
             toggle_decorations,
             set_transparent_window_frame,
             show_window,

--- a/apps/app/src/updater_impl.rs
+++ b/apps/app/src/updater_impl.rs
@@ -1,6 +1,7 @@
 use crate::api::Result;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tauri::http::HeaderValue;
 use tauri::http::header::ACCEPT;
@@ -9,7 +10,7 @@ use tauri_plugin_http::reqwest;
 use tauri_plugin_http::reqwest::ClientBuilder;
 use tauri_plugin_updater::{Error, Update, UpdaterExt};
 use theseus::{
-    LoadingBarType, emit_loading, init_loading, launcher_user_agent,
+    LoadingBarType, emit_loading, init_loading, launcher_user_agent, settings,
 };
 use tokio::time::Instant;
 use url::Url;
@@ -18,6 +19,12 @@ const MIAWA_API_BASE: &str = "https://miawa.cn/api/v2";
 const MIAWA_HOST: &str = "https://miawa.cn";
 const MIAWA_API_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(15);
+
+// Debian and derivatives update via the apt package manager. The whole
+// operation (repo setup script plus package install) runs as a single
+// `pkexec` invocation so the polkit authorization prompt appears only once.
+const AXOLOTL_APT_SETUP_URL: &str = "https://ppa.axlmc.org/setup.sh";
+const AXOLOTL_APT_PACKAGE: &str = "axolotl-launcher";
 
 // The updater plugin builds `Update` with no request timeout, so a stalled
 // connection would hang the download forever. Bound the whole download
@@ -448,4 +455,82 @@ pub async fn enqueue_update_for_installation<R: Runtime>(
 pub fn remove_enqueued_update<R: Runtime>(webview: Webview<R>) {
     let pending_data = webview.state::<PendingUpdateData>().inner();
     pending_data.0.lock().unwrap().take();
+}
+
+// ── Debian / derivatives apt update ─────────────────────────────
+
+/// Whether this Linux system updates Axolotl through apt (Debian and its
+/// derivatives) and has `pkexec` available for a single privileged prompt.
+#[tauri::command]
+pub fn is_apt_linux() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        let debian_like = Path::new("/etc/debian_version").exists()
+            || Path::new("/etc/apt").is_dir()
+            || Path::new("/usr/bin/apt-get").exists();
+        let has_pkexec = ["/usr/bin/pkexec", "/bin/pkexec"]
+            .iter()
+            .any(|path| Path::new(path).exists());
+        debian_like && has_pkexec
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+/// Update Axolotl on Debian and its derivatives through apt, prompting for
+/// root once via `pkexec`. Runs the repo setup script and the package
+/// install in a single privileged shell so only one authorization is asked.
+#[tauri::command]
+pub async fn install_apt_update(version: String) -> Result<()> {
+    if !is_apt_linux() {
+        return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
+            "apt updates are only supported on Debian-based Linux systems with pkexec"
+                .to_string(),
+        ))
+        .into());
+    }
+
+    // Everything runs as root under one pkexec prompt; no `sudo` needed inside.
+    let script = format!(
+        "curl -fsSL {AXOLOTL_APT_SETUP_URL} | bash && \
+         apt-get update && \
+         apt-get install -y {AXOLOTL_APT_PACKAGE}"
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        std::process::Command::new("pkexec")
+            .arg("sh")
+            .arg("-c")
+            .arg(&script)
+            .output()
+    })
+    .await
+    .map_err(|join| {
+        theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+            "Failed to run the apt updater: {join}"
+        )))
+    })?
+    .map_err(|io| {
+        theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+            "Failed to start pkexec: {io}"
+        )))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
+            format!("apt update failed: {}", stderr.trim()),
+        ))
+        .into());
+    }
+
+    // Persist the post-update announcement trigger so the new release notes
+    // show after the app restarts into the freshly installed version.
+    let mut current = settings::get().await?;
+    current.pending_update_toast_for_version = Some(version);
+    settings::set(current).await?;
+
+    Ok(())
 }

--- a/apps/app/src/updater_impl_noop.rs
+++ b/apps/app/src/updater_impl_noop.rs
@@ -29,3 +29,14 @@ fn updates_are_disabled() -> Result<()> {
 
 #[tauri::command]
 pub fn remove_enqueued_update() {}
+
+#[tauri::command]
+pub fn is_apt_linux() -> bool {
+    false
+}
+
+#[tauri::command]
+pub async fn install_apt_update(version: String) -> Result<()> {
+    let _ = version;
+    updates_are_disabled()
+}


### PR DESCRIPTION
在启动器运行在debian系并且更新的时候，不会使用文件替换，而是运行
```bash
pkexec sh -c 'curl -fsSL https://ppa.axlmc.org/setup.sh | bash &&apt-get update && apt-get install -y axolotl-launcher'
```

## Sourcery 摘要

允许基于 Debian 的 Linux 用户通过一次特权授权使用 apt 更新启动器，并重新启动到已安装的版本。

新功能：
- 通过一次经过 pkexec 授权的 apt 安装流程，支持基于 Debian 的 Linux 更新。
- 为由 apt 管理的系统提供平台检测和更新安装命令。

增强功能：
- 调整软件包管理器安装的更新的更新通知和重启行为，包括按流量计费网络的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Debian-based Linux users to update the launcher through apt with one privileged authorization and relaunch into the installed version.

New Features:
- Add Debian-based Linux updates through a single pkexec-authorized apt installation flow.
- Provide platform detection and update installation commands for apt-managed systems.

Enhancements:
- Adapt update notifications and restart behavior for package-manager-installed updates, including metered-network handling.

</details>