### PR TITLE
fix(app): 全局文字禁止选择

### DIFF
--- a/apps/app-frontend/src/assets/stylesheets/global.css
+++ b/apps/app-frontend/src/assets/stylesheets/global.css
@@ -1,0 +1,21 @@
+/* Disable text selection across the app by default (desktop-app feel). */
+html,
+body,
+#app {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
+}
+
+/* Allow selection where it is genuinely useful: text inputs, editable
+   regions, and any element explicitly opted in via the `selectable` class. */
+input,
+textarea,
+select,
+[contenteditable='true'],
+[contenteditable=''],
+.selectable {
+	-webkit-user-select: text;
+	-moz-user-select: text;
+	user-select: text;
+}

--- a/apps/app-frontend/src/data/about/contributors.json
+++ b/apps/app-frontend/src/data/about/contributors.json
@@ -126,6 +126,12 @@
 		"contributions": 51
 	},
 	{
+		"name": "xjuunn",
+		"avatarUrl": "https://avatars.githubusercontent.com/u/145442547?v=4&s=96",
+		"url": "https://github.com/xjuunn",
+		"contributions": 50
+	},
+	{
 		"name": "kakala666",
 		"avatarUrl": "https://avatars.githubusercontent.com/u/110977625?v=4&s=96",
 		"url": "https://github.com/kakala666",
@@ -136,12 +142,6 @@
 		"avatarUrl": "https://avatars.githubusercontent.com/u/28601081?v=4&s=96",
 		"url": "https://github.com/clrxbl",
 		"contributions": 43
-	},
-	{
-		"name": "xjuunn",
-		"avatarUrl": "https://avatars.githubusercontent.com/u/145442547?v=4&s=96",
-		"url": "https://github.com/xjuunn",
-		"contributions": 41
 	},
 	{
 		"name": "piprett",

--- a/apps/app-frontend/src/main.js
+++ b/apps/app-frontend/src/main.js
@@ -1,5 +1,6 @@
 import 'floating-vue/dist/style.css'
 import 'overlayscrollbars/overlayscrollbars.css'
+import '@/assets/stylesheets/global.css'
 
 import { VueQueryPlugin } from '@tanstack/vue-query'
 import FloatingVue from 'floating-vue'


### PR DESCRIPTION
[错误] 部分不该被选中的 UI 文本可以选中
Fixes #383

## Sourcery 总结

错误修复：
- 防止在应用程序 UI 中选择文本，同时保留输入框、可编辑区域以及明确设置为可选择内容中的文本选择功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 禁用整个应用 UI 中的文本选择，同时保留输入框、可编辑区域和明确设置为可选择内容中的文本选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disable text selection across the application UI while preserving selection in inputs, editable regions, and explicitly selectable content.

</details>

</details>