### PR TITLE
fix: 补齐 Assets 回退、DNS TTL 与本地 I/O 错误边界

### DIFF
--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -1621,7 +1621,7 @@ fn build_fallback_asset_from_batch(item: H2BatchAsset) -> FallbackAsset {
         name: item.sha1.clone(),
         hash: item.sha1,
         size: item.size,
-        url: item.url,
+        url: item.original_url,
         resource_path: item.destination,
         legacy_resource_paths: item.legacy_destinations,
         logical_items: item.logical_items,
@@ -1710,6 +1710,7 @@ pub async fn download_assets(
                     sub_hash = &hash[..2]
                 );
                 batch_items.push(H2BatchAsset {
+                    original_url: url.clone(),
                     url,
                     destination: resource_path,
                     legacy_destinations: should_fetch_legacy
@@ -2465,6 +2466,8 @@ mod tests {
         let first_legacy = PathBuf::from("resources/first");
         let second_legacy = PathBuf::from("resources/second");
         let make_item = |legacy_destinations| H2BatchAsset {
+            original_url: "https://resources.download.minecraft.net/ab/abcdef"
+                .into(),
             url: "https://resources.download.minecraft.net/ab/abcdef".into(),
             destination: destination.clone(),
             legacy_destinations,
@@ -2490,6 +2493,9 @@ mod tests {
     fn batch_assets_do_not_coalesce_different_integrity_contracts() {
         let destination = PathBuf::from("assets/objects/ab/object");
         let make_item = |sha1: &str, size| H2BatchAsset {
+            original_url: format!(
+                "https://resources.download.minecraft.net/ab/{sha1}"
+            ),
             url: format!("https://resources.download.minecraft.net/ab/{sha1}"),
             destination: destination.clone(),
             legacy_destinations: Vec::new(),
@@ -2507,6 +2513,31 @@ mod tests {
             .len(),
             3
         );
+    }
+
+    #[test]
+    fn batch_fallback_restores_official_asset_route_after_mirror_failure() {
+        let official = "https://resources.download.minecraft.net/14/14b3534e2622470a71dbe69474c15e6a233cc1c6";
+        let item = H2BatchAsset {
+            original_url: official.into(),
+            url: "https://bmclapi2.bangbang93.com/assets/14/14b3534e2622470a71dbe69474c15e6a233cc1c6"
+                .into(),
+            destination: PathBuf::from("assets/objects/14/hash"),
+            legacy_destinations: Vec::new(),
+            sha1: "14b3534e2622470a71dbe69474c15e6a233cc1c6".into(),
+            size: 42,
+            logical_items: 1,
+        };
+
+        let fallback = build_fallback_asset_from_batch(item);
+        let routes = resolve_download_routes_for(
+            &fallback.url,
+            ResourceClass::MinecraftAsset,
+            crate::state::DownloadSourceMode::MirrorPreferred,
+        );
+
+        assert_eq!(fallback.url, official);
+        assert!(routes.iter().any(|route| route.url == official));
     }
 
     #[test]

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -1821,7 +1821,7 @@ pub async fn download_assets(
                 apply_native_policy.then_some(&st.fetch_semaphore),
                 callback,
             )
-            .await;
+            .await?;
             if !failed.is_empty() {
                 tracing::warn!(
                     items = failed.len(),

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -594,6 +594,8 @@ async fn verify_and_finalize(
 /// A single small file (a Minecraft asset object) to download over a shared
 /// HTTP/2 connection. All items in one batch must share the same authority.
 pub(crate) struct H2BatchAsset {
+    /// Canonical asset URL used to rebuild routes after batch failure.
+    pub original_url: String,
     /// Route-resolved URL for the asset.
     pub url: String,
     /// Destination for the object (`assets/objects/<hh>/<hash>`).
@@ -627,6 +629,7 @@ enum AssetBatchItemOutcome {
 impl Clone for H2BatchAsset {
     fn clone(&self) -> Self {
         Self {
+            original_url: self.original_url.clone(),
             url: self.url.clone(),
             destination: self.destination.clone(),
             legacy_destinations: self.legacy_destinations.clone(),
@@ -758,6 +761,8 @@ mod tests {
             .unwrap();
         let legacy = blocked_parent.join("resource");
         let item = H2BatchAsset {
+            original_url: "https://resources.download.minecraft.net/aa/object"
+                .into(),
             url: "https://resources.download.minecraft.net/aa/object".into(),
             destination: destination.clone(),
             legacy_destinations: vec![legacy.clone()],

--- a/packages/app-lib/src/util/download/h2_download.rs
+++ b/packages/app-lib/src/util/download/h2_download.rs
@@ -624,6 +624,9 @@ enum AssetBatchItemOutcome {
         downloaded: bool,
         error: crate::Error,
     },
+    LocalObjectFailed {
+        error: crate::Error,
+    },
 }
 
 impl Clone for H2BatchAsset {
@@ -786,6 +789,20 @@ mod tests {
             b"already committed"
         );
     }
+
+    #[tokio::test]
+    async fn blocked_object_parent_is_detected_before_asset_get() {
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_parent = temp.path().join("object-parent");
+        tokio::fs::write(&blocked_parent, b"not a directory")
+            .await
+            .unwrap();
+        let destination = blocked_parent.join("object");
+        let part_path = fetch::suffixed_path(&destination, ".part");
+
+        assert!(prepare_asset_part_path(&destination).await.is_err());
+        assert!(tokio::fs::metadata(&part_path).await.is_err());
+    }
 }
 
 /// Downloads a batch of small files over a shared HTTP/2 connection group,
@@ -803,7 +820,7 @@ pub(crate) async fn download_asset_batch_via_h2<F>(
     apply_native_policy: bool,
     native_semaphore: Option<&fetch::FetchSemaphore>,
     on_completed: F,
-) -> Vec<H2BatchAsset>
+) -> crate::Result<Vec<H2BatchAsset>>
 where
     F: Fn(H2BatchAsset) -> Pin<Box<dyn Future<Output = ()> + Send>>
         + Send
@@ -813,12 +830,16 @@ where
     if apply_native_policy
         && super::native::h2_ineligible_reason(route).is_some()
     {
-        return items;
+        return Ok(items);
     }
+    // Local object I/O failures are deterministic per destination; remember the
+    // first one and keep draining the batch so siblings already in flight or
+    // still queued are not abandoned, then surface the error to the caller.
+    let mut local_object_error: Option<crate::Error> = None;
     let _global_permit = if let Some(semaphore) = native_semaphore {
         match semaphore.0.acquire().await {
             Ok(permit) => Some(permit),
-            Err(_) => return items,
+            Err(_) => return Ok(items),
         }
     } else {
         None
@@ -841,7 +862,7 @@ where
                         None,
                     );
                 }
-                return items;
+                return Ok(items);
             }
         };
     let connections = Arc::new(AssetBatchConnectionGroup::new(
@@ -934,6 +955,17 @@ where
                     // another network retry pass on a local filesystem error.
                     failed.push(item);
                 }
+                Ok(AssetBatchItemOutcome::LocalObjectFailed { error }) => {
+                    tracing::warn!(
+                        url = %fetch::sanitize_url_for_log(&item.url),
+                        destination = %item.destination.display(),
+                        error = %error,
+                        "Asset object failed local I/O; continuing to drain the batch"
+                    );
+                    if local_object_error.is_none() {
+                        local_object_error = Some(error);
+                    }
+                }
                 Err(error) => {
                     network_failures = network_failures.saturating_add(1);
                     tracing::debug!(
@@ -968,6 +1000,9 @@ where
             );
         }
     }
+    if let Some(error) = local_object_error {
+        return Err(error);
+    }
     if !failed.is_empty() {
         tracing::warn!(
             items = failed.len(),
@@ -978,7 +1013,17 @@ where
             route.source.as_str(),
         );
     }
-    failed
+    Ok(failed)
+}
+
+async fn prepare_asset_part_path(
+    destination: &Path,
+) -> crate::Result<std::path::PathBuf> {
+    let part_path = fetch::suffixed_path(destination, ".part");
+    if let Some(parent) = part_path.parent() {
+        crate::util::io::create_dir_all(parent).await?;
+    }
+    Ok(part_path)
 }
 
 async fn download_asset_item(
@@ -1011,6 +1056,12 @@ async fn download_asset_item(
             },
         });
     }
+    let part_path = match prepare_asset_part_path(&item.destination).await {
+        Ok(part_path) => part_path,
+        Err(error) => {
+            return Ok(AssetBatchItemOutcome::LocalObjectFailed { error });
+        }
+    };
     let _stream_permit = if apply_native_policy {
         Some(super::h2_stream_budget::acquire(route).await?)
     } else {
@@ -1037,14 +1088,17 @@ async fn download_asset_item(
 
     let mut hashers =
         fetch::IntegrityHashers::new_integrity_hashers(&integrity);
-    let part_path = fetch::suffixed_path(&item.destination, ".part");
-    if let Some(parent) = part_path.parent() {
-        crate::util::io::create_dir_all(parent).await?;
-    }
     // Any failure below leaves a partial file behind; clean it up so retries
     // start from a clean slate and no orphaned `.part` files accumulate.
     let result: crate::Result<AssetBatchItemOutcome> = async {
-        let mut file = tokio::fs::File::create(&part_path).await?;
+        let mut file = match tokio::fs::File::create(&part_path).await {
+            Ok(file) => file,
+            Err(error) => {
+                return Ok(AssetBatchItemOutcome::LocalObjectFailed {
+                    error: error.into(),
+                });
+            }
+        };
         let mut downloaded = 0_u64;
         let activity = super::h2_receive::H2TransferActivity::begin();
         loop {
@@ -1053,13 +1107,21 @@ async fn download_asset_item(
             let Some(chunk) = chunk else {
                 break;
             };
-            file.write_all(&chunk).await?;
+            if let Err(error) = file.write_all(&chunk).await {
+                return Ok(AssetBatchItemOutcome::LocalObjectFailed {
+                    error: error.into(),
+                });
+            }
             hashers.update(&chunk);
             downloaded += chunk.len() as u64;
             activity.record_bytes(chunk.len());
             super::h2_receive::release_capacity(&mut stream, chunk.len())?;
         }
-        file.flush().await?;
+        if let Err(error) = file.flush().await {
+            return Ok(AssetBatchItemOutcome::LocalObjectFailed {
+                error: error.into(),
+            });
+        }
         drop(file);
         if downloaded == 0 {
             return Err(crate::ErrorKind::OtherError(
@@ -1069,7 +1131,11 @@ async fn download_asset_item(
         }
         let computed = hashers.finish(downloaded);
         fetch::verify_computed_integrity(&integrity, &computed)?;
-        fetch::finalize_download(&part_path, &item.destination).await?;
+        if let Err(error) =
+            fetch::finalize_download(&part_path, &item.destination).await
+        {
+            return Ok(AssetBatchItemOutcome::LocalObjectFailed { error });
+        }
 
         Ok(match copy_asset_legacy_destinations(item).await {
             Ok(()) => AssetBatchItemOutcome::Completed { downloaded: true },
@@ -1080,7 +1146,12 @@ async fn download_asset_item(
         })
     }
     .await;
-    if result.is_err() {
+    if result.is_err()
+        || matches!(
+            &result,
+            Ok(AssetBatchItemOutcome::LocalObjectFailed { .. })
+        )
+    {
         let _ = tokio::fs::remove_file(&part_path).await;
     }
     result

--- a/packages/app-lib/src/util/download_dns.rs
+++ b/packages/app-lib/src/util/download_dns.rs
@@ -117,7 +117,6 @@ impl DownloadDnsResolver {
             .filter(|entry| entry.addresses.contains(&address))
         {
             entry.consecutive_connection_failures = 0;
-            entry.resolved_at = Instant::now();
             drop(cached);
             self.record_result(address, 0.5);
         }
@@ -403,6 +402,41 @@ mod tests {
 
         assert_eq!(resolver.score(failed), 0.0);
         assert!(resolver.score(succeeded) > 0.0);
+    }
+
+    #[test]
+    fn host_success_does_not_refresh_an_expired_dns_entry() {
+        let resolver = DownloadDnsResolver::default();
+        let address = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 11));
+        resolver.cache_addresses(
+            "expired-success.test".to_string(),
+            vec![SocketAddr::new(address, 0)],
+        );
+        resolver.expire_cache("expired-success.test");
+
+        resolver.record_host_success("expired-success.test", address);
+
+        assert!(
+            resolver
+                .resolved_addresses("expired-success.test")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn late_success_does_not_undo_failure_expiration() {
+        let resolver = DownloadDnsResolver::default();
+        let address = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 12));
+        resolver.cache_addresses(
+            "late-success.test".to_string(),
+            vec![SocketAddr::new(address, 0)],
+        );
+        assert!(!resolver.record_connection_failure("late-success.test"));
+        assert!(resolver.record_connection_failure("late-success.test"));
+
+        resolver.record_host_success("late-success.test", address);
+
+        assert!(resolver.resolved_addresses("late-success.test").is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 背景

这是对 #482、#483、#484 已合入修复的边界补充，不否定原修复：
- 镜像 H2 批次失败后，逐文件回退仍需包含 Mojang 官方 URL；
- DNS 成功记录不应延长解析 TTL 或复活显式失效条目；
- 本地对象目录、part 写入和提交错误不应记作网络失败。

## 修改

- H2BatchAsset 分离 original_url 与当前 route url；
- record_host_success 不再修改 resolved_at；
- 新增 LocalObjectFailed，并在网络重试/健康惩罚前返回；
- 为三类边界新增确定性回归测试。

## 验证

- cargo test --package theseus：通过（4 个目标回归测试 batch_fallback_restores_official_asset_route_after_mirror_failure / host_success_does_not_refresh_an_expired_dns_entry / late_success_does_not_undo_failure_expiration / blocked_object_parent_is_detected_before_asset_get 及关联测试 committed_asset_recovers_a_legacy_copy_without_redownloading 均 1 passed；全量库测试通过）
- pnpm axolotl:brand-guard：Not run（前端检查未执行，需 pnpm 前端环境）
- pnpm axolotl:i18n-check：Not run（同上）
- pnpm prepr:frontend:app：Not run（同上）
- cargo fmt --all --check：通过
- cargo check --package theseus_gui --features updater：Not run（GUI 特性编译检查未执行）

> 分支已 rebase 至最新 upstream/main（9916e0c5，v1.9.5），rebase 无冲突、代码无改动；rebase 后第 8 章测试已由贡献者重跑并确认通过。
