### PR TITLE
fix(website): adapt viewport units for mobile firefox

### DIFF
--- a/apps/website/src/components/landing/ProjectsShowcase.vue
+++ b/apps/website/src/components/landing/ProjectsShowcase.vue
@@ -193,7 +193,8 @@ const messages = defineMessages({
 	.row {
 		--gap: var(--gap-md);
 
-		width: 100vw;
+		// 100vw 在桌面 Firefox（经典滚动条）下包含滚动条宽度会横向溢出，改用容器宽度
+		width: 100%;
 		gap: var(--gap);
 		margin-bottom: var(--gap);
 		display: flex;

--- a/apps/website/src/components/ui/SiteSettingsModal.vue
+++ b/apps/website/src/components/ui/SiteSettingsModal.vue
@@ -455,7 +455,9 @@ onBeforeUnmount(() => {
 	display: flex;
 	flex-direction: column;
 	width: min(60rem, 100%);
+	// 手机 Firefox/Chrome 的动态工具栏不计入 vh，用 dvh 避免面板底部被遮挡
 	height: min(40rem, calc(100vh - 2rem));
+	height: min(40rem, calc(100dvh - 2rem));
 	overflow: hidden;
 	border: 1px solid var(--color-divider);
 	border-radius: 1.25rem;
@@ -668,6 +670,7 @@ onBeforeUnmount(() => {
 
 	.settings-panel {
 		height: 94vh;
+		height: 94dvh;
 		border-radius: 1.25rem 1.25rem 0 0;
 	}
 

--- a/apps/website/src/layouts/default.vue
+++ b/apps/website/src/layouts/default.vue
@@ -68,13 +68,16 @@ html {
 }
 
 .site-layout {
+	// svh 以小视口（工具栏展开时）为基准，避免移动端 Firefox/Chrome 动态工具栏导致的高度偏差
 	min-height: 100vh;
+	min-height: 100svh;
 	background: linear-gradient(rgb(255 255 255 / 1%) 1px, transparent 1px), var(--color-bg);
 	background-size: 100% 8rem;
 }
 
 .site-layout > main {
 	min-height: calc(100vh - 4.5rem);
+	min-height: calc(100svh - 4.5rem);
 }
 
 .reduced-effects * {


### PR DESCRIPTION
## Summary

Fix mobile / Firefox adaptation issues on the website caused by viewport-unit handling:

- `SiteSettingsModal.vue`: use `dvh` (with `vh` fallback) for the settings panel so the bottom sheet is no longer clipped behind mobile Firefox/Chrome dynamic toolbars
- `layouts/default.vue`: use `svh` (with `vh` fallback) for `.site-layout` / `main` min-heights
- `ProjectsShowcase.vue`: replace `width: 100vw` with `width: 100%` to avoid horizontal overflow on desktop Firefox with classic scrollbars

All changes are pure CSS with graceful cascade fallbacks (older browsers keep the previous `vh`-based values).

## Testing

- Verified locally with `nuxi dev`: `/`, `/changelog`, `/terms` all return 200
- Confirmed on-device that the mobile settings bottom sheet is no longer cut off by the browser toolbar

## Sourcery 摘要

通过使用适当的视口单位和相对于容器的宽度，改进移动浏览器和桌面版 Firefox 中的网站布局尺寸。

错误修复：
- 通过将移动端设置面板的高度调整为动态视口单位，防止浏览器工具栏动态变化时面板被裁剪。
- 通过避免使用包含滚动条的视口宽度，防止桌面版 Firefox 中项目展示区域出现水平溢出。

增强功能：
- 使用小视口单位设置网站布局和主要内容的高度，以便在浏览器工具栏展开时提供稳定的移动端尺寸。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve website layout sizing across mobile browsers and desktop Firefox by using appropriate viewport units and container-relative widths.

Bug Fixes:
- Prevent mobile settings panels from being clipped by dynamic browser toolbars by adapting their height to dynamic viewport units.
- Prevent desktop Firefox horizontal overflow in the projects showcase caused by scrollbar-inclusive viewport width.

Enhancements:
- Use small viewport units for the website layout and main content heights to provide stable mobile sizing when browser toolbars are expanded.

</details>