### PR TITLE
fix: 模组翻译开始按钮禁用状态未正确生效

### DIFF
--- a/apps/app-frontend/src/pages/LabModTranslation.vue
+++ b/apps/app-frontend/src/pages/LabModTranslation.vue
@@ -50,11 +50,7 @@ const analyzeElapsed = computed(() => {
 
 const canStart = computed(
 	() =>
-		!!inputPath.value &&
-		!!providerId.value &&
-		!!modelId.value &&
-		!starting.value &&
-		!analyzing.value,
+		!!inputPath.value && !!providerId.value && !!modelId.value && starting.value && analyzing.value,
 )
 const startHint = computed(() => {
 	if (!inputPath.value) return formatMessage(messages.startHint)
@@ -258,8 +254,8 @@ onMounted(() => {
 						v-model:model-id="modelId"
 					/>
 					<div class="flex flex-col gap-1.5">
-						<ButtonStyled color="brand" :disabled="!canStart">
-							<button class="start-button" @click="startTranslation">
+						<ButtonStyled color="brand">
+							<button class="start-button" @click="startTranslation" :disabled="!canStart">
 								<PlayIcon />{{ formatMessage(messages.start) }}
 							</button>
 						</ButtonStyled>

--- a/apps/app-frontend/src/pages/LabModTranslation.vue
+++ b/apps/app-frontend/src/pages/LabModTranslation.vue
@@ -50,7 +50,11 @@ const analyzeElapsed = computed(() => {
 
 const canStart = computed(
 	() =>
-		!!inputPath.value && !!providerId.value && !!modelId.value && starting.value && analyzing.value,
+		!!inputPath.value &&
+		!!providerId.value &&
+		!!modelId.value &&
+		!starting.value &&
+		!analyzing.value,
 )
 const startHint = computed(() => {
 	if (!inputPath.value) return formatMessage(messages.startHint)


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 正确将禁用状态应用于模组翻译开始按钮，以便在不满足翻译前置条件时无法激活该按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly apply the disabled state to the mod translation start button so it cannot be activated when translation prerequisites are unmet.

</details>