### PR TITLE
feat: Debian/apt 自动更新改用 pkexec apt install 安装 .deb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6828,6 +6828,7 @@ dependencies = [
  "either",
  "enumset",
  "flate2",
+ "futures",
  "hyper",
  "hyper-util",
  "image",

--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -137,8 +137,6 @@ import {
 	exportErrorLogs,
 	getOS,
 	getUpdateSize,
-	installAptUpdate,
-	isAptLinux,
 	isDev,
 	isElevated,
 	isNetworkMetered,
@@ -319,7 +317,6 @@ const onboardingReplay = ref(false)
 const nativeDecorations = ref(false)
 
 const os = ref('')
-const aptLinux = ref(false)
 const isDevEnvironment = ref(false)
 
 /**
@@ -966,7 +963,6 @@ async function setupApp() {
 	if (defaultPageRoute && defaultPageRoute !== '/') await router.push(defaultPageRoute)
 
 	os.value = await getOS()
-	aptLinux.value = await isAptLinux().catch(() => false)
 	const dev = await isDev()
 	isDevEnvironment.value = dev
 	pendingUpdateAnnouncementVersion.value = pending_update_toast_for_version
@@ -1681,18 +1677,9 @@ const updatePopupMessages = defineMessages({
 		id: 'app.update-popup.body.download-complete',
 		defaultMessage: `Axolotl Launcher v{version} has finished downloading. Reload to update now, or automatically when you close Axolotl Launcher.`,
 	},
-	linuxBody: {
-		id: 'app.update-popup.body.linux',
-		defaultMessage:
-			'Axolotl Launcher v{version} is available. Use your package manager to update for the latest features and fixes!',
-	},
 	reload: {
 		id: 'app.update-popup.reload',
 		defaultMessage: 'Reload to update',
-	},
-	aptUpdate: {
-		id: 'app.update-popup.apt-update',
-		defaultMessage: 'Update',
 	},
 	download: {
 		id: 'app.update-popup.download',
@@ -1754,28 +1741,7 @@ function showDelayedUpdatePopup() {
 		return
 	}
 
-	if (aptLinux.value && !finishedDownloading.value) {
-		// Debian and derivatives: the update installs through the package
-		// manager with a single pkexec prompt, so there is no download size.
-		addPopupNotification({
-			title: formatMessage(updatePopupMessages.updateAvailable),
-			text: formatMessage(updatePopupMessages.linuxBody, { version: update.version }),
-			type: 'info',
-			autoCloseMs: null,
-			buttons: [
-				{
-					label: formatMessage(updatePopupMessages.aptUpdate),
-					action: () => downloadAvailableAppUpdate(),
-					color: 'brand',
-				},
-				{
-					label: formatMessage(updatePopupMessages.changelog),
-					action: () => openAppUpdateChangelog(),
-					keepOpen: true,
-				},
-			],
-		})
-	} else if (metered.value && !finishedDownloading.value) {
+	if (metered.value && !finishedDownloading.value) {
 		addPopupNotification({
 			title: formatMessage(updatePopupMessages.updateAvailable),
 			text: formatMessage(updatePopupMessages.meteredBody, { version: update.version }),
@@ -1879,20 +1845,6 @@ async function performUpdateCheck() {
 	console.log(`Update ${update.version} is available.`)
 
 	metered.value = await isNetworkMetered()
-	if (aptLinux.value) {
-		// Debian and derivatives update through apt; the pkexec prompt is the
-		// single authorization for the whole repo setup + package install.
-		console.log('apt-managed system; updating through apt')
-		if (!metered.value) {
-			console.log('Starting apt update')
-			downloadUpdate(update)
-		} else {
-			console.log(`Metered connection detected, not auto-updating via apt.`)
-			markAppUpdateActionable(update.version)
-			scheduleDelayedUpdatePopup()
-		}
-		return 'available'
-	}
 
 	if (!metered.value) {
 		console.log('Starting download of update')
@@ -1935,9 +1887,6 @@ async function downloadUpdate(versionToDownload) {
 		return
 	}
 
-	if (aptLinux.value) {
-		return installAptUpdateForVersion(versionToDownload)
-	}
 	if (downloading.value || appUpdateDownload.progress.value !== 0) {
 		console.error(`Update ${versionToDownload.version} already downloading`)
 		return
@@ -1977,44 +1926,8 @@ async function downloadUpdate(versionToDownload) {
 	}
 }
 
-// Debian and derivatives update through apt with a single pkexec prompt.
-// The package is installed directly, so there is no separate download step.
-async function installAptUpdateForVersion(versionToDownload) {
-	if (downloading.value) {
-		console.error(`Update ${versionToDownload.version} already installing`)
-		return
-	}
-
-	console.log(`Installing update ${versionToDownload.version} via apt`)
-	downloading.value = true
-	try {
-		await backupAppDbForUpdate(versionToDownload.version)
-		await installAptUpdate(versionToDownload.version)
-		downloading.value = false
-		finishedDownloading.value = true
-		console.log('Finished installing via apt!')
-		markAppUpdateActionable(versionToDownload.version, 'downloaded')
-		scheduleDelayedUpdatePopup()
-	} catch (error) {
-		downloading.value = false
-		handleError(error)
-	}
-}
-
 async function installUpdate() {
 	restarting.value = true
-
-	if (aptLinux.value) {
-		// The apt package was already installed by pkexec; just relaunch into
-		// the new version.
-		try {
-			await restartApp()
-		} catch (e) {
-			restarting.value = false
-			handleError(e)
-		}
-		return
-	}
 
 	try {
 		await backupAppDbForUpdate(availableUpdate.value?.version)

--- a/apps/app-frontend/src/helpers/utils.js
+++ b/apps/app-frontend/src/helpers/utils.js
@@ -39,15 +39,6 @@ export async function setRestartAfterPendingUpdate(should_restart) {
 	return await invoke('set_restart_after_pending_update', { shouldRestart: should_restart })
 }
 
-// Debian and its derivatives update through apt with a single pkexec prompt
-export async function isAptLinux() {
-	return await invoke('is_apt_linux')
-}
-
-export async function installAptUpdate(version) {
-	return await invoke('install_apt_update', { version })
-}
-
 // One of 'Windows', 'Linux', 'MacOS'
 export async function getOS() {
 	return await invoke('plugin:utils|get_os')

--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -16,6 +16,7 @@ dashmap = { workspace = true }
 either = { workspace = true }
 enumset = { workspace = true, features = ["serde"] }
 flate2 = { workspace = true }
+futures = { workspace = true }
 hyper = { workspace = true, features = ["server"] }
 hyper-util = { workspace = true }
 image = { workspace = true }

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -862,7 +862,6 @@ fn main() {
             remove_enqueued_update,
             set_restart_after_pending_update,
             is_apt_linux,
-            install_apt_update,
             toggle_decorations,
             set_transparent_window_frame,
             show_window,
@@ -927,39 +926,50 @@ fn main() {
                             }
                         }
 
-                        let update = if should_restart {
-                            (**update).clone()
+                        let version = update.version.clone();
+                        let install_result = if is_apt_linux() {
+                            tauri::async_runtime::block_on(
+                                install_apt_package(&version, data),
+                            )
+                            .map_err(|error| error.to_string())
                         } else {
-                            (**update).clone().restart_after_install(false)
+                            let update = if should_restart {
+                                (**update).clone()
+                            } else {
+                                (**update).clone().restart_after_install(false)
+                            };
+
+                            // Persist the trigger before installing: on Windows
+                            // the updater plugin launches the NSIS installer and
+                            // exits the process via `std::process::exit(0)`
+                            // without returning, so the success path below never
+                            // runs there.
+                            #[cfg(target_os = "windows")]
+                            set_changelog_toast(Some(update.version.clone()));
+
+                            update.install(data).map_err(|error| error.to_string())
                         };
 
-                        // Persist the trigger before installing: on Windows the
-                        // updater plugin launches the NSIS installer and exits the
-                        // process via `std::process::exit(0)` without returning, so
-                        // the success path below never runs there.
-                        #[cfg(target_os = "windows")]
-                        set_changelog_toast(Some(update.version.clone()));
-
-                        match update.install(data) {
+                        match install_result {
                             Ok(()) => {
-                                set_changelog_toast(Some(update.version.clone()));
+                                set_changelog_toast(Some(version.clone()));
                                 if should_restart {
                                     tracing::info!(
                                         "Pending update installed successfully (version {}); restarting because user requested reload",
-                                        update.version
+                                        version
                                     );
                                     app.restart();
                                 } else {
                                     tracing::info!(
                                         "Pending update installed successfully (version {}); exiting without relaunch (user did not request reload)",
-                                        update.version
+                                        version
                                     );
                                 }
                             }
                             Err(e) => {
                                 tracing::error!(
                                     "Pending update install failed (version {}): {e}",
-                                    update.version
+                                    version
                                 );
                                 set_changelog_toast(None);
 

--- a/apps/app/src/updater_impl.rs
+++ b/apps/app/src/updater_impl.rs
@@ -518,6 +518,7 @@ pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
             "Failed to write the downloaded deb: {io}"
         )))
     })?;
+    let _deb_cleanup = TempDebFile(deb_path.clone());
 
     let install_path = deb_path.clone();
     let output = tokio::task::spawn_blocking(move || {
@@ -540,8 +541,6 @@ pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
         )))
     })?;
 
-    let _ = std::fs::remove_file(&deb_path);
-
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
@@ -551,4 +550,25 @@ pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Removes a temporary Debian package when installation finishes or fails.
+///
+/// The installer awaits a blocking task and has several fallible operations
+/// after creating the file. Keeping cleanup in `Drop` makes every return path
+/// (including task and process-launch errors) remove the package.
+struct TempDebFile(std::path::PathBuf);
+
+impl Drop for TempDebFile {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_file(&self.0) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    path = %self.0.display(),
+                    error = %error,
+                    "Failed to remove temporary deb file"
+                );
+            }
+        }
+    }
 }

--- a/apps/app/src/updater_impl.rs
+++ b/apps/app/src/updater_impl.rs
@@ -524,6 +524,7 @@ pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
         std::process::Command::new("pkexec")
             .arg("apt")
             .arg("install")
+            .arg("-y")
             .arg(&install_path)
             .output()
     })

--- a/apps/app/src/updater_impl.rs
+++ b/apps/app/src/updater_impl.rs
@@ -139,10 +139,13 @@ async fn fetch_apt_deb_asset(version: &str) -> Result<AptDebAsset> {
         )))
     })?;
 
-    let url = Url::parse(&format!("{UPDATE_SERVER_BASE}{}", artifact.relative_path))
-        .map_err(|error| {
-            theseus::Error::from(theseus::ErrorKind::OtherError(error.to_string()))
-        })?;
+    let url =
+        Url::parse(&format!("{UPDATE_SERVER_BASE}{}", artifact.relative_path))
+            .map_err(|error| {
+                theseus::Error::from(theseus::ErrorKind::OtherError(
+                    error.to_string(),
+                ))
+            })?;
 
     Ok(AptDebAsset {
         url,
@@ -367,7 +370,8 @@ pub async fn enqueue_update_for_installation<R: Runtime>(
             );
         }
 
-        let mut request = ClientBuilder::new().user_agent(launcher_user_agent());
+        let mut request =
+            ClientBuilder::new().user_agent(launcher_user_agent());
         if let Some(timeout) = update.timeout {
             request = request.timeout(timeout);
         }
@@ -507,9 +511,8 @@ pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
     }
 
     let arch = apt_deb_arch()?;
-    let deb_path = std::env::temp_dir().join(format!(
-        "Axolotl.Launcher_{version}_{arch}.deb"
-    ));
+    let deb_path = std::env::temp_dir()
+        .join(format!("Axolotl.Launcher_{version}_{arch}.deb"));
     std::fs::write(&deb_path, data).map_err(|io| {
         theseus::Error::from(theseus::ErrorKind::OtherError(format!(
             "Failed to write the downloaded deb: {io}"

--- a/apps/app/src/updater_impl.rs
+++ b/apps/app/src/updater_impl.rs
@@ -1,5 +1,7 @@
 use crate::api::Result;
-use serde::Serialize;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 use tauri::http::HeaderValue;
 use tauri::http::header::ACCEPT;
@@ -8,18 +10,14 @@ use tauri_plugin_http::reqwest;
 use tauri_plugin_http::reqwest::ClientBuilder;
 use tauri_plugin_updater::{Error, Update, UpdaterExt};
 use theseus::{
-    LoadingBarType, emit_loading, init_loading, launcher_user_agent, settings,
+    LoadingBarType, emit_loading, init_loading, launcher_user_agent,
 };
 use tokio::time::Instant;
 use url::Url;
 
 const UPDATE_SERVER_LATEST_URL: &str = "https://update.axlmc.org/latest";
-
-// Debian and derivatives update via the apt package manager. The whole
-// operation (repo setup script plus package install) runs as a single
-// `pkexec` invocation so the polkit authorization prompt appears only once.
-const AXOLOTL_APT_SETUP_URL: &str = "https://ppa.axlmc.org/setup.sh";
-const AXOLOTL_APT_PACKAGE: &str = "axolotl-launcher";
+const UPDATE_SERVER_API: &str = "https://update.axlmc.org/api/versions";
+const UPDATE_SERVER_BASE: &str = "https://update.axlmc.org/";
 
 // The updater plugin builds `Update` with no request timeout, so a stalled
 // connection would hang the download forever. Bound the whole download.
@@ -43,6 +41,115 @@ pub struct UpdateMetadata {
 
 #[derive(Default)]
 pub struct PendingUpdateData(pub Mutex<Option<(Arc<Update>, Vec<u8>)>>);
+
+// ── Update Server API types ─────────────────────────────────────
+
+#[derive(Deserialize)]
+struct VersionsResponse {
+    versions: Vec<VersionEntry>,
+}
+
+#[derive(Deserialize)]
+struct VersionEntry {
+    version: String,
+    artifacts: Vec<ArtifactEntry>,
+}
+
+#[derive(Deserialize)]
+struct ArtifactEntry {
+    kind: String,
+    #[serde(default)]
+    variant: Option<String>,
+    platform: String,
+    architecture: String,
+    relative_path: String,
+    #[serde(default)]
+    sha256: Option<String>,
+    #[serde(default)]
+    size: u64,
+}
+
+/// The .deb asset for an apt-managed Linux update, from the Update Server
+/// catalog (`/api/versions`). The deb has no minisign signature, so its
+/// integrity is verified with the catalog's sha256 and size instead.
+struct AptDebAsset {
+    url: Url,
+    sha256: String,
+    size: u64,
+}
+
+fn apt_deb_arch() -> Result<&'static str> {
+    match std::env::consts::ARCH {
+        "x86_64" => Ok("amd64"),
+        "aarch64" => Ok("arm64"),
+        arch => Err(theseus::Error::from(theseus::ErrorKind::OtherError(
+            format!("Unsupported architecture for apt updates: {arch}"),
+        ))
+        .into()),
+    }
+}
+
+async fn fetch_apt_deb_asset(version: &str) -> Result<AptDebAsset> {
+    let response = ClientBuilder::new()
+        .user_agent(launcher_user_agent())
+        .timeout(UPDATE_DOWNLOAD_TIMEOUT)
+        .build()?
+        .get(UPDATE_SERVER_API)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(Error::Network(format!(
+            "Failed to fetch update catalog: {}",
+            response.status()
+        ))
+        .into());
+    }
+
+    let catalog: VersionsResponse = response.json().await?;
+    let release = catalog
+        .versions
+        .iter()
+        .find(|entry| entry.version == version)
+        .ok_or_else(|| {
+            theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+                "Update catalog has no entry for version {version}"
+            )))
+        })?;
+
+    let arch = std::env::consts::ARCH;
+    let artifact = release
+        .artifacts
+        .iter()
+        .find(|entry| {
+            entry.kind == "installer"
+                && entry.variant.as_deref() == Some("deb")
+                && entry.platform == "linux"
+                && entry.architecture == arch
+        })
+        .ok_or_else(|| {
+            theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+                "Update catalog has no deb artifact for {version} on {arch}"
+            )))
+        })?;
+
+    let sha256 = artifact.sha256.clone().ok_or_else(|| {
+        theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+            "Update catalog has no sha256 for the deb artifact of {version}"
+        )))
+    })?;
+
+    let url = Url::parse(&format!("{UPDATE_SERVER_BASE}{}", artifact.relative_path))
+        .map_err(|error| {
+            theseus::Error::from(theseus::ErrorKind::OtherError(error.to_string()))
+        })?;
+
+    Ok(AptDebAsset {
+        url,
+        sha256,
+        size: artifact.size,
+    })
+}
 
 // ── Updater plugin helpers ───────────────────────────────────────
 
@@ -135,6 +242,14 @@ async fn check_with_updater<R: Runtime>(
         return Ok(None);
     };
     update.timeout = Some(UPDATE_DOWNLOAD_TIMEOUT);
+
+    // On Debian and derivatives the plugin's minisign signature check cannot
+    // validate the unsigned .deb, so point the download at the deb from the
+    // Update Server catalog instead of the AppImage artifact. Its integrity
+    // is verified with the catalog's sha256/size during the download.
+    if is_apt_linux() {
+        update.download_url = fetch_apt_deb_asset(&update.version).await?.url;
+    }
 
     let published_at = update
         .raw_json
@@ -238,25 +353,107 @@ pub async fn enqueue_update_for_installation<R: Runtime>(
     .await?;
 
     let download_start = Instant::now();
-    let update_data = update
-        .download(
-            |chunk_size, total_size| {
-                let Some(total_size) = total_size else {
-                    return;
-                };
+    let update_data = if is_apt_linux() {
+        // The .deb carries no minisign signature, so the plugin's signed
+        // download cannot be used. Fetch the catalog entry and verify the
+        // downloaded bytes against its sha256 and size instead.
+        let asset = fetch_apt_deb_asset(&update.version).await?;
+
+        let mut headers = update.headers.clone();
+        if !headers.contains_key(ACCEPT) {
+            headers.insert(
+                ACCEPT,
+                HeaderValue::from_static("application/octet-stream"),
+            );
+        }
+
+        let mut request = ClientBuilder::new().user_agent(launcher_user_agent());
+        if let Some(timeout) = update.timeout {
+            request = request.timeout(timeout);
+        }
+        if let Some(ref proxy) = update.proxy {
+            let proxy = reqwest::Proxy::all(proxy.as_str())?;
+            request = request.proxy(proxy);
+        }
+        let response = request
+            .build()?
+            .get(update.download_url.clone())
+            .headers(headers)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(Error::Network(format!(
+                "Download request failed with status: {}",
+                response.status()
+            ))
+            .into());
+        }
+
+        let total_size = response.content_length().unwrap_or(asset.size);
+        let mut buffer = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            buffer.extend_from_slice(&chunk);
+            if total_size > 0 {
                 if let Err(e) = emit_loading(
                     &progress,
-                    chunk_size as f64 / total_size as f64,
+                    buffer.len() as f64 / total_size as f64,
                     None,
                 ) {
                     tracing::error!(
                         "Failed to update download progress bar: {e}"
                     );
                 }
-            },
-            || {},
-        )
-        .await?;
+            }
+        }
+
+        if buffer.len() as u64 != asset.size {
+            return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
+                format!(
+                    "Downloaded deb size mismatch: expected {}, got {}",
+                    asset.size,
+                    buffer.len()
+                ),
+            ))
+            .into());
+        }
+
+        let digest = Sha256::digest(&buffer);
+        let digest_hex = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        if digest_hex != asset.sha256 {
+            return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
+                "Downloaded deb sha256 mismatch".to_string(),
+            ))
+            .into());
+        }
+
+        buffer
+    } else {
+        update
+            .download(
+                |chunk_size, total_size| {
+                    let Some(total_size) = total_size else {
+                        return;
+                    };
+                    if let Err(e) = emit_loading(
+                        &progress,
+                        chunk_size as f64 / total_size as f64,
+                        None,
+                    ) {
+                        tracing::error!(
+                            "Failed to update download progress bar: {e}"
+                        );
+                    }
+                },
+                || {},
+            )
+            .await?
+    };
     let download_duration = download_start.elapsed();
     tracing::info!("Downloaded update in {download_duration:?}");
 
@@ -297,11 +494,10 @@ pub fn is_apt_linux() -> bool {
     }
 }
 
-/// Update Axolotl on Debian and its derivatives through apt, prompting for
-/// root once via `pkexec`. Runs the repo setup script and the package
-/// install in a single privileged shell so only one authorization is asked.
-#[tauri::command]
-pub async fn install_apt_update(version: String) -> Result<()> {
+/// Install the downloaded .deb on Debian and its derivatives, prompting for
+/// root once via `pkexec`. The package is installed from the absolute path
+/// of a temporary file, which is removed afterwards.
+pub async fn install_apt_package(version: &str, data: &[u8]) -> Result<()> {
     if !is_apt_linux() {
         return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
             "apt updates are only supported on Debian-based Linux systems with pkexec"
@@ -310,18 +506,22 @@ pub async fn install_apt_update(version: String) -> Result<()> {
         .into());
     }
 
-    // Everything runs as root under one pkexec prompt; no `sudo` needed inside.
-    let script = format!(
-        "curl -fsSL {AXOLOTL_APT_SETUP_URL} | bash && \
-         apt-get update && \
-         apt-get install -y {AXOLOTL_APT_PACKAGE}"
-    );
+    let arch = apt_deb_arch()?;
+    let deb_path = std::env::temp_dir().join(format!(
+        "Axolotl.Launcher_{version}_{arch}.deb"
+    ));
+    std::fs::write(&deb_path, data).map_err(|io| {
+        theseus::Error::from(theseus::ErrorKind::OtherError(format!(
+            "Failed to write the downloaded deb: {io}"
+        )))
+    })?;
 
+    let install_path = deb_path.clone();
     let output = tokio::task::spawn_blocking(move || {
         std::process::Command::new("pkexec")
-            .arg("sh")
-            .arg("-c")
-            .arg(&script)
+            .arg("apt")
+            .arg("install")
+            .arg(&install_path)
             .output()
     })
     .await
@@ -336,19 +536,15 @@ pub async fn install_apt_update(version: String) -> Result<()> {
         )))
     })?;
 
+    let _ = std::fs::remove_file(&deb_path);
+
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(theseus::Error::from(theseus::ErrorKind::OtherError(
-            format!("apt update failed: {}", stderr.trim()),
+            format!("apt install failed: {}", stderr.trim()),
         ))
         .into());
     }
-
-    // Persist the post-update announcement trigger so the new release notes
-    // show after the app restarts into the freshly installed version.
-    let mut current = settings::get().await?;
-    current.pending_update_toast_for_version = Some(version);
-    settings::set(current).await?;
 
     Ok(())
 }

--- a/apps/app/src/updater_impl_noop.rs
+++ b/apps/app/src/updater_impl_noop.rs
@@ -25,9 +25,3 @@ pub fn remove_enqueued_update() {}
 pub fn is_apt_linux() -> bool {
     false
 }
-
-#[tauri::command]
-pub async fn install_apt_update(version: String) -> Result<()> {
-    let _ = version;
-    Ok(())
-}


### PR DESCRIPTION
复用 AppImage 更新流程实现 Debian/apt 系自动更新，仅改两处逻辑：

- 检查阶段：若为 apt 系 Linux，将下载地址替换为 `/api/versions` 目录中的 `.deb`（Axolotl.Launcher_<版本>_amd64/arm64.deb）；deb 无 minisign 签名，改用目录中的 sha256 + size 校验。
- 下载阶段：因插件 `Update::download()` 强制做 minisign 验签、deb 无法通过，改为用 reqwest 自下载并流式上报进度，下载完校验 size 与 sha256 后存入 PendingUpdateData。
- 退出安装阶段：原 AppImage 的 `update.install()` 改为 `pkexec apt install <临时 deb 路径>`，装完删除临时文件，后续 toast / 重启逻辑不变。
- 前端：移除 apt 特例分支，apt 走与 AppImage 完全相同的下载进度 UI 流程。

## Sourcery 总结

通过使用经过验证的 `.deb` 软件包，让基于 Debian 的系统也能与其他平台一样享受自动更新体验。

新功能：
- 支持自动进行 Debian/apt 更新，下载并安装特定架构的 `.deb` 软件包。

增强功能：
- 使用目录提供的软件包大小和 SHA-256 元数据验证 Debian 软件包，并通过标准下载进度流程展示 apt 更新。
- 通过单次 `pkexec apt install` 调用安装已下载的 Debian 软件包，同时保留现有的重启和更新通知。
- 移除前端单独的 apt 更新流程及相关辅助命令。

构建：
- 添加 `futures` 依赖，以流式传输 Debian 软件包下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Debian-based systems to follow the same automatic update experience as other platforms using verified `.deb` packages.

New Features:
- Support automatic Debian/apt updates by downloading and installing architecture-specific `.deb` packages.

Enhancements:
- Use catalog-provided size and SHA-256 metadata to validate Debian packages and present apt updates through the standard download-progress flow.
- Install downloaded Debian packages through a single `pkexec apt install` invocation while preserving existing restart and update notifications.
- Remove the frontend’s separate apt update flow and related helper commands.

Build:
- Add the futures dependency for streaming Debian package downloads.

</details>