### PR TITLE
fix(app): 二次启动时恢复轻量模式下的启动器界面

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "theseus"
-version = "1.9.5-beta.6"
+version = "1.9.5"
 dependencies = [
  "ariadne",
  "async-minecraft-ping",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "theseus_gui"
-version = "1.9.5-beta.6"
+version = "1.9.5"
 dependencies = [
  "async_zip",
  "bytes",

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -724,9 +724,8 @@ fn main() {
             // so focusing it is not enough (see #490).
             let app = app.clone();
             tauri::async_runtime::spawn(async move {
-                let _ = app
-                    .state::<lightweight_mode::LightweightMode>()
-                    .exit(&app);
+                let _ =
+                    app.state::<lightweight_mode::LightweightMode>().exit(&app);
             });
         }))
         .plugin(tauri_plugin_http::init())

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -719,9 +719,15 @@ fn main() {
                 ));
             }
 
-            if let Some(win) = app.get_window("main") {
-                let _ = win.set_focus();
-            }
+            // A second launch must restore the launcher UI. The main window
+            // may be hidden or destroyed when the app is in lightweight mode,
+            // so focusing it is not enough (see #490).
+            let app = app.clone();
+            tauri::async_runtime::spawn(async move {
+                let _ = app
+                    .state::<lightweight_mode::LightweightMode>()
+                    .exit(&app);
+            });
         }))
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_os::init())


### PR DESCRIPTION
## 修复内容

修复 #490：启动器最小化到托盘（轻量模式）后，再次通过快捷方式、开始菜单或 .exe 启动程序时无法恢复主界面。

## 原因

单实例回调此前只对已有的 `main` 窗口调用 `set_focus`。轻量模式下主窗口已被销毁；普通隐藏场景下仅设置焦点也不会显示窗口，因此第二次启动没有任何可见效果。

## 修改

单实例回调现在与托盘图标“显示 Axolotl 启动器”行为一致，调用轻量模式的 `exit`：处于轻量模式时重建并显示主窗口；处于普通状态时显示/还原并聚焦已有窗口。原有 deep link 参数处理保持不变。

## 验证说明

当前环境没有 Rust 工具链，无法在本地编译或在 Windows 实机复现，建议由 CI（fmt/clippy）与维护者在 Windows 上确认一次。

## Sourcery 摘要

错误修复：
- 修复应用在最小化到系统托盘或隐藏后再次启动时恢复启动器窗口的问题，包括窗口被销毁的轻量模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the launcher window when the application is launched again after being minimized to the tray or hidden, including lightweight mode where the window was destroyed.

</details>