### PR TITLE
fix(website): restore feature grid column spans for mods and website cards

### DIFF
--- a/apps/website/src/pages/index.vue
+++ b/apps/website/src/pages/index.vue
@@ -1544,6 +1544,8 @@ useHead(() => ({
 
 .mods,
 .website {
+	grid-column: span 3 / span 3;
+
 	h3,
 	p {
 		margin: 0;


### PR DESCRIPTION
## Description

On desktop, the two landing-page feature cards — the installed-mods table (`.mods`) and the projects showcase (`.website`) — render as narrow ~169px-wide, ~950px-tall strips with a large empty gap next to them.

18b860872b (*refactor(style): migrate utility-alias CSS classes to Tailwind utilities*) removed the shared rule:

```css
.mods,
.website {
	grid-column: span 3;
}
```

and migrated the promise/showcase cards to `col-span-*` utilities, but no utility class was added to these two cards, so they lost their desktop spans entirely and each collapsed to a single column of the 6-column feature grid.

This restores `grid-column: span 3 / span 3` on both cards so they sit side by side as before the refactor. Mobile behavior is unchanged: the `<= 1024px` media query still forces full-width stacking via `grid-column: 1 / -1 !important`, and `<= 746px` still collapses the grid to a single column.

## Testing

- Ran `pnpm website:dev` and verified computed grid placement: all 8 grid children resolve to their expected tracks (`mods` and `website` each `span 3 / span 3`, 540px at a 1280px viewport), with no empty tracks
- Verified visually in Chromium at 1280×720 and with a mobile viewport (cards stack full-width)

## Screenshots

After the fix — mods table and projects showcase side by side, grid fully filled:

## Sourcery 总结

错误修复：
- 恢复已安装模组和项目展示卡片在桌面端的三列跨度，使功能网格正确填充，并让卡片并排显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the desktop three-column spans for the installed-mods and projects showcase cards so the feature grid fills correctly and the cards display side by side.

</details>