### PR TITLE
Fix duplicate content filter resetting after sorting

### DIFF
--- a/packages/ui/src/layouts/shared/content-tab/composables/content-filter-state.test.ts
+++ b/packages/ui/src/layouts/shared/content-tab/composables/content-filter-state.test.ts
@@ -39,6 +39,17 @@ test('keeps valid filters when the current search has no matches', () => {
 	)
 })
 
+test('keeps the duplicate filter when sorting changes the available type options', () => {
+	assert.deepEqual(
+		pruneContentFilterSelections(
+			{ typeFilters: ['duplicates'], statusFilters: [] },
+			{ type: ['mod', 'duplicates'], status: [] },
+			true,
+		),
+		{ typeFilters: ['duplicates'], statusFilters: [] },
+	)
+})
+
 test('keeps metadata exclusions through an empty loading state', () => {
 	const selections = { state: ['enabled'], loader: ['forge'] }
 	assert.deepEqual(pruneMetadataFilterSelections(selections, [], false), selections)

--- a/packages/ui/src/layouts/shared/content-tab/composables/content-pipeline.ts
+++ b/packages/ui/src/layouts/shared/content-tab/composables/content-pipeline.ts
@@ -173,6 +173,7 @@ export function useContentPipeline(config: ContentPipelineConfig) {
 		const type = new Set<string>()
 		const status = new Set<string>()
 		const allItems = [...modpackItemsNoUpdate.value, ...sortedItems.value]
+		const duplicateItemIds = new Set((duplicateItems?.value ?? []).map((item) => getItemId(item)))
 
 		for (const item of allItems) {
 			type.add(normalizeProjectType(item.project_type))
@@ -180,6 +181,9 @@ export function useContentPipeline(config: ContentPipelineConfig) {
 			if (showWarningsFilter && getClientWarningType(item) !== null) status.add('warnings')
 			if (isEnabledContentItem(item)) status.add('enabled')
 			if (isDisabledContentItem(item)) status.add('disabled')
+		}
+		if (allItems.some((item) => duplicateItemIds.has(getItemId(item)))) {
+			type.add('duplicates')
 		}
 
 		return {


### PR DESCRIPTION
## 修复内容

修复实例内容页面中选择“重复”筛选后更改排序，筛选条件会跳回“全部”的问题。滚动触发列表更新后，重新选择“重复”筛选也会再次被重置。

## 根因

“重复”是由重复内容数据动态生成的特殊筛选项，但筛选选项校验没有将它纳入有效选项集合；排序或列表更新后，校验逻辑会误将已选的“重复”筛选清除。

## 修改

- 将实际存在的重复内容加入筛选选项校验集合。
- 增加回归测试，确保排序导致选项重新计算时仍保留“重复”筛选。

## 验证

- `corepack pnpm --filter @modrinth/ui test`
- 19 项测试全部通过。

## Sourcery 总结

确保重复内容过滤器在排序和列表刷新过程中保持有效。

Bug 修复：
- 当排序或列表更新重新计算可用的过滤选项时，保留“重复项”内容过滤器。

测试：
- 添加回归测试，覆盖排序导致可用类型选项变化时仍保留重复项过滤器的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep the duplicate content filter valid across sorting and list refreshes.

Bug Fixes:
- Preserve the “duplicates” content filter when sorting or list updates recalculate available filter options.

Tests:
- Add regression coverage for retaining the duplicate filter when sorting changes the available type options.

</details>