### PR TITLE
fix(installer): 安装完成后是否启动以点击安装时的选择为准

### DIFF
--- a/apps/installer-ui/src/installer.html
+++ b/apps/installer-ui/src/installer.html
@@ -1306,7 +1306,7 @@
 
 			const language = boot.language === 'zhCn' ? 'zhCn' : 'en'
 			const t = copy[language]
-			const state = { screen: 'welcome', progress: 4, failed: false, launchFailed: false }
+			const state = { screen: 'welcome', progress: 4, failed: false, launchFailed: false, launchAfter: true }
 			const screens = ['welcome', 'configure', 'installing', 'complete']
 			const $ = (selector) => document.querySelector(selector)
 			const post = (payload) => window.ipc.postMessage(JSON.stringify(payload))
@@ -1383,8 +1383,8 @@
 					$('#footer-note').textContent = state.launchFailed
 						? t.footerLaunchFailed
 						: t.footerComplete
-					$('#primary-label').textContent = $('#launch-after').checked ? t.launch : t.finish
-					icon.innerHTML = $('#launch-after').checked
+					$('#primary-label').textContent = state.launchAfter ? t.launch : t.finish
+					icon.innerHTML = state.launchAfter
 						? '<path d="M5 12h14m-6-6 6 6-6 6"/>'
 						: '<path d="m5 12 4 4L19 6"/>'
 				}
@@ -1396,12 +1396,13 @@
 				$('#launch-error').classList.remove('visible')
 				state.failed = false
 				state.launchFailed = false
+				state.launchAfter = $('#launch-after').checked
 				post({
 					command: 'install',
 					installDir: $('#install-dir').value.trim(),
 					resourceDir: $('#resource-dir').value.trim(),
 					desktopShortcut: $('#desktop-shortcut').checked,
-					launchAfter: $('#launch-after').checked,
+					launchAfter: state.launchAfter,
 				})
 
 				// Developer Preview Mock
@@ -1444,14 +1445,17 @@
 			$('#browse-resource').addEventListener('click', () =>
 				post({ command: 'browse', target: 'resource', current: $('#resource-dir').value }),
 			)
-			$('#launch-after').addEventListener('change', renderFooter)
+			$('#launch-after').addEventListener('change', () => {
+				state.launchAfter = $('#launch-after').checked
+				renderFooter()
+			})
 
 			$('#primary-action').addEventListener('click', () => {
 				if (state.screen === 'welcome') setScreen('configure')
 				else if (state.screen === 'configure' || (state.screen === 'installing' && state.failed))
 					install()
 				else if (state.screen === 'complete')
-					post({ command: 'finish', launch: $('#launch-after').checked })
+					post({ command: 'finish', launch: state.launchAfter })
 			})
 			$('#secondary-action').addEventListener('click', () => setScreen('welcome'))
 
@@ -1473,10 +1477,12 @@
 					} else if (message.type === 'progress') {
 						setProgress(message.value)
 					} else if (message.type === 'installFinished') {
+						state.launchAfter = message.launchAfter ?? state.launchAfter
 						setProgress(100)
 						setScreen('complete')
 					} else if (message.type === 'launchFailed') {
 						state.launchFailed = true
+						state.launchAfter = true
 						setProgress(100)
 						$('#launch-error').textContent = t.launchFailed
 						$('#launch-error').classList.add('visible')

--- a/apps/installer-ui/src/windows.rs
+++ b/apps/installer-ui/src/windows.rs
@@ -312,7 +312,10 @@ pub fn run() -> Result<(), String> {
                     }
                     Ok(()) => send_to_webview(
                         webview.as_ref(),
-                        json!({ "type": "installFinished" }),
+                        json!({
+                            "type": "installFinished",
+                            "launchAfter": launch_after_install,
+                        }),
                     ),
                     Err(error) => send_to_webview(
                         webview.as_ref(),


### PR DESCRIPTION
## 修复内容

修复 #489：安装/更新启动器时，用户取消勾选“完成后启动”后仍可能出现自动启动的情况。

## 原因

安装器完成页（complete screen）的按钮文案与 finish 事件此前在安装结束后重新读取隐藏的“完成后启动”复选框的当前状态来决定是否启动。该状态与用户点击“安装/更新”时提交的选择来自不同时点，一旦状态在安装过程中发生变化或页面状态被重置，最终动作就会与用户的选择不一致。

## 修改

- 点击“安装/更新”时把复选框选择记录为唯一状态 `state.launchAfter`，并随 install 请求提交；
- 安装完成后，后端把安装时记录的 `launchAfter` 随 `installFinished` 一并回传，完成页按钮与 finish 事件都以该记录值为准；
- 启动失败后的重试继续沿用原选择。

## 验证说明

- 嵌入页面的 JS 已做语法解析校验；
- 当前环境没有 Rust 工具链，且无法在 Windows 实机运行安装包，建议维护者用 GitHub Releases 的 Windows 安装包复核一次；若仍有其他安装包变体可复现，欢迎在 issue 中补充版本与安装路径信息。

## Sourcery 总结

修复安装程序完成行为，使其遵循安装时提交的启动偏好。

错误修复：
- 确保安装程序的完成操作始终遵循用户在开始安装或更新时所做的启动选择。

增强功能：
- 在安装完成、结束操作以及启动失败重试期间保留记录的启动选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix installer completion behavior to honor the launch preference submitted at installation time.

Bug Fixes:
- Ensure the installer’s completion action consistently follows the user’s launch choice made when starting installation or updating.

Enhancements:
- Preserve the recorded launch choice across installation completion, finish actions, and launch-failure retries.

</details>