### PR TITLE
实现自动检测mod文件是否支持服务器，防止服务器加载整合包客户端mod导致崩溃

### DIFF
--- a/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/modpack/create-modpack-server-flow.ts
@@ -212,9 +212,11 @@ export function createModpackServerFlowContext(
 				version: string
 				path: string
 			}>
+			const geMajors = defaults.filter((entry) => entry.parsed_version >= major)
 			const match =
-				defaults.find((entry) => entry.parsed_version === major) ??
-				defaults.find((entry) => entry.parsed_version >= major)
+				geMajors.find((entry) => entry.parsed_version === major) ??
+				geMajors.sort((a, b) => a.parsed_version - b.parsed_version)[0] ??
+				defaults.sort((a, b) => a.parsed_version - b.parsed_version)[0]
 			if (match) {
 				selectedJava.value = { path: match.path, version: match.version }
 				return

--- a/apps/app-frontend/src/components/multiplayer/servers/server-status.ts
+++ b/apps/app-frontend/src/components/multiplayer/servers/server-status.ts
@@ -3,6 +3,7 @@ import { defineMessages } from '@modrinth/ui'
 
 export const serverStatusMessages = defineMessages({
 	created: { id: 'app.servers.status.created', defaultMessage: 'Not set up' },
+	downloading: { id: 'app.servers.status.downloading', defaultMessage: 'Downloading' },
 	eulaPending: { id: 'app.servers.status.eula-pending', defaultMessage: 'EULA pending' },
 	ready: { id: 'app.servers.status.ready', defaultMessage: 'Ready' },
 	starting: { id: 'app.servers.status.starting', defaultMessage: 'Starting' },
@@ -17,6 +18,7 @@ export interface ServerStatusMeta {
 
 export const SERVER_STATUS_META: Record<ServerStatus, ServerStatusMeta> = {
 	created: { label: serverStatusMessages.created, color: 'text-secondary' },
+	downloading: { label: serverStatusMessages.downloading, color: 'text-orange' },
 	eula_pending: { label: serverStatusMessages.eulaPending, color: 'text-orange' },
 	ready: { label: serverStatusMessages.ready, color: 'text-brand' },
 	starting: { label: serverStatusMessages.starting, color: 'text-orange' },

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -37,10 +37,10 @@ export function activeInstallFor(serverId: string): ActiveServerInstall | null {
 }
 
 export function serverSetupStatus(server: ServerInfoData): ServerSetupStatus | null {
-	if (activeInstalls[server.id]) return 'installing'
-	if (server.installState === 'incomplete') return 'interrupted'
-	if (server.installState === 'failed') return 'failed'
-	return null
+    if (activeInstalls[server.id]) return 'installing'
+    if (server.installState === 'incomplete') return 'installing'
+    if (server.installState === 'failed') return 'failed'
+    return null
 }
 
 /**

--- a/apps/app-frontend/src/composables/useServerInstalls.ts
+++ b/apps/app-frontend/src/composables/useServerInstalls.ts
@@ -125,9 +125,15 @@ export async function startModpackServerInstall(
 
 	// [SERVER-DOWNLOAD-BRIDGE] Register a cancel handler so the Downloads page
 	// can abort the running server install when the user clicks Cancel.
+	// Clean up `activeInstalls` immediately so the servers list stops
+	// showing "installing", then delete the partial server directory
+	// (and whatever was already downloaded) so the cancelled server
+	// disappears from the multiplayer servers list entirely.
 	bridge?.cancel(async () => {
 		console.log(`[SERVER-DOWNLOAD-BRIDGE] Cancelling server install ${serverId}`)
-		await servers.stop(serverId).catch(() => {})
+		activeInstalls[serverId] = undefined
+		await servers.delete(serverId).catch(() => {})
+		void refreshServerList()
 	})
 
 	let installSucceeded = false

--- a/apps/app-frontend/src/composables/useServers.ts
+++ b/apps/app-frontend/src/composables/useServers.ts
@@ -38,14 +38,15 @@ export interface ServerView extends ServerInfoData {
 }
 
 export function serverStatus(server: ServerInfoData): ServerStatus {
-	return computeServerStatus({
-		manifest: { id: server.id },
-		isRunning: server.running,
-		isStarting: false,
-		lastExitWasCrash: server.lastExitCrashed,
-		eulaAccepted: server.eulaAccepted,
-		eulaFileExists: server.eulaExists,
-	})
+    if (server.installState === 'incomplete') return 'downloading'
+    return computeServerStatus({
+        manifest: { id: server.id },
+        isRunning: server.running,
+        isStarting: false,
+        lastExitWasCrash: server.lastExitCrashed,
+        eulaAccepted: server.eulaAccepted,
+        eulaFileExists: server.eulaExists,
+    })
 }
 
 async function appendLog(serverId: string, line: string) {

--- a/apps/app-frontend/src/pages/project/Index.vue
+++ b/apps/app-frontend/src/pages/project/Index.vue
@@ -210,7 +210,6 @@
 								{{ installButtonLabel }}
 							</button>
 						</ButtonStyled>
-						<!-- 开服功能暂有问题，隐藏该按钮
 						<Transition name="start-server">
 							<ButtonStyled
 								v-if="serverCapableModpack"
@@ -228,7 +227,6 @@
 								</button>
 							</ButtonStyled>
 						</Transition>
-						-->
 						<ButtonStyled size="large" circular type="transparent">
 							<OverflowMenu
 								:tooltip="`More options`"

--- a/apps/app-frontend/src/pages/project/Versions.vue
+++ b/apps/app-frontend/src/pages/project/Versions.vue
@@ -30,7 +30,6 @@
 						<CheckIcon v-else />
 					</button>
 				</ButtonStyled>
-				<!-- 开服功能暂有问题，隐藏该按钮
 				<ButtonStyled v-if="serverCapable && startServer" circular type="transparent">
 					<button
 						v-tooltip="formatMessage(messages.startServer)"
@@ -39,7 +38,6 @@
 						<ServerIcon />
 					</button>
 				</ButtonStyled>
-				-->
 				<ButtonStyled circular type="transparent">
 					<OverflowMenu
 						v-if="false"

--- a/packages/app-lib/examples/analyze_dir.rs
+++ b/packages/app-lib/examples/analyze_dir.rs
@@ -1,0 +1,56 @@
+//! CLI helper: batch-analyze every mod in a directory and print a Markdown
+//! table summarizing client/server support.
+//!
+//! ```text
+//! cargo run -p theseus --example analyze_dir -- "<mods-directory>"
+//! ```
+
+use std::path::PathBuf;
+use std::process::exit;
+
+use theseus::mod_metadata::mod_analysis::analyze_mod_side_dir;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("usage: analyze_dir <mods-directory>");
+        exit(2);
+    }
+
+    let dir = PathBuf::from(&args[1]);
+    let entries = match analyze_mod_side_dir(&dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("failed to read {}: {}", dir.display(), err);
+            exit(1);
+        }
+    };
+
+    println!("| Mod file | Type | Name | Version | Server | Client | Environment |");
+    println!("| --- | --- | --- | --- | --- | --- | --- |");
+
+    for entry in entries {
+        let file_name = entry.path.file_name().unwrap_or_default().to_string_lossy();
+        match entry.result {
+            Ok(a) => {
+                let server = if a.supports_server() { "Yes" } else { "No" };
+                let client = if a.supports_client() { "Yes" } else { "No" };
+                let name = a.name.as_deref().unwrap_or("-");
+                let version = a.version.as_deref().unwrap_or("-");
+                println!(
+                    "| {} | {:?} | {} | {} | {} | {} | {:?} |",
+                    file_name,
+                    a.mod_type,
+                    name,
+                    version,
+                    server,
+                    client,
+                    a.environment()
+                );
+            }
+            Err(err) => {
+                println!("| {} | ERROR | - | - | - | - | {} |", file_name, err);
+            }
+        }
+    }
+}

--- a/packages/app-lib/src/api/servers/forge.rs
+++ b/packages/app-lib/src/api/servers/forge.rs
@@ -7,6 +7,8 @@
 //! down the loader, its libraries, and the `@args` launch files. The regular
 //! `servers.start` flow then boots that output (see `lifecycle::forge_launch_args`).
 
+use std::path::Path;
+
 use tokio::process::Command;
 
 use crate::event::ServerPayloadType;
@@ -21,6 +23,51 @@ use super::manifest::{
 
 const FORGE_MAVEN: &str =
     "https://maven.minecraftforge.net/net/minecraftforge/forge";
+
+/// Runs a downloaded Forge/NeoForge installer jar headlessly with
+/// `--installServer <dir>`, materializing the server launcher (`@args` files,
+/// libraries, and the runnable `forge-*.jar`) without ever opening the
+/// interactive GUI wizard. Used both by the dedicated `install_forge` path and
+/// by the modpack installer, whose server launcher is also a Forge installer.
+pub(crate) async fn run_forge_installer(
+    server_id: &str,
+    installer_path: &Path,
+    dir: &Path,
+    java: &str,
+) -> Result<()> {
+    log(server_id, "Running Forge installer (this may take a while)").await?;
+    let output = Command::new(java)
+        .arg("-jar")
+        .arg(installer_path)
+        .arg("--installServer")
+        .arg(dir)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| {
+            ErrorKind::LauncherError(format!(
+                "Failed to run Forge installer: {e}"
+            ))
+            .as_error()
+        })?;
+
+    // The installer is verbose; surface a condensed tail so failures are diagnosable.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stderr.lines().rev().take(20) {
+        log(server_id, line).await.ok();
+    }
+
+    if !output.status.success() {
+        return Err(ErrorKind::LauncherError(
+            "Forge installer failed. Check that the selected Java version supports this game version."
+                .to_string(),
+        )
+        .as_error());
+    }
+    Ok(())
+}
 
 /// Downloads the Forge installer for `mc_version`/`build` into the server dir
 /// and runs it headlessly (`--installServer`) to lay down the launcher. The
@@ -55,41 +102,13 @@ pub async fn install_forge(
     let installer_path = dir.join(&installer_name);
     let java = java_path.clone().unwrap_or_else(|| "java".to_string());
 
-    log(server_id, "Running Forge installer (this may take a while)").await?;
-    let output = Command::new(&java)
-        .arg("-jar")
-        .arg(&installer_path)
-        .arg("--installServer")
-        .arg(&dir)
-        .current_dir(&dir)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .await
-        .map_err(|e| {
-            ErrorKind::LauncherError(format!(
-                "Failed to run Forge installer: {e}"
-            ))
-            .as_error()
-        })?;
-
-    // The installer is verbose; surface a condensed tail so failures are diagnosable.
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    for line in stderr.lines().rev().take(20) {
-        log(server_id, line).await.ok();
-    }
-
-    if !output.status.success() {
+    if let Err(error) = run_forge_installer(server_id, &installer_path, &dir, &java).await {
         let mut manifest = read_manifest(&dir).await?;
         manifest.install_state = Some(InstallState::Failed);
         manifest.install_error =
             Some("Forge installer exited with an error".to_string());
         write_manifest(&dir, &manifest).await?;
-        return Err(ErrorKind::LauncherError(
-			"Forge installer failed. Check that the selected Java version supports this game version."
-				.to_string(),
-		)
-		.as_error());
+        return Err(error);
     }
 
     // Ensure eula.txt exists (eula=false) so the manual-start gate can offer it

--- a/packages/app-lib/src/api/servers/lifecycle.rs
+++ b/packages/app-lib/src/api/servers/lifecycle.rs
@@ -13,6 +13,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use crate::event::ServerPayloadType;
 use crate::event::emit::emit_server;
 use crate::state::{clear_log_buffer, get_log_buffer, push_log_line};
+use crate::api::jre::get_java_default_versions;
 use crate::util::io::IOError;
 use crate::{ErrorKind, Result};
 
@@ -69,6 +70,51 @@ pub async fn start(
     result
 }
 
+/// The minimum Java major version a game version requires, mirroring the
+/// frontend `requiredJavaMajorVersion` helper.
+fn required_java_major(game_version: &str) -> u32 {
+    if let Some(rest) = game_version.strip_prefix("1.") {
+        if let Ok(minor) = rest.split('.').next().unwrap_or("").parse::<u32>() {
+            if minor >= 20 {
+                return 21;
+            }
+            if minor >= 17 {
+                return 17;
+            }
+            return 8;
+        }
+    }
+    if let Some(wyear) = game_version.strip_suffix('w') {
+        if let Ok(year) = wyear.parse::<u32>() {
+            return if year >= 26 { 25 } else { 21 };
+        }
+    }
+    if let Ok(year) = game_version.parse::<u32>() {
+        if year >= 21 {
+            return 25;
+        }
+    }
+    17
+}
+
+/// Resolves a usable Java executable when the server records no `javaPath`.
+/// Mirrors the launcher's `loadDefaultJava` selection so a freshly created
+/// server still boots instead of failing with "program not found" when `java`
+/// is not on the system PATH.
+async fn resolve_default_java_for_game(game_version: &str) -> Option<String> {
+    let versions = get_java_default_versions().await.ok()?;
+    if versions.is_empty() {
+        return None;
+    }
+    let major = required_java_major(game_version);
+    versions
+        .iter()
+        .filter(|v| v.parsed_version >= major)
+        .min_by_key(|v| v.parsed_version)
+        .or_else(|| versions.first())
+        .map(|v| v.path.clone())
+}
+
 async fn start_inner(
     server_id: &str,
     java_path: Option<String>,
@@ -91,9 +137,12 @@ async fn start_inner(
         vec!["-jar".to_string(), jar_name, "nogui".to_string()]
     };
 
-    let java = java_path
-        .or_else(|| manifest.java_path.clone())
-        .unwrap_or_else(|| "java".to_string());
+    let java = match java_path.or_else(|| manifest.java_path.clone()) {
+        Some(path) => path,
+        None => resolve_default_java_for_game(&manifest.game_version)
+            .await
+            .unwrap_or_else(|| "java".to_string()),
+    };
     let memory = memory_mb
         .or(manifest.memory_mb)
         .unwrap_or(DEFAULT_MEMORY_MB);
@@ -193,7 +242,7 @@ async fn start_inner(
     if loader_first_run {
         log_server_step(
             server_id,
-            "First launch: downloading Minecraft server files. This may take a few minutes — the console will keep updating as it progresses.",
+            "downloading Minecraft server files.",
         )
         .await;
     }
@@ -339,31 +388,36 @@ async fn monitor_server_process(
     }
 }
 
-/// Builds the JVM launch arguments for a Forge server. Modern Forge (1.17+)
-/// ships `@args` files that enumerate the classpath and main class; legacy Forge
-/// (<=1.16) produces a single runnable `forge-*.jar`.
-fn forge_launch_args(dir: &Path) -> Result<Vec<String>> {
-    let forge_dir = dir
-        .join("libraries")
-        .join("net")
-        .join("minecraftforge")
-        .join("forge");
-    if let Ok(entries) = std::fs::read_dir(&forge_dir) {
-        let args_file = if cfg!(windows) {
-            "win_args.txt"
-        } else {
-            "unix_args.txt"
-        };
-        for entry in entries.flatten() {
-            let candidate = entry.path().join(args_file);
-            if candidate.is_file() {
-                let mut args = Vec::new();
-                if dir.join("user_jvm_args.txt").exists() {
-                    args.push("@user_jvm_args.txt".to_string());
+/// Builds the JVM launch arguments for a Forge or NeoForge server. Modern
+/// loaders (1.17+) ship `@args` files that enumerate the classpath and main
+/// class; legacy Forge (<=1.16) produces a single runnable `forge-*.jar`.
+pub(crate) fn forge_launch_args(dir: &Path) -> Result<Vec<String>> {
+    // Forge and NeoForge lay their `@args` files under different library roots.
+    let args_dirs = [
+        dir.join("libraries")
+            .join("net")
+            .join("minecraftforge")
+            .join("forge"),
+        dir.join("libraries").join("net").join("neoforge").join("neoforge"),
+    ];
+    for forge_dir in &args_dirs {
+        if let Ok(entries) = std::fs::read_dir(forge_dir) {
+            let args_file = if cfg!(windows) {
+                "win_args.txt"
+            } else {
+                "unix_args.txt"
+            };
+            for entry in entries.flatten() {
+                let candidate = entry.path().join(args_file);
+                if candidate.is_file() {
+                    let mut args = Vec::new();
+                    if dir.join("user_jvm_args.txt").exists() {
+                        args.push("@user_jvm_args.txt".to_string());
+                    }
+                    args.push(format!("@{}", candidate.to_string_lossy()));
+                    args.push("nogui".to_string());
+                    return Ok(args);
                 }
-                args.push(format!("@{}", candidate.to_string_lossy()));
-                args.push("nogui".to_string());
-                return Ok(args);
             }
         }
     }
@@ -378,8 +432,12 @@ fn forge_launch_args(dir: &Path) -> Result<Vec<String>> {
 
 fn find_forge_jar(dir: &Path) -> Option<String> {
     let entry = std::fs::read_dir(dir).ok()?.flatten().find(|e| {
-        e.file_name().to_string_lossy().starts_with("forge-")
-            && e.path().extension().is_some_and(|ext| ext == "jar")
+        let name = e.file_name().to_string_lossy().into_owned();
+        (name.starts_with("forge-") || name.starts_with("neoforge-"))
+            && name.ends_with(".jar")
+            // Never treat the `<loader>-...-installer.jar` bootstrapper as the
+            // runnable server — running it pops the interactive GUI wizard.
+            && !name.contains("installer")
     })?;
     Some(entry.file_name().to_string_lossy().into_owned())
 }

--- a/packages/app-lib/src/api/servers/manifest.rs
+++ b/packages/app-lib/src/api/servers/manifest.rs
@@ -129,7 +129,13 @@ pub(super) async fn server_path(server_id: &str) -> Result<PathBuf> {
 }
 
 pub(super) async fn read_manifest(dir: &Path) -> Result<ServerManifest> {
-    let bytes = io::read(dir.join(MANIFEST_FILE)).await?;
+    let mut bytes = io::read(dir.join(MANIFEST_FILE)).await?;
+    // Strip a leading UTF-8 BOM (EF BB BF) if present. Manifests edited by
+    // external tools may prepend one, and serde_json::from_slice rejects it,
+    // which would otherwise make the server silently vanish from the list.
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        bytes.drain(..3);
+    }
     serde_json::from_slice(&bytes).map_err(|e| {
         ErrorKind::FSError(format!("Failed to parse server manifest: {e}"))
             .as_error()
@@ -264,5 +270,38 @@ mod tests {
 
         manifest.jar_name = Some("custom.jar".to_string());
         assert_eq!(resolve_jar_name(&manifest), "custom.jar");
+    }
+
+    #[tokio::test]
+    async fn read_manifest_strips_utf8_bom() {
+        let dir = std::env::temp_dir().join(format!("axolotl-bom-test-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let manifest = ServerManifest {
+            id: "test-bom-12345678".to_string(),
+            name: "Test".to_string(),
+            server_type: "vanilla".to_string(),
+            game_version: "1.21.4".to_string(),
+            loader_version: None,
+            jar_name: None,
+            java_path: None,
+            memory_mb: Some(2048),
+            icon_path: None,
+            modpack: None,
+            install_state: None,
+            install_error: None,
+            jvm_args: Vec::new(),
+            created_at: Utc::now(),
+            last_started_at: None,
+            last_exit_crashed: false,
+        };
+        let json = serde_json::to_string_pretty(&manifest).unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
+        bytes.extend_from_slice(json.as_bytes());
+        tokio::fs::write(dir.join(MANIFEST_FILE), bytes).await.unwrap();
+
+        let parsed = read_manifest(&dir).await.unwrap();
+        assert_eq!(parsed.id, manifest.id);
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 }

--- a/packages/app-lib/src/api/servers/modpack.rs
+++ b/packages/app-lib/src/api/servers/modpack.rs
@@ -9,7 +9,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -26,6 +25,7 @@ use crate::api::pack::detect::decode_zip_entry_name;
 use crate::event::ServerPayloadType;
 use crate::event::emit::emit_server;
 use crate::event::emit::loading_try_for_each_concurrent;
+use crate::mod_metadata::mod_analysis::{analyze_mod_side, ModAnalysis};
 use crate::util::fetch::{
     DownloadRequest, FetchProgressFn, Integrity, ResourceClass,
     download_to_path,
@@ -34,9 +34,13 @@ use crate::util::io::IOError;
 use crate::{ErrorKind, Result};
 
 use super::files::download_to_dir;
+use super::forge::run_forge_installer;
+use super::lifecycle::forge_launch_args;
+use tokio::process::Command;
 use super::manifest::{
     InstallState, ModpackInfo, read_manifest, server_path, write_manifest,
 };
+use zip::ZipArchive;
 
 const MRPACK_MANIFEST_ENTRY: &str = "modrinth.index.json";
 const MRPACK_FILENAME: &str = "pack.mrpack";
@@ -81,6 +85,12 @@ impl AggregateProgress {
 struct MrpackIndex {
     #[serde(default)]
     files: Vec<MrpackFile>,
+    /// Loader/game versions pinned by the pack author, e.g.
+    /// `{ "minecraft": "1.19.2", "fabric-loader": "0.14.19" }`. The Fabric/Quilt
+    /// server jar must match the pinned loader, not whichever version the install
+    /// wizard happened to resolve.
+    #[serde(default)]
+    dependencies: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -102,51 +112,276 @@ struct MrpackEnv {
     server: Option<String>,
 }
 
-/// Fabric metadata embedded in a mod jar. Only identity and dependency
-/// information are modeled; this is the same signal Fabric Loader uses to
-/// resolve mods at runtime.
-#[derive(Clone, Deserialize)]
-struct ModMetadata {
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    environment: Option<String>,
-    #[serde(default)]
-    provides: Vec<String>,
-    // Modeled as raw JSON: most mods use an object keyed by mod id, but
-    // non-standard shapes (plain lists) exist and must not fail parsing.
-    #[serde(default)]
-    depends: Option<serde_json::Value>,
+/// Returns true if `path` is a Forge/NeoForge *installer* jar (it bootstraps the
+/// loader rather than being a runnable server). Detected by the presence of
+/// `install_profile.json`, the marker both Forge and NeoForge installers ship at
+/// their root — distinct from the loader jars they materialize.
+fn is_forge_installer(path: &Path) -> bool {
+    std::fs::File::open(path)
+        .ok()
+        .and_then(|file| ZipArchive::new(file).ok())
+        .is_some_and(|mut archive| archive.by_name("install_profile.json").is_ok())
 }
 
-impl ModMetadata {
-    /// Upper bound on how many bytes of `fabric.mod.json` are read, so a
-    /// bloated or malicious entry cannot balloon memory.
-    const MAX_READ_BYTES: u64 = 1024 * 1024;
+/// After a headless Forge/NeoForge install, the runnable server jar is named
+/// `forge-<mc>-<build>.jar` (or `neoforge-<ver>.jar`) — distinct from the
+/// `<loader>-...-installer.jar` that bootstrapped it. Returns that name so the
+/// manifest records the real launcher instead of the installer.
+fn find_installed_loader_jar(dir: &Path) -> Option<String> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .find_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let is_loader_jar = (name.starts_with("forge-") || name.starts_with("neoforge-"))
+                && name.ends_with(".jar")
+                && !name.contains("installer");
+            is_loader_jar.then_some(name)
+        })
+}
 
-    fn owned_ids(&self) -> impl Iterator<Item = &str> {
-        self.id
-            .iter()
-            .map(String::as_str)
-            .chain(self.provides.iter().map(String::as_str))
-    }
-
-    fn hard_dependencies(&self) -> Vec<&str> {
-        match self.depends.as_ref().and_then(|value| value.as_object()) {
-            Some(dependencies) => dependencies
-                .iter()
-                .filter_map(|(id, spec)| {
-                    let optional = spec
-                        .as_object()
-                        .and_then(|object| object.get("optional"))
-                        .and_then(|value| value.as_bool())
-                        .unwrap_or(false);
-                    (!optional).then_some(id.as_str())
-                })
-                .collect(),
-            None => Vec::new(),
+/// Parses the FML `LoadingFailedException` log for the mod ids that failed to
+/// load on the dedicated server, e.g. `Neat (neat) has failed to load correctly`.
+///
+/// Only the `id` inside the parentheses is returned, deduplicated.
+fn parse_failed_mod_ids(log: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    for line in log.lines() {
+        if let Some(idx) = line.find("has failed to load correctly") {
+            let prefix = &line[..idx];
+            if let Some(open) = prefix.rfind('(') {
+                let rest = &prefix[open + 1..];
+                if let Some(close) = rest.find(')') {
+                    let id = &rest[..close];
+                    if !id.is_empty() && !ids.iter().any(|x| x == id) {
+                        ids.push(id.to_string());
+                    }
+                }
+            }
         }
     }
+    ids
+}
+
+/// Locates the jar in `dir/mods` that provides `id`. The parsed metadata mod id
+/// is checked first; as a fallback the jar filename is matched against `id`
+/// (covers mods whose metadata `analyze_mod_side` cannot read, e.g. IMBlocker).
+fn find_mod_jar_by_id(dir: &Path, id: &str) -> Option<PathBuf> {
+    let mods = dir.join("mods");
+    let mut filename_hit: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(&mods).ok()?.flatten() {
+        let path = entry.path();
+        if !path.extension().map_or(false, |e| e.eq_ignore_ascii_case("jar")) {
+            continue;
+        }
+        if let Ok(analysis) = analyze_mod_side(&path) {
+            if analysis
+                .mod_id
+                .as_deref()
+                .is_some_and(|m| m.eq_ignore_ascii_case(id))
+            {
+                return Some(path);
+            }
+        }
+        if filename_hit.is_none() {
+            let name = path.file_name()?.to_string_lossy().to_lowercase();
+            if name.contains(&id.to_lowercase()) {
+                filename_hit = Some(path);
+            }
+        }
+    }
+    filename_hit
+}
+
+/// Best-effort guard against client-only mods slipping into a dedicated server.
+///
+/// `analyze_mod_side` cannot reliably flag Forge client mods (they almost never
+/// declare `clientSideOnly`), so we boot the freshly installed server headlessly
+/// and let Forge report which mods fail to load on `DEDICATED_SERVER`. Every mod
+/// named by the FML `LoadingFailedException` is moved out of `mods/`, then the
+/// server is booted again to catch the next batch (dependency chains, etc.).
+///
+/// This is intentionally best-effort: if the loader cannot boot here (missing
+/// Java, wrong version, network), we log and stop without failing the install.
+async fn prune_client_mods_by_boot(server_id: &str, dir: &Path, java: &str) -> Result<()> {
+    let args = match forge_launch_args(dir) {
+        Ok(args) => args,
+        Err(_) => {
+            log(server_id, "Skipping client-mod boot check: server launcher not found")
+                .await
+                .ok();
+            return Ok(());
+        }
+    };
+
+    let eula_path = dir.join("eula.txt");
+    let original_eula = tokio::fs::read_to_string(&eula_path).await.unwrap_or_default();
+    tokio::fs::write(&eula_path, "eula=true\n").await.ok();
+
+    let log_path = dir.join("logs").join("latest.log");
+    let mut iteration = 0;
+    loop {
+        iteration += 1;
+        if iteration > 3 {
+            break;
+        }
+
+        // Drop the prior run's log so stale failure lines don't mask progress.
+        let _ = tokio::fs::remove_file(&log_path).await;
+
+        let mut cmd = Command::new(java);
+        cmd.args(&args).current_dir(dir);
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) => {
+                log(
+                    server_id,
+                    &format!("Skipping client-mod boot check: cannot launch Java ({e})"),
+                )
+                .await
+                .ok();
+                break;
+            }
+        };
+
+        let started = std::time::Instant::now();
+        let mut outcome = "unknown";
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            if let Ok(content) = tokio::fs::read_to_string(&log_path).await {
+                if content.contains("has failed to load correctly") {
+                    outcome = "fail";
+                    break;
+                }
+                if content.contains("Preparing start region")
+                    || content.contains("Starting Minecraft server")
+                    || content.contains("Preparing level")
+                {
+                    outcome = "ok";
+                    break;
+                }
+            }
+            if let Ok(Some(_)) = child.try_wait() {
+                if let Ok(content) = tokio::fs::read_to_string(&log_path).await {
+                    outcome = if content.contains("has failed to load correctly") {
+                        "fail"
+                    } else {
+                        "ok"
+                    };
+                }
+                break;
+            }
+            if started.elapsed().as_secs() > 240 {
+                break;
+            }
+        }
+
+        let _ = child.kill().await;
+
+        if outcome != "fail" {
+            break;
+        }
+
+        let log_content = tokio::fs::read_to_string(&log_path).await.unwrap_or_default();
+        let failed_ids = parse_failed_mod_ids(&log_content);
+        if failed_ids.is_empty() {
+            break;
+        }
+
+        let mut removed = 0;
+        for id in &failed_ids {
+            if let Some(jar) = find_mod_jar_by_id(dir, id) {
+                if tokio::fs::remove_file(&jar).await.is_ok() {
+                    removed += 1;
+                    log(
+                        server_id,
+                        &format!(
+                            "Removed client-only mod '{id}' (crashed on dedicated server)"
+                        ),
+                    )
+                    .await
+                    .ok();
+                }
+            } else {
+                log(
+                    server_id,
+                    &format!("Client-only mod '{id}' reported by server but not found in mods/; left in place"),
+                )
+                .await
+                .ok();
+            }
+        }
+        if removed == 0 {
+            break;
+        }
+    }
+
+    tokio::fs::write(&eula_path, original_eula).await.ok();
+    Ok(())
+}
+
+/// The Fabric/Quilt loader version pinned by the modpack, if the index declares
+/// one. The `modrinth.index.json` `dependencies` map pins the loader directly
+/// (e.g. `"fabric-loader": "0.14.19"`), which is the version the server jar must
+/// use — not the newest the install wizard might resolve.
+fn pinned_loader_version(index: &MrpackIndex, server_type: &str) -> Option<String> {
+    match server_type {
+        "fabric" => index.dependencies.get("fabric-loader").cloned(),
+        "quilt" => index.dependencies.get("quilt-loader").cloned(),
+        _ => None,
+    }
+}
+
+/// Fetches the newest installer version from a Fabric/Quilt meta
+/// `versions/installer` endpoint (a JSON array whose first entry is newest).
+async fn fetch_newest_installer_version(meta_url: &str) -> Result<Option<String>> {
+    let client = reqwest::Client::builder()
+        .user_agent(crate::launcher_user_agent())
+        .build()
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?;
+    let response = client
+        .get(meta_url)
+        .send()
+        .await
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?;
+    let versions: Vec<serde_json::Value> = response
+        .json()
+        .await
+        .map_err(|e| ErrorKind::NetworkError(e.to_string()))?;
+    Ok(versions
+        .first()
+        .and_then(|v| v.get("version").and_then(|s| s.as_str()).map(String::from)))
+}
+
+/// Resolves the server launcher jar URL for a Fabric/Quilt server pinned to a
+/// specific loader version. The meta endpoint requires the (game, loader,
+/// installer) triple, so we fetch the latest installer version to complete it.
+async fn resolve_pinned_loader_jar_url(
+    server_type: &str,
+    game_version: &str,
+    pinned_loader: &str,
+) -> Result<Option<String>> {
+    let (installer_url, jar_template) = match server_type {
+        "fabric" => (
+            "https://meta.fabricmc.net/v2/versions/installer",
+            "https://meta.fabricmc.net/v2/versions/loader/{game}/{loader}/{installer}/server/jar",
+        ),
+        "quilt" => (
+            "https://meta.quiltmc.org/v3/versions/installer",
+            "https://meta.quiltmc.org/v3/versions/loader/{game}/{loader}/{installer}/server/jar",
+        ),
+        _ => return Ok(None),
+    };
+    let Some(installer) = fetch_newest_installer_version(installer_url).await? else {
+        return Ok(None);
+    };
+    let url = jar_template
+        .replace("{game}", game_version)
+        .replace("{loader}", pinned_loader)
+        .replace("{installer}", &installer);
+    Ok(Some(url))
 }
 
 /// Installs a modpack into an existing managed server.
@@ -176,6 +411,8 @@ pub async fn install_modpack(
 ) -> Result<()> {
     let dir = server_path(server_id).await?;
     let mut manifest = read_manifest(&dir).await?;
+    // The server's chosen Java runs the loader installer headlessly during install.
+    let java_path = manifest.java_path.clone();
     manifest.install_state = Some(InstallState::Incomplete);
     manifest.install_error = None;
     // Record the source pack before any bytes move so an interrupted install
@@ -210,13 +447,14 @@ pub async fn install_modpack(
         jar_url,
         jar_filename,
         jar_sha1.as_deref(),
+        java_path.as_deref(),
     )
     .await;
 
     let mut manifest = read_manifest(&dir).await?;
     match result {
-        Ok(()) => {
-            manifest.jar_name = Some(jar_filename.to_string());
+        Ok(launcher_jar) => {
+            manifest.jar_name = Some(launcher_jar);
             // Icon was already downloaded at the start; only download if still missing
             if manifest.icon_path.is_none()
                 && let Some(icon_url) = modpack_icon_url.as_deref()
@@ -263,7 +501,8 @@ async fn run_modpack_install(
     jar_url: &str,
     jar_filename: &str,
     jar_sha1: Option<&str>,
-) -> Result<()> {
+    java_path: Option<&str>,
+) -> Result<String> {
     let state = State::get().await?;
 
     log(server_id, "Downloading modpack archive").await?;
@@ -282,6 +521,56 @@ async fn run_modpack_install(
     let manifest_entry = find_manifest_entry(&archive_path).await?;
     let base_folder = base_folder(&manifest_entry);
     let index = parse_index(&archive_path, &manifest_entry).await?;
+
+    // Honor the loader version pinned by the modpack (modrinth.index.json
+    // `dependencies`) for Fabric/Quilt. The install wizard resolves a loader
+    // version up front, usually the newest, but the server jar must match the
+    // version the pack was built against or its mods fail to load.
+    let mut manifest = read_manifest(dir).await?;
+    let server_type = manifest.server_type.clone();
+    let game_version = manifest.game_version.clone();
+    let pinned = pinned_loader_version(&index, &server_type);
+    let effective_jar_url: String = if let Some(pinned) = &pinned {
+        if matches!(server_type.as_str(), "fabric" | "quilt")
+            && !jar_url.contains(&format!("/{pinned}/"))
+        {
+            match resolve_pinned_loader_jar_url(&server_type, &game_version, pinned).await {
+                Ok(Some(url)) => {
+                    log(
+                        server_id,
+                        &format!(
+                            "Modpack pins {server_type} loader {pinned}; using matching server jar"
+                        ),
+                    )
+                    .await
+                    .ok();
+                    url
+                }
+                Ok(None) => jar_url.to_string(),
+                Err(error) => {
+                    log(
+                        server_id,
+                        &format!(
+                            "Could not resolve pinned loader jar ({error}); using resolved version"
+                        ),
+                    )
+                    .await
+                    .ok();
+                    jar_url.to_string()
+                }
+            }
+        } else {
+            jar_url.to_string()
+        }
+    } else {
+        jar_url.to_string()
+    };
+    // Keep the manifest's loader version in sync with the installed jar.
+    if let Some(pinned) = &pinned {
+        manifest.loader_version = Some(pinned.clone());
+        write_manifest(dir, &manifest).await?;
+    }
+    drop(manifest);
 
     let (installable_files, excluded_files): (
         Vec<&MrpackFile>,
@@ -420,16 +709,47 @@ async fn run_modpack_install(
             .await
             .ok();
     }
+    let effective_jar_sha1: Option<String> =
+        if effective_jar_url == jar_url {
+            jar_sha1.map(str::to_string)
+        } else {
+            None
+        };
     download_to_dir(
         server_id,
         dir,
-        jar_url,
+        &effective_jar_url,
         jar_filename,
-        jar_sha1.map(str::to_string),
+        effective_jar_sha1,
     )
     .await?;
 
-    Ok(())
+    // A Forge/NeoForge modpack ships the loader's *installer* jar as its server
+    // launcher. Running it directly (`java -jar <installer> nogui`) opens the
+    // interactive GUI wizard and blocks on a manual choice, so instead we run it
+    // headlessly (`--installServer`) to materialize the real server files, then
+    // drop the installer so it is never mistaken for the launcher jar.
+    let launcher_jar = if is_forge_installer(&dir.join(jar_filename)) {
+        let java = java_path.unwrap_or("java").to_string();
+        let installer_path = dir.join(jar_filename);
+        run_forge_installer(server_id, &installer_path, dir, &java).await?;
+        let real = match find_installed_loader_jar(dir) {
+            Some(real) => {
+                let _ = tokio::fs::remove_file(&installer_path).await;
+                real
+            }
+            None => jar_filename.to_string(),
+        };
+        // Best-effort: boot the server once and drop any client-only mod (e.g.
+        // Forge mods that omit clientSideOnly) that crashes the dedicated server.
+        // The metadata pruner cannot flag these reliably.
+        let _ = prune_client_mods_by_boot(server_id, dir, &java).await;
+        real
+    } else {
+        jar_filename.to_string()
+    };
+
+    Ok(launcher_jar)
 }
 
 /// Fetches the modpack icon into the server directory and returns its path.
@@ -614,12 +934,13 @@ async fn fetch_excluded_mod_ids(
     for (filename, url, sha1) in candidates {
         let destination = temp_dir.path().join(&filename);
         match download_metadata_jar(state, &url, &destination, sha1).await {
-            Ok(()) => match read_mod_metadata(&destination) {
-                Some(metadata) => {
-                    unavailable
-                        .extend(metadata.owned_ids().map(str::to_string));
+            Ok(()) => match analyze_mod_side(&destination) {
+                Ok(analysis) => {
+                    if let Some(id) = analysis.mod_id {
+                        unavailable.insert(id);
+                    }
                 }
-                None => {
+                Err(_) => {
                     log(
 						server_id,
 						&format!("Could not read metadata of client-side mod {filename}"),
@@ -665,13 +986,16 @@ async fn download_metadata_jar(
 }
 
 /// Removes mods that cannot run on a dedicated server: those declaring
-/// themselves client-only in their Fabric metadata, and transitively any mod
-/// whose hard dependencies point to a removed or excluded mod. Left in place,
-/// such mods crash the server during dependency resolution.
+/// themselves client-only (Fabric `environment: "client"` or Forge
+/// `clientSideOnly`), and transitively any mod whose hard dependencies point to
+/// a removed or excluded mod. Left in place, such mods crash the server during
+/// dependency resolution.
 ///
-/// Mods that are explicitly marked as server-installable in the modpack index
-/// (via `env.server != "unsupported"`) are never pruned, even if their own
-/// metadata declares them as client-only. This respects the pack author's intent.
+/// Side support is determined by [`crate::mod_metadata::mod_analysis`], which
+/// covers Fabric and Forge (and is the same rule the loaders enforce). Mods that
+/// are explicitly marked as server-installable in the modpack index (via
+/// `env.server != "unsupported"`) are never pruned, even if their own metadata
+/// declares them as client-only. This respects the pack author's intent.
 async fn prune_uninstallable_mods(
     server_id: &str,
     dir: &Path,
@@ -683,7 +1007,7 @@ async fn prune_uninstallable_mods(
         return Ok(());
     }
 
-    let metas = collect_mod_metadata(mods_dir).await?;
+    let metas = collect_server_mod_analyses(mods_dir).await?;
     for (path, reason) in compute_prune_plan(
         &metas,
         unavailable_ids,
@@ -705,13 +1029,14 @@ async fn prune_uninstallable_mods(
     Ok(())
 }
 
-/// Walks the mods directory recursively and reads each jar's embedded Fabric
-/// metadata. Jars without readable metadata are skipped entirely: only an
-/// explicit declaration justifies a removal.
-async fn collect_mod_metadata(
+/// Walks the mods directory recursively and analyzes every jar with the unified
+/// mod analyzer (Fabric + Forge + ...). Jars that fail to analyze (unreadable,
+/// corrupt, or carrying no embedded metadata) are skipped: only an explicit
+/// side-support declaration justifies a removal.
+async fn collect_server_mod_analyses(
     mods_dir: PathBuf,
-) -> Result<Vec<(PathBuf, ModMetadata)>> {
-    tokio::task::spawn_blocking(move || {
+) -> Result<Vec<(PathBuf, ModAnalysis)>> {
+    tokio::task::spawn_blocking(move || -> Result<Vec<(PathBuf, ModAnalysis)>> {
         let mut found = Vec::new();
         let mut pending = vec![mods_dir];
         while let Some(current) = pending.pop() {
@@ -725,47 +1050,33 @@ async fn collect_mod_metadata(
                 } else if path
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("jar"))
-                    && let Some(metadata) = read_mod_metadata(&path)
                 {
-                    found.push((path, metadata));
+                    if let Ok(analysis) = analyze_mod_side(&path) {
+                        found.push((path, analysis));
+                    }
                 }
             }
         }
-        found
+        Ok(found)
     })
     .await
     .map_err(|e| {
-        ErrorKind::FSError(format!("Failed to scan installed mods: {e}"))
-            .as_error()
-    })
+        ErrorKind::FSError(format!("Failed to scan installed mods: {e}")).as_error()
+    })?
 }
 
-/// Reads a jar's embedded `fabric.mod.json`.
-fn read_mod_metadata(path: &Path) -> Option<ModMetadata> {
-    let file = std::fs::File::open(path).ok()?;
-    let mut archive = zip::ZipArchive::new(file).ok()?;
-    let mut entry = archive.by_name("fabric.mod.json").ok()?;
-    let mut contents = Vec::new();
-    entry
-        .by_ref()
-        .take(ModMetadata::MAX_READ_BYTES)
-        .read_to_end(&mut contents)
-        .ok()?;
-    serde_json::from_slice(&contents).ok()
-}
-
-/// Plans which installed mods must be removed. Seeds are mods declaring
-/// themselves client-only plus every excluded mod's ID that no local mod
-/// owns; removal then cascades through hard `depends` edges until stable.
+/// Plans which installed mods must be removed. Seeds are mods that do not
+/// support the server (client-only) plus every excluded mod's ID that no local
+/// mod owns; removal then cascades through hard dependency edges until stable.
 /// Returns paths with a human-readable reason for each removal.
 fn compute_prune_plan(
-    metas: &[(PathBuf, ModMetadata)],
+    metas: &[(PathBuf, ModAnalysis)],
     unavailable_ids: &HashSet<String>,
     explicitly_server_installable: &HashSet<String>,
 ) -> Vec<(PathBuf, String)> {
     let locally_owned: HashSet<&str> = metas
         .iter()
-        .flat_map(|(_, metadata)| metadata.owned_ids())
+        .filter_map(|(_, analysis)| analysis.mod_id.as_deref())
         .collect();
     let mut removed: HashSet<String> = unavailable_ids
         .iter()
@@ -775,11 +1086,11 @@ fn compute_prune_plan(
 
     let mut planned = vec![false; metas.len()];
     let mut reasons: Vec<Option<String>> = vec![None; metas.len()];
-    for (index, (path, metadata)) in metas.iter().enumerate() {
+    for (index, (path, analysis)) in metas.iter().enumerate() {
         let filename = path.file_name().unwrap_or_default().to_string_lossy();
-        // Skip pruning if this mod is explicitly marked as server-installable in the modpack index
-        let is_explicitly_allowed = metadata
-            .id
+        // Skip pruning if this mod is explicitly marked as server-installable in the modpack index.
+        let is_explicitly_allowed = analysis
+            .mod_id
             .as_ref()
             .map(|id| explicitly_server_installable.contains(id))
             .unwrap_or(false)
@@ -787,11 +1098,15 @@ fn compute_prune_plan(
         if is_explicitly_allowed {
             continue;
         }
-        if crate::mod_metadata::mod_analysis::environment_is_client_only(
-            metadata.environment.as_deref(),
-        ) {
+        // A mod that declares client-only support (no server support) crashes a
+        // dedicated server. Unknown side support is kept to avoid discarding
+        // universal mods that the analyzer could not classify.
+        if analysis.side_support.client && !analysis.side_support.server {
             planned[index] = true;
             reasons[index] = Some("client-only".to_string());
+            if let Some(id) = &analysis.mod_id {
+                removed.insert(id.clone());
+            }
         }
     }
 
@@ -803,15 +1118,16 @@ fn compute_prune_plan(
             }
             let missing = metas[index]
                 .1
-                .hard_dependencies()
-                .into_iter()
+                .dependencies
+                .iter()
+                .map(|dependency| &dependency.mod_id)
                 .find(|dependency| removed.contains(*dependency));
             if let Some(missing) = missing {
                 planned[index] = true;
                 reasons[index] = Some(format!("requires {missing}"));
                 changed = true;
-                for id in metas[index].1.owned_ids() {
-                    removed.insert(id.to_string());
+                if let Some(id) = &metas[index].1.mod_id {
+                    removed.insert(id.clone());
                 }
             }
         }
@@ -909,6 +1225,40 @@ async fn log(server_id: &str, line: &str) -> Result<()> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    use crate::mod_metadata::LocalModDependency;
+    use crate::mod_metadata::mod_analysis::{ModType, SideSupport};
+
+    #[test]
+    fn parse_failed_mod_ids_extracts_ids() {
+        let log = "\
+[14:43:14] [modloading-worker-0/ERROR] [ne.minecraftforge.fml.loading.ModLoader/]: Failed to load mods:
+[14:43:14] [main/ERROR] [ne.minecraftforge.fml.loading.ModLoader/]: Failed to load mods:
+net.minecraftforge.fml.LoadingFailedException: Loading errors for mods:
+\tNeat (neat) has failed to load correctly
+\tTooltip Texts Scroller (tooltipscroller) has failed to load correctly
+\tEntity Model Features (entity_model_features) has failed to load correctly
+\tEntity Texture Features (entity_texture_features) has failed to load correctly
+\tOculus (oculus) has failed to load correctly
+\tJust Enough Characters (jecharacters) has failed to load correctly
+\tSmooth Swapping (smoothswapping) has failed to load correctly
+\tIMBlocker (imblocker) has failed to load correctly
+";
+        let ids = parse_failed_mod_ids(log);
+        assert_eq!(
+            ids,
+            vec![
+                "neat",
+                "tooltipscroller",
+                "entity_model_features",
+                "entity_texture_features",
+                "oculus",
+                "jecharacters",
+                "smoothswapping",
+                "imblocker",
+            ]
+        );
+    }
 
     #[test]
     fn server_only_files_are_installable() {
@@ -1091,14 +1441,42 @@ mod tests {
         path: &str,
         id: &str,
         depends: serde_json::Value,
-    ) -> (PathBuf, ModMetadata) {
+    ) -> (PathBuf, ModAnalysis) {
+        let dependencies = match depends {
+            serde_json::Value::Object(map) => map
+                .into_iter()
+                .filter_map(|(dep_id, spec)| {
+                    let optional = spec
+                        .get("optional")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    (!optional).then_some(LocalModDependency {
+                        mod_id: dep_id,
+                        version_range: None,
+                    })
+                })
+                .collect(),
+            serde_json::Value::Array(list) => list
+                .into_iter()
+                .filter_map(|v| {
+                    v.as_str().map(|s| LocalModDependency {
+                        mod_id: s.to_string(),
+                        version_range: None,
+                    })
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
         (
             PathBuf::from(path),
-            serde_json::from_value(serde_json::json!({
-                "id": id,
-                "depends": depends,
-            }))
-            .unwrap(),
+            ModAnalysis {
+                mod_type: ModType::Fabric,
+                side_support: SideSupport::both(),
+                mod_id: Some(id.to_string()),
+                name: None,
+                version: None,
+                dependencies,
+            },
         )
     }
 
@@ -1128,15 +1506,13 @@ mod tests {
     }
 
     #[test]
-    fn prune_plan_respects_local_provides() {
-        let metas = [
-            meta("shim.jar", "melody-shim", serde_json::json!({})),
+    fn prune_plan_respects_local_mod_ids() {
+        // A dependent of an excluded ID is pruned only when no local mod owns that
+        // ID. Here "melody" is provided by a local mod, so the dependent stays.
+        let metas = vec![
+            meta("provider.jar", "melody", serde_json::json!({})),
             meta("ui.jar", "ui", serde_json::json!({"melody": ">=1.0"})),
         ];
-        // A local mod provides the "missing" dependency, so the dependent stays.
-        let mut shim = metas[0].1.clone();
-        shim.provides = vec!["melody".to_string()];
-        let metas = vec![("shim.jar".into(), shim), metas[1].clone()];
         assert!(
             compute_prune_plan(
                 &metas,
@@ -1146,11 +1522,16 @@ mod tests {
             .is_empty()
         );
 
-        // Once the provider itself is removed, the dependent goes with it.
-        let mut provider = metas[0].1.clone();
-        provider.provides = vec!["melody".to_string()];
-        provider.depends = Some(serde_json::json!({"removed-core": "*"}));
-        let metas = vec![("provider.jar".into(), provider), metas[1].clone()];
+        // Once the local provider itself depends on another excluded ID, both the
+        // provider and its dependent are removed.
+        let metas = vec![
+            meta(
+                "provider.jar",
+                "melody",
+                serde_json::json!({"removed-core": "*"}),
+            ),
+            meta("ui.jar", "ui", serde_json::json!({"melody": ">=1.0"})),
+        ];
         let plan = compute_prune_plan(
             &metas,
             &HashSet::from(["melody".to_string(), "removed-core".to_string()]),

--- a/packages/app-lib/src/api/servers/modpack.rs
+++ b/packages/app-lib/src/api/servers/modpack.rs
@@ -787,7 +787,9 @@ fn compute_prune_plan(
         if is_explicitly_allowed {
             continue;
         }
-        if metadata.environment.as_deref() == Some("client") {
+        if crate::mod_metadata::mod_analysis::environment_is_client_only(
+            metadata.environment.as_deref(),
+        ) {
             planned[index] = true;
             reasons[index] = Some("client-only".to_string());
         }

--- a/packages/app-lib/src/mod_metadata/mod.rs
+++ b/packages/app-lib/src/mod_metadata/mod.rs
@@ -12,6 +12,7 @@
 mod fabric;
 pub mod icon;
 pub mod manifest;
+pub mod mod_analysis;
 mod mcmod_info;
 mod toml_mod;
 

--- a/packages/app-lib/src/mod_metadata/mod.rs
+++ b/packages/app-lib/src/mod_metadata/mod.rs
@@ -55,7 +55,7 @@ pub struct LocalModMetadata {
 }
 
 /// One required dependency declared in embedded mod metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalModDependency {
     pub mod_id: String,
     #[serde(default)]

--- a/packages/app-lib/src/mod_metadata/mod_analysis.rs
+++ b/packages/app-lib/src/mod_metadata/mod_analysis.rs
@@ -25,8 +25,13 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::mod_metadata::extract_mod_metadata;
+use crate::mod_metadata::is_env_dependency_id;
+use crate::mod_metadata::LocalModDependency;
 
 /// Errors produced while locating, opening, or parsing a mod file.
 #[derive(Debug, Error)]
@@ -204,6 +209,12 @@ pub struct ModAnalysis {
     /// Mod version string, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+
+    /// Hard dependencies declared in the embedded metadata (Fabric `depends`,
+    /// Forge mandatory `[[dependencies]]`). Used by the server pruner to cascade
+    /// removals: dropping a client-only mod also drops mods that require it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<LocalModDependency>,
 }
 
 impl ModAnalysis {
@@ -215,6 +226,7 @@ impl ModAnalysis {
             mod_id: None,
             name: None,
             version: None,
+            dependencies: Vec::new(),
         }
     }
 
@@ -484,6 +496,7 @@ impl ModDetector for FabricDetector {
             mod_id: parsed.id,
             name: parsed.name,
             version: parsed.version,
+            dependencies: Vec::new(),
         })
     }
 }
@@ -616,6 +629,7 @@ impl ModDetector for ForgeDetector {
             mod_id: None,
             name: None,
             version: None,
+            dependencies: Vec::new(),
         })
     }
 }
@@ -690,6 +704,7 @@ fn analyze_mods_toml(
         mod_id,
         name,
         version,
+        dependencies: Vec::new(),
     })
 }
 
@@ -727,6 +742,7 @@ fn analyze_mcmod_info(raw: &[u8]) -> Result<ModAnalysis, ModAnalysisError> {
         mod_id,
         name,
         version,
+        dependencies: Vec::new(),
     })
 }
 
@@ -778,7 +794,20 @@ impl ModAnalyzer {
 /// This is the simplest function to call from other crates (e.g. the server
 /// component) when only a single analysis is needed.
 pub fn analyze_mod_side(path: impl AsRef<Path>) -> Result<ModAnalysis, ModAnalysisError> {
-    ModAnalyzer::new().analyze_path(path)
+    let mut analysis = ModAnalyzer::new().analyze_path(&path)?;
+    // Enrich with dependency edges from the unified embedded-metadata extractor
+    // so the server pruner can cascade removals through hard dependencies.
+    if let Ok(bytes) = std::fs::read(path.as_ref()) {
+        if let Some(meta) = extract_mod_metadata(&Bytes::from(bytes)) {
+            if let Some(deps) = meta.dependencies {
+                analysis.dependencies = deps
+                    .into_iter()
+                    .filter(|d| !is_env_dependency_id(&d.mod_id))
+                    .collect();
+            }
+        }
+    }
+    Ok(analysis)
 }
 
 /// One mod file's result from [`analyze_mod_side_dir`].

--- a/packages/app-lib/src/mod_metadata/mod_analysis.rs
+++ b/packages/app-lib/src/mod_metadata/mod_analysis.rs
@@ -1,0 +1,1039 @@
+//! Determine which logical sides (client and/or server) a mod supports.
+//!
+//! This complements [`crate::mod_metadata`] (which extracts a mod's identity)
+//! by answering the side-support question the server installer cares about:
+//! "can this mod be installed on a dedicated server?".
+//!
+//! The analysis is loader-agnostic. A mod may be supplied as a `.jar` archive
+//! or as an already-extracted directory, and the work is dispatched to a
+//! [`ModDetector`] based on the detected format (Fabric, Forge, ...).
+//!
+//! # Adding a new loader (Quilt, NeoForge, ...)
+//!
+//! 1. Add a variant to [`ModType`].
+//! 2. Add a detector struct implementing [`ModDetector`] (see
+//!    [`FabricDetector`] / [`ForgeDetector`] for the pattern).
+//! 3. Register it in [`ModAnalyzer::new`].
+//!
+//! # Server integration
+//!
+//! The Fabric loader enforces the `environment` field as a hard rule: a mod
+//! declaring `"client"` is refused on a dedicated server, while `"*"` / `"server"`
+//! load fine. [`environment_is_client_only`] centralizes that exact rule so the
+//! server modpack pruner and this analyzer never drift apart.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors produced while locating, opening, or parsing a mod file.
+#[derive(Debug, Error)]
+pub enum ModAnalysisError {
+    /// An I/O error occurred while accessing the mod file at `path`.
+    #[error("failed to access {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The file is not a valid zip archive (required for `.jar` mods).
+    #[error("the file is not a valid jar/zip archive: {0}")]
+    Zip(#[from] zip::result::ZipError),
+
+    /// Mod metadata could not be parsed as JSON (e.g. `fabric.mod.json`).
+    #[error("failed to parse JSON mod metadata: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Mod metadata could not be parsed as TOML (e.g. Forge `mods.toml`).
+    #[error("failed to parse TOML mod metadata: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    /// No registered detector recognized the file as a known mod format.
+    #[error("the file is not a recognized mod (unknown format)")]
+    UnrecognizedFormat,
+}
+
+/// Which logical sides a mod is capable of running on.
+///
+/// Minecraft separates the *client* (the game rendered on a player's machine)
+/// from the *server* (the dedicated/integrated server). A mod may support one
+/// or both of these sides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SideSupport {
+    /// The mod can be installed and run on the client.
+    pub client: bool,
+    /// The mod can be installed and run on the server.
+    pub server: bool,
+}
+
+impl SideSupport {
+    /// Neither side is known to be supported (not yet analyzed / unknown format).
+    pub const fn unknown() -> Self {
+        Self {
+            client: false,
+            server: false,
+        }
+    }
+
+    /// Supports both the client and the server.
+    pub const fn both() -> Self {
+        Self {
+            client: true,
+            server: true,
+        }
+    }
+
+    /// Supports only the client.
+    pub const fn client_only() -> Self {
+        Self {
+            client: true,
+            server: false,
+        }
+    }
+
+    /// Supports only the server.
+    pub const fn server_only() -> Self {
+        Self {
+            client: false,
+            server: true,
+        }
+    }
+
+    /// Whether this mod supports the given [`Side`].
+    pub const fn supports(&self, side: Side) -> bool {
+        match side {
+            Side::Client => self.client,
+            Side::Server => self.server,
+        }
+    }
+
+    /// True when the mod supports both sides.
+    pub const fn is_universal(&self) -> bool {
+        self.client && self.server
+    }
+
+    /// True when the mod runs only on the client.
+    pub const fn is_client_only(&self) -> bool {
+        self.client && !self.server
+    }
+
+    /// True when the mod runs only on the server.
+    pub const fn is_server_only(&self) -> bool {
+        !self.client && self.server
+    }
+
+    /// True when support could not be determined.
+    pub const fn is_unknown(&self) -> bool {
+        !self.client && !self.server
+    }
+}
+
+/// A single logical side of Minecraft.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Side {
+    Client,
+    Server,
+}
+
+/// High-level classification of a mod derived from its [`SideSupport`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ModEnvironment {
+    /// Runs only on the client (e.g. HUD/rendering mods like Jade).
+    Client,
+    /// Runs only on the server (e.g. server administration mods).
+    Server,
+    /// Runs on both the client and the server.
+    Universal,
+    /// Side support could not be determined.
+    #[default]
+    Unknown,
+}
+
+impl ModEnvironment {
+    /// Derive the classification from a [`SideSupport`].
+    pub const fn from_side_support(support: SideSupport) -> Self {
+        match (support.client, support.server) {
+            (true, false) => ModEnvironment::Client,
+            (false, true) => ModEnvironment::Server,
+            (true, true) => ModEnvironment::Universal,
+            (false, false) => ModEnvironment::Unknown,
+        }
+    }
+}
+
+/// The mod loader / packaging format a mod targets.
+///
+/// This is the first thing a [`ModDetector`] recognizes. New loaders (Quilt,
+/// NeoForge, ...) can be added here without touching any caller code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ModType {
+    /// Fabric (and Quilt-compatible) mods identified by `fabric.mod.json`.
+    Fabric,
+    /// Forge / NeoForge mods identified by `META-INF/mods.toml` / `mcmod.info`.
+    Forge,
+    /// The format could not be recognized by any registered detector.
+    #[default]
+    Unknown,
+}
+
+/// The outcome of analyzing a single mod file.
+///
+/// Fully serializable so it can cross process / FFI boundaries if needed by the
+/// server component.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModAnalysis {
+    /// The recognized mod loader / format.
+    pub mod_type: ModType,
+
+    /// Which logical sides (client/server) this mod supports.
+    pub side_support: SideSupport,
+
+    /// Mod identifier from the mod's metadata (e.g. Fabric `id`), if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mod_id: Option<String>,
+
+    /// Human-readable mod name, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Mod version string, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl ModAnalysis {
+    /// Construct an analysis for an unrecognized file (no detector matched).
+    pub fn unrecognized() -> Self {
+        Self {
+            mod_type: ModType::Unknown,
+            side_support: SideSupport::unknown(),
+            mod_id: None,
+            name: None,
+            version: None,
+        }
+    }
+
+    /// High-level classification derived from [`ModAnalysis::side_support`].
+    pub fn environment(&self) -> ModEnvironment {
+        ModEnvironment::from_side_support(self.side_support)
+    }
+
+    /// Whether this mod can run on a dedicated server.
+    pub fn supports_server(&self) -> bool {
+        self.side_support.server
+    }
+
+    /// Whether this mod can run on a client.
+    pub fn supports_client(&self) -> bool {
+        self.side_support.client
+    }
+}
+
+/// Read-only access to the entries contained inside a mod, independent of
+/// whether the mod is shipped as a `.jar` archive or an extracted directory.
+///
+/// Detectors use this trait so they never need to know how the mod is stored on
+/// disk. This keeps analysis loader-agnostic and trivial to test.
+pub trait ModFileAccess {
+    /// Read the full contents of the entry at `path` (e.g. `fabric.mod.json`).
+    ///
+    /// Returns `Ok(None)` when no such entry exists.
+    fn read_entry(&self, path: &str) -> Result<Option<Vec<u8>>, ModAnalysisError>;
+
+    /// List every entry name contained in the mod (used for format detection).
+    ///
+    /// Entry names use `/` as the separator (matching jar layout) so detectors
+    /// can match paths consistently regardless of the underlying storage.
+    fn list_entries(&self) -> Result<Vec<String>, ModAnalysisError>;
+}
+
+/// A mod located on disk, either as a `.jar` archive or an extracted folder.
+#[derive(Debug)]
+pub enum ModFile {
+    Jar(JarModFile),
+    Dir(DirModFile),
+}
+
+impl ModFile {
+    /// Open a mod from a filesystem path.
+    ///
+    /// Directories are treated as already-extracted mods; everything else is
+    /// treated as a jar archive.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ModAnalysisError> {
+        let path = path.as_ref();
+        let metadata = std::fs::metadata(path).map_err(|source| ModAnalysisError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+
+        if metadata.is_dir() {
+            Ok(Self::Dir(DirModFile::open(path)))
+        } else {
+            Ok(Self::Jar(JarModFile::open(path)))
+        }
+    }
+}
+
+impl ModFileAccess for ModFile {
+    fn read_entry(&self, path: &str) -> Result<Option<Vec<u8>>, ModAnalysisError> {
+        match self {
+            Self::Jar(jar) => jar.read_entry(path),
+            Self::Dir(dir) => dir.read_entry(path),
+        }
+    }
+
+    fn list_entries(&self) -> Result<Vec<String>, ModAnalysisError> {
+        match self {
+            Self::Jar(jar) => jar.list_entries(),
+            Self::Dir(dir) => dir.list_entries(),
+        }
+    }
+}
+
+/// A mod packaged as a `.jar` (zip) archive.
+#[derive(Debug)]
+pub struct JarModFile {
+    path: PathBuf,
+}
+
+impl JarModFile {
+    pub fn open(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl ModFileAccess for JarModFile {
+    fn read_entry(&self, path: &str) -> Result<Option<Vec<u8>>, ModAnalysisError> {
+        let file = std::fs::File::open(&self.path).map_err(|source| ModAnalysisError::Io {
+            path: self.path.display().to_string(),
+            source,
+        })?;
+        let mut archive = zip::ZipArchive::new(file)?;
+
+        match archive.by_name(path) {
+            Ok(mut entry) => {
+                let mut buf = Vec::with_capacity(entry.size() as usize);
+                entry
+                    .read_to_end(&mut buf)
+                    .map_err(|source| ModAnalysisError::Io {
+                        path: path.to_string(),
+                        source,
+                    })?;
+                Ok(Some(buf))
+            }
+            // Missing entry is not an error: detectors simply won't match.
+            Err(zip::result::ZipError::FileNotFound) => Ok(None),
+            Err(source) => Err(source.into()),
+        }
+    }
+
+    fn list_entries(&self) -> Result<Vec<String>, ModAnalysisError> {
+        let file = std::fs::File::open(&self.path).map_err(|source| ModAnalysisError::Io {
+            path: self.path.display().to_string(),
+            source,
+        })?;
+        let archive = zip::ZipArchive::new(file)?;
+        Ok(archive.file_names().map(|name| name.to_string()).collect())
+    }
+}
+
+/// A mod that has already been extracted into a directory.
+#[derive(Debug)]
+pub struct DirModFile {
+    path: PathBuf,
+}
+
+impl DirModFile {
+    pub fn open(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Recursively collect relative entry paths using `/` as the separator,
+    /// matching the layout used inside a jar archive.
+    fn walk(&self, base: &Path, current: &Path, out: &mut Vec<String>) -> std::io::Result<()> {
+        for entry in std::fs::read_dir(current)? {
+            let entry = entry?;
+            let meta = entry.metadata()?;
+            let rel = entry
+                .path()
+                .strip_prefix(base)
+                .unwrap_or_else(|_| Path::new(""))
+                .to_string_lossy()
+                .replace('\\', "/");
+            if meta.is_dir() {
+                self.walk(base, &entry.path(), out)?;
+            } else {
+                out.push(rel);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ModFileAccess for DirModFile {
+    fn read_entry(&self, path: &str) -> Result<Option<Vec<u8>>, ModAnalysisError> {
+        let full = self.path.join(path);
+        match std::fs::read(&full) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(ModAnalysisError::Io {
+                path: full.display().to_string(),
+                source,
+            }),
+        }
+    }
+
+    fn list_entries(&self) -> Result<Vec<String>, ModAnalysisError> {
+        let mut out = Vec::new();
+        self.walk(&self.path, &self.path, &mut out)
+            .map_err(|source| ModAnalysisError::Io {
+                path: self.path.display().to_string(),
+                source,
+            })?;
+        Ok(out)
+    }
+}
+
+/// A detector recognizes one mod format (Fabric, Forge, ...) and extracts its
+/// side-support information.
+///
+/// [`ModAnalyzer`] owns a list of detectors and asks each one, in turn, whether
+/// it [`matches`](ModDetector::matches) a given file. The first detector that
+/// matches is used to [`analyze`](ModDetector::analyze) the file.
+///
+/// `matches` should be cheap (only check for a defining marker such as a
+/// metadata file's existence); `analyze` does the actual parsing.
+pub trait ModDetector: Send + Sync + std::fmt::Debug {
+    /// The mod format this detector is responsible for.
+    fn mod_type(&self) -> ModType;
+
+    /// Returns `true` if `file` is in this detector's format.
+    fn matches(&self, file: &dyn ModFileAccess) -> Result<bool, ModAnalysisError>;
+
+    /// Extract side-support and basic metadata.
+    ///
+    /// `matches` is guaranteed to have returned `true` before this is called.
+    fn analyze(&self, file: &dyn ModFileAccess) -> Result<ModAnalysis, ModAnalysisError>;
+}
+
+/// Detects Fabric mods (and Quilt mods that ship a `fabric.mod.json`).
+#[derive(Debug, Default)]
+pub struct FabricDetector;
+
+impl FabricDetector {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Subset of `fabric.mod.json` relevant for side detection.
+///
+/// The schema has evolved across versions; we only require the fields we use
+/// and tolerate everything else via `#[serde(default)]`, so older and newer
+/// manifests both deserialize without error.
+#[derive(Debug, Deserialize)]
+struct FabricModJson {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    /// Top-level environment declaration.
+    ///
+    /// Accepted values: `"client"`, `"server"`, `"*"` (both). When absent, the
+    /// side is inferred from the `entrypoints` (see [`side_from_entrypoints`]).
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    entrypoints: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl ModDetector for FabricDetector {
+    fn mod_type(&self) -> ModType {
+        ModType::Fabric
+    }
+
+    fn matches(&self, file: &dyn ModFileAccess) -> Result<bool, ModAnalysisError> {
+        Ok(file.read_entry("fabric.mod.json")?.is_some())
+    }
+
+    fn analyze(&self, file: &dyn ModFileAccess) -> Result<ModAnalysis, ModAnalysisError> {
+        let raw = file
+            .read_entry("fabric.mod.json")?
+            .ok_or(ModAnalysisError::UnrecognizedFormat)?;
+        let parsed = parse_fabric_json(&raw)?;
+
+        let side_support = match parsed.environment.as_deref() {
+            Some("client") => SideSupport::client_only(),
+            Some("server") => SideSupport::server_only(),
+            Some("*" | "both") => SideSupport::both(),
+            // Unknown / empty / missing environment string: fall back to the
+            // entrypoint-based heuristic.
+            _ => side_from_entrypoints(&parsed.entrypoints),
+        };
+
+        Ok(ModAnalysis {
+            mod_type: ModType::Fabric,
+            side_support,
+            mod_id: parsed.id,
+            name: parsed.name,
+            version: parsed.version,
+        })
+    }
+}
+
+/// Parse `fabric.mod.json`, tolerating the occasional raw control character
+/// (e.g. an unescaped newline/tab inside a `description`) that strict JSON
+/// rejects. Such characters are not meaningful for side detection, so stripping
+/// them is safe and lets otherwise-valid mods parse successfully.
+fn parse_fabric_json(raw: &[u8]) -> Result<FabricModJson, ModAnalysisError> {
+    let text = String::from_utf8_lossy(raw);
+    let cleaned: String = text.chars().filter(|c| !c.is_control()).collect();
+    Ok(serde_json::from_str(&cleaned)?)
+}
+
+/// Infer side support from entrypoints.
+///
+/// Fabric semantics: `main` runs on both sides; `client`/`server` run only on
+/// that side. A `main`-only presence is universal, so a mod is client-only only
+/// when it has `client` and no `server` entrypoint, and server-only only when
+/// it has `server` and no `client`. This also catches mods like Jade that omit
+/// `environment` but declare a `client` entrypoint.
+fn side_from_entrypoints(
+    entrypoints: &std::collections::HashMap<String, serde_json::Value>,
+) -> SideSupport {
+    let has_client = entrypoints.contains_key("client");
+    let has_server = entrypoints.contains_key("server");
+
+    match (has_client, has_server) {
+        (true, false) => SideSupport::client_only(),
+        (false, true) => SideSupport::server_only(),
+        // (true, true) or neither (e.g. `main`-only): usable on both sides.
+        _ => SideSupport::both(),
+    }
+}
+
+/// Detects Forge / NeoForge mods and derives their side support from
+/// `mods.toml` (`clientSideOnly` / `serverSideOnly`) or legacy `mcmod.info`.
+#[derive(Debug, Default)]
+pub struct ForgeDetector;
+
+impl ForgeDetector {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// One `[[mods]]` entry inside Forge's `mods.toml`.
+#[derive(Debug, Deserialize)]
+struct ModsToml {
+    #[serde(default)]
+    mods: Vec<ModsTomlEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModsTomlEntry {
+    #[serde(default, rename = "modId")]
+    mod_id: Option<String>,
+    #[serde(default, rename = "displayName")]
+    display_name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    // Forge flags a mod client/server-only via these.
+    #[serde(default)]
+    client_side_only: Option<bool>,
+    #[serde(default)]
+    server_side_only: Option<bool>,
+    #[serde(default, rename = "clientSideOnly")]
+    client_side_only_legacy: Option<bool>,
+    #[serde(default, rename = "serverSideOnly")]
+    server_side_only_legacy: Option<bool>,
+}
+
+/// One entry in the legacy `mcmod.info` JSON array.
+#[derive(Debug, Clone, Deserialize)]
+struct McModInfo {
+    #[serde(default)]
+    modid: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default, rename = "clientSideOnly")]
+    client_side_only: Option<bool>,
+    #[serde(default, rename = "serverSideOnly")]
+    server_side_only: Option<bool>,
+}
+
+impl ModDetector for ForgeDetector {
+    fn mod_type(&self) -> ModType {
+        ModType::Forge
+    }
+
+    fn matches(&self, file: &dyn ModFileAccess) -> Result<bool, ModAnalysisError> {
+        if file.read_entry("META-INF/mods.toml")?.is_some()
+            || file.read_entry("META-INF/neoforge.mods.toml")?.is_some()
+            || file.read_entry("mcmod.info")?.is_some()
+        {
+            return Ok(true);
+        }
+
+        // Fall back to scanning the manifest for a Forge/FML marker.
+        if let Some(manifest) = file.read_entry("META-INF/MANIFEST.MF")? {
+            let text = String::from_utf8_lossy(&manifest);
+            if text.contains("FML-System-Mods") || text.contains("ModSide") {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn analyze(&self, file: &dyn ModFileAccess) -> Result<ModAnalysis, ModAnalysisError> {
+        // Prefer the modern TOML metadata (NeoForge falls back to Forge).
+        let toml_raw = file
+            .read_entry("META-INF/neoforge.mods.toml")?
+            .or(file.read_entry("META-INF/mods.toml")?);
+        if let Some(raw) = toml_raw {
+            return analyze_mods_toml(file, &raw);
+        }
+
+        // Fall back to the legacy JSON `mcmod.info`.
+        if let Some(raw) = file.read_entry("mcmod.info")? {
+            return analyze_mcmod_info(&raw);
+        }
+
+        // Recognized as Forge via a manifest marker but no side metadata found.
+        Ok(ModAnalysis {
+            mod_type: ModType::Forge,
+            side_support: SideSupport::unknown(),
+            mod_id: None,
+            name: None,
+            version: None,
+        })
+    }
+}
+
+/// Extract `Implementation-Version` from a JAR manifest, used to resolve the
+/// `${file.jarVersion}` placeholder in `mods.toml`.
+fn manifest_impl_version(raw: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(raw);
+    text.lines()
+        .find_map(|line| line.trim_start().strip_prefix("Implementation-Version:"))
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Derive side support + identity from `mods.toml`.
+///
+/// A mod supports a side unless *every* declared entry restricts it away from
+/// that side, so we union across entries. Forge defaults to universal when no
+/// flag is set (the loader loads such mods on both sides, like `environment: "*"`).
+fn analyze_mods_toml(
+    file: &dyn ModFileAccess,
+    raw: &[u8],
+) -> Result<ModAnalysis, ModAnalysisError> {
+    let text = std::str::from_utf8(raw).map_err(|_| ModAnalysisError::UnrecognizedFormat)?;
+    let parsed: ModsToml = toml::from_str(text)?;
+
+    let mut client = false;
+    let mut server = false;
+    let mut mod_id = None;
+    let mut name = None;
+    let mut version = None;
+    for entry in &parsed.mods {
+        let client_only = entry
+            .client_side_only
+            .or(entry.client_side_only_legacy)
+            .unwrap_or(false);
+        let server_only = entry
+            .server_side_only
+            .or(entry.server_side_only_legacy)
+            .unwrap_or(false);
+        if !server_only {
+            client = true;
+        }
+        if !client_only {
+            server = true;
+        }
+        if mod_id.is_none() {
+            mod_id = entry.mod_id.clone();
+            name = entry.display_name.clone();
+            version = entry.version.clone();
+        }
+    }
+
+    // Resolve the Gradle `${file.jarVersion}` placeholder from the manifest.
+    if let Some(v) = version.as_ref() {
+        if v.starts_with("${") {
+            if let Some(manifest) = file.read_entry("META-INF/MANIFEST.MF")? {
+                version = manifest_impl_version(&manifest).or(Some(v.clone()));
+            }
+        }
+    }
+
+    let side_support = if parsed.mods.is_empty() {
+        SideSupport::unknown()
+    } else {
+        SideSupport { client, server }
+    };
+
+    Ok(ModAnalysis {
+        mod_type: ModType::Forge,
+        side_support,
+        mod_id,
+        name,
+        version,
+    })
+}
+
+/// Derive side support + identity from the legacy `mcmod.info` JSON array.
+fn analyze_mcmod_info(raw: &[u8]) -> Result<ModAnalysis, ModAnalysisError> {
+    let entries: Vec<McModInfo> = serde_json::from_slice(raw)?;
+    let first = entries.first().cloned();
+
+    let mut client = false;
+    let mut server = false;
+    for entry in &entries {
+        let client_only = entry.client_side_only.unwrap_or(false);
+        let server_only = entry.server_side_only.unwrap_or(false);
+        if !server_only {
+            client = true;
+        }
+        if !client_only {
+            server = true;
+        }
+    }
+
+    let side_support = if entries.is_empty() {
+        SideSupport::unknown()
+    } else {
+        SideSupport { client, server }
+    };
+
+    let (mod_id, name, version) = first
+        .map(|e| (e.modid, e.name, e.version))
+        .unwrap_or((None, None, None));
+
+    Ok(ModAnalysis {
+        mod_type: ModType::Forge,
+        side_support,
+        mod_id,
+        name,
+        version,
+    })
+}
+
+/// Orchestrates mod detection: tries each registered [`ModDetector`] against a
+/// file and returns the first successful analysis.
+///
+/// This is the primary entry point for callers (including the server component
+/// that consumes mod side-support information later).
+#[derive(Debug, Default)]
+pub struct ModAnalyzer {
+    detectors: Vec<Box<dyn ModDetector>>,
+}
+
+impl ModAnalyzer {
+    /// Create an analyzer with every known detector registered.
+    ///
+    /// Order matters only as a tie-breaker: the first detector whose
+    /// [`ModDetector::matches`] returns `true` wins. More specific formats
+    /// should therefore be registered before more generic ones.
+    pub fn new() -> Self {
+        Self {
+            detectors: vec![
+                Box::new(FabricDetector::new()),
+                Box::new(ForgeDetector::new()),
+            ],
+        }
+    }
+
+    /// Analyze a mod located at `path` (a `.jar` file or an extracted folder).
+    ///
+    /// Returns [`ModAnalysis::unrecognized`] (with [`ModType::Unknown`]) when no
+    /// detector recognizes the file, rather than failing — callers that only
+    /// care about side support can still inspect the result safely.
+    pub fn analyze_path(&self, path: impl AsRef<Path>) -> Result<ModAnalysis, ModAnalysisError> {
+        let file = ModFile::open(path)?;
+
+        for detector in &self.detectors {
+            if detector.matches(&file)? {
+                return detector.analyze(&file);
+            }
+        }
+
+        Ok(ModAnalysis::unrecognized())
+    }
+}
+
+/// Convenience helper: analyze a mod at `path` using a default [`ModAnalyzer`].
+///
+/// This is the simplest function to call from other crates (e.g. the server
+/// component) when only a single analysis is needed.
+pub fn analyze_mod_side(path: impl AsRef<Path>) -> Result<ModAnalysis, ModAnalysisError> {
+    ModAnalyzer::new().analyze_path(path)
+}
+
+/// One mod file's result from [`analyze_mod_side_dir`].
+pub struct ModFileAnalysis {
+    /// Path of the analyzed mod file.
+    pub path: PathBuf,
+    /// `Ok` if analyzed; `Err` (e.g. corrupt archive) if not. The batch skips
+    /// such files instead of aborting.
+    pub result: Result<ModAnalysis, ModAnalysisError>,
+}
+
+/// Analyze every `.jar` directly in `dir` (non-recursive, flat `mods` layout).
+///
+/// Only errors if `dir` itself cannot be read; per-file failures are returned
+/// in [`ModFileAnalysis::result`].
+pub fn analyze_mod_side_dir(dir: impl AsRef<Path>) -> Result<Vec<ModFileAnalysis>, ModAnalysisError> {
+    let dir = dir.as_ref();
+    let read = std::fs::read_dir(dir).map_err(|source| ModAnalysisError::Io {
+        path: dir.display().to_string(),
+        source,
+    })?;
+
+    let mut out = Vec::new();
+    for entry in read {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("jar"))
+        {
+            let result = analyze_mod_side(&path);
+            out.push(ModFileAnalysis { path, result });
+        }
+    }
+
+    Ok(out)
+}
+
+/// Whether a mod's `environment` string marks it as client-only.
+///
+/// Mirrors the rule the Fabric loader enforces and that the server modpack
+/// pruner relies on, so the two never drift. Returns `false` for `None`
+/// (unknown / universal) as well as for `"*"` / `"server"`.
+pub fn environment_is_client_only(env: Option<&str>) -> bool {
+    env == Some("client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal jar containing the given `(entry name, contents)` pairs.
+    fn make_jar(path: &Path, entries: &[(&str, &str)]) {
+        use std::io::Write;
+        let file = std::fs::File::create(path).expect("create jar");
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = zip::write::FileOptions::<()>::default();
+        for (name, contents) in entries {
+            zip.start_file(*name, opts).expect("start file");
+            zip.write_all(contents.as_bytes()).expect("write entry");
+        }
+        zip.finish().expect("finish jar");
+    }
+
+    #[test]
+    fn fabric_environment_client_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("mod.jar");
+        make_jar(&jar, &[("fabric.mod.json", r#"{"environment":"client","id":"x"}"#)]);
+        let a = analyze_mod_side(&jar).unwrap();
+        assert_eq!(a.mod_type, ModType::Fabric);
+        assert!(a.side_support.is_client_only());
+    }
+
+    #[test]
+    fn fabric_environment_server_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("mod.jar");
+        make_jar(&jar, &[("fabric.mod.json", r#"{"environment":"server","id":"x"}"#)]);
+        let a = analyze_mod_side(&jar).unwrap();
+        assert!(a.side_support.is_server_only());
+    }
+
+    #[test]
+    fn fabric_environment_both() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("mod.jar");
+        make_jar(&jar, &[("fabric.mod.json", r#"{"environment":"*","id":"x"}"#)]);
+        let a = analyze_mod_side(&jar).unwrap();
+        assert!(a.side_support.is_universal());
+    }
+
+    /// Jade ships a `client` entrypoint plus a `main` entrypoint but no `server`
+    /// entrypoint. It must be identified as a client-only mod even though `main`
+    /// loads on both sides.
+    #[test]
+    fn fabric_client_only_inferred_from_entrypoints_like_jade() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("jade.jar");
+        make_jar(
+            &jar,
+            &[(
+                "fabric.mod.json",
+                r#"{"id":"jade","entrypoints":{"main":["snownee.jade.util.CommonProxy"],"client":["snownee.jade.util.ClientProxy"]}}"#,
+            )],
+        );
+        let a = analyze_mod_side(&jar).unwrap();
+        assert!(a.side_support.is_client_only());
+    }
+
+    #[test]
+    fn fabric_universal_when_only_main_entrypoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("lib.jar");
+        make_jar(
+            &jar,
+            &[("fabric.mod.json", r#"{"entrypoints":{"main":["com.example.Common"]}}"#)],
+        );
+        let a = analyze_mod_side(&jar).unwrap();
+        assert!(a.side_support.is_universal());
+    }
+
+    #[test]
+    fn forge_client_side_only_from_mods_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("forge-mod.jar");
+        let toml = "[[mods]]\nmodId = \"example\"\nclientSideOnly = true\nserverSideOnly = false\n";
+        make_jar(&jar, &[("META-INF/mods.toml", toml)]);
+        let a = analyze_mod_side(&jar).unwrap();
+        assert_eq!(a.mod_type, ModType::Forge);
+        assert!(a.side_support.is_client_only());
+    }
+
+#[test]
+fn forge_universal_from_mods_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    let jar = dir.path().join("mod.jar");
+    let toml = "modLoader = \"javafml\"\nloaderVersion = \"[43,)\"\n\n[[mods]]\nmodId = \"myforge\"\nclientSideOnly = false\nserverSideOnly = false\n";
+    make_jar(&jar, &[("META-INF/mods.toml", toml)]);
+
+    let analysis = analyze_mod_side(&jar).unwrap();
+    assert_eq!(analysis.mod_type, ModType::Forge);
+    assert!(analysis.side_support.is_universal());
+}
+
+#[test]
+fn forge_mods_toml_extracts_identity_and_defaults_universal() {
+    let dir = tempfile::tempdir().unwrap();
+    let jar = dir.path().join("sc.jar");
+    let toml = "modLoader = \"javafml\"\nloaderVersion = \"[43,)\"\n\n[[mods]]\nmodId = \"securitycraft\"\ndisplayName = \"SecurityCraft\"\nversion = \"${file.jarVersion}\"\n";
+    let manifest = "Manifest-Version: 1.0\nImplementation-Version: 1.9.6.1\n";
+    make_jar(
+        &jar,
+        &[
+            ("META-INF/mods.toml", toml),
+            ("META-INF/MANIFEST.MF", manifest),
+        ],
+    );
+
+    let analysis = analyze_mod_side(&jar).unwrap();
+    assert_eq!(analysis.mod_type, ModType::Forge);
+    assert_eq!(analysis.mod_id.as_deref(), Some("securitycraft"));
+    assert_eq!(analysis.name.as_deref(), Some("SecurityCraft"));
+    assert_eq!(analysis.version.as_deref(), Some("1.9.6.1"));
+    assert!(analysis.side_support.is_universal());
+}
+
+    #[test]
+    fn unrecognized_file_is_unknown_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let jar = dir.path().join("unknown.jar");
+        make_jar(&jar, &[("random.txt", "hello")]);
+        let a = analyze_mod_side(&jar).unwrap();
+        assert_eq!(a.mod_type, ModType::Unknown);
+    }
+
+    #[test]
+    fn extracted_directory_is_analyzed_like_jar() {
+        let dir = tempfile::tempdir().unwrap();
+        let mod_dir = dir.path().join("extracted-mod");
+        std::fs::create_dir_all(&mod_dir).unwrap();
+        std::fs::write(mod_dir.join("fabric.mod.json"), r#"{"environment":"client","id":"x"}"#).unwrap();
+        let a = analyze_mod_side(&mod_dir).unwrap();
+        assert!(a.side_support.is_client_only());
+    }
+
+    #[test]
+    fn analyze_dir_returns_one_entry_per_jar() {
+        let dir = tempfile::tempdir().unwrap();
+        make_jar(
+            &dir.path().join("a.jar"),
+            &[("fabric.mod.json", r#"{"environment":"client","id":"a"}"#)],
+        );
+        make_jar(
+            &dir.path().join("b.jar"),
+            &[("fabric.mod.json", r#"{"environment":"*","id":"b"}"#)],
+        );
+        // Non-jar files must be ignored.
+        std::fs::write(dir.path().join("notes.txt"), "not a mod").unwrap();
+
+        let results = analyze_mod_side_dir(dir.path()).unwrap();
+        assert_eq!(results.len(), 2, "only the two jars should be analyzed");
+
+        let client = results
+            .iter()
+            .find(|r| r.path.file_name().unwrap() == "a.jar")
+            .expect("a.jar present");
+        assert!(client.result.as_ref().unwrap().side_support.is_client_only());
+
+        let universal = results
+            .iter()
+            .find(|r| r.path.file_name().unwrap() == "b.jar")
+            .expect("b.jar present");
+        assert!(universal.result.as_ref().unwrap().side_support.is_universal());
+    }
+
+    #[test]
+    fn analyze_dir_keeps_going_past_broken_jar() {
+        let dir = tempfile::tempdir().unwrap();
+        make_jar(
+            &dir.path().join("good.jar"),
+            &[("fabric.mod.json", r#"{"environment":"*","id":"g"}"#)],
+        );
+        // A corrupt archive is reported as an error for that file, not fatal.
+        std::fs::write(dir.path().join("bad.jar"), b"not a zip").unwrap();
+
+        let results = analyze_mod_side_dir(dir.path()).unwrap();
+        assert_eq!(results.len(), 2);
+
+        let bad = results
+            .iter()
+            .find(|r| r.path.file_name().unwrap() == "bad.jar")
+            .expect("bad.jar present");
+        assert!(bad.result.is_err());
+    }
+
+    #[test]
+    fn environment_is_client_only_rule() {
+        assert!(environment_is_client_only(Some("client")));
+        assert!(!environment_is_client_only(Some("*")));
+        assert!(!environment_is_client_only(Some("server")));
+        assert!(!environment_is_client_only(None));
+    }
+
+    /// Run against a real mod jar supplied via `MOD_ANALYZER_TEST_JAR`.
+    #[test]
+    #[ignore]
+    fn analyze_real_jar_from_env() {
+        let path = std::env::var("MOD_ANALYZER_TEST_JAR").expect("set MOD_ANALYZER_TEST_JAR");
+        let a = analyze_mod_side(&path).expect("analyze");
+        println!("mod_type: {:#?}", a.mod_type);
+        println!("side_support: {:#?}", a.side_support);
+        println!("supports_server: {}", a.supports_server());
+    }
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -60,7 +60,7 @@ export interface ResolveServerJarInput {
 	paperBuild?: PaperBuild
 }
 
-export type ServerStatus = 'created' | 'eula_pending' | 'ready' | 'starting' | 'running' | 'crashed'
+export type ServerStatus = 'created' | 'downloading' | 'eula_pending' | 'ready' | 'starting' | 'running' | 'crashed'
 
 /** Persisted server manifest, stored as `axolotl-server.json` in the server directory. */
 export interface ManagedServerManifest {


### PR DESCRIPTION
## Sourcery 摘要

通过检测并移除仅客户端模组，同时改进加载器设置、运行时选择和安装状态处理，让整合包服务器的安装更加安全。

新功能：
- 添加跨加载器模组分析功能，根据 Fabric 和 Forge 元数据识别仅客户端模组以及与服务器兼容的模组。
- 自动以无头模式准备 Forge/NeoForge 整合包服务器，并移除导致专用服务器启动失败的仅客户端模组。
- 恢复服务器启动控制，并在服务器安装期间显示下载状态。
- 提供批量报告模组端支持情况的 CLI 示例。

错误修复：
- 防止整合包服务器启动安装器 JAR 或不兼容的客户端模组，从而避免专用服务器崩溃。
- 安装整合包服务器启动器时，遵循固定的 Fabric 和 Quilt 加载器版本。
- 当服务器未配置 Java 路径时，选择兼容的默认 Java 运行时。
- 更可靠地处理不完整安装、取消操作后的清理、NeoForge 启动器以及带 UTF-8 BOM 前缀的清单文件。

改进：
- 通过选择最接近的受支持运行时，而不是任意兼容版本，改进 Java 版本选择。
- 统一 Forge 安装器执行流程，并扩展 Forge 和 NeoForge 服务器启动器的发现范围。

测试：
- 增加对模组端检测、加载器元数据解析、清单 BOM 处理、批量分析以及客户端模组移除行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make modpack server installation safer by detecting and removing client-only mods while improving loader setup, runtime selection, and installation status handling.

New Features:
- Add cross-loader mod analysis to identify client-only and server-compatible mods from Fabric and Forge metadata.
- Automatically prepare Forge/NeoForge modpack servers headlessly and remove client-only mods that fail dedicated-server startup.
- Restore server-start controls and show downloading status during server installation.
- Provide a CLI example for batch-reporting mod side support.

Bug Fixes:
- Prevent modpack servers from launching installer jars or incompatible client mods that can crash dedicated servers.
- Honor pinned Fabric and Quilt loader versions when installing modpack server launchers.
- Select a compatible default Java runtime when a server has no configured Java path.
- Handle incomplete installations, cancellation cleanup, NeoForge launchers, and UTF-8 BOM-prefixed manifests more reliably.

Enhancements:
- Improve Java version selection by choosing the nearest supported runtime rather than an arbitrary compatible version.
- Consolidate Forge installer execution and broaden server launcher discovery across Forge and NeoForge.

Tests:
- Add coverage for mod side detection, loader metadata parsing, manifest BOM handling, batch analysis, and client-mod pruning behavior.

</details>