### PR TITLE
fix: download both Java artifact and natives for merged LWJGL libraries

### DIFF
--- a/packages/app-lib/src/install/import_plan.rs
+++ b/packages/app-lib/src/install/import_plan.rs
@@ -18,7 +18,7 @@ use crate::launcher::download::{
     is_native_library, legacy_library_sha1, library_native_classifier,
     local_asset_index_path, local_asset_object_path, local_client_path,
     local_library_path, local_log_config_path, local_native_library_path,
-    native_library_artifact_path,
+    native_library_artifact_path, needs_java_artifact,
 };
 use crate::launcher::parse_rules;
 use crate::state::{ModLoader, State};
@@ -719,78 +719,84 @@ fn library_artifacts(
             continue;
         }
 
+        // Native library artifact for this platform, if any.
         if is_native_library(library) {
-            let Some(classifier) =
+            if let Some(classifier) =
                 library_native_classifier(library, java_arch)
-            else {
-                continue;
-            };
-            let native = library
-                .downloads
-                .as_ref()
-                .and_then(|downloads| downloads.classifiers.as_ref())
-                .and_then(|classifiers| classifiers.get(&classifier));
-            if let Some(native) = native {
-                natives.push(RequiredArtifact {
-                    relative_path: local_native_library_path(
-                        library,
-                        native,
-                        &classifier,
-                    )?,
-                    destination: state
-                        .directories
-                        .caches_dir()
-                        .join("minecraft-natives")
-                        .join(format!("{}.jar", native.sha1)),
-                    expected_sha1: Some(native.sha1.clone()),
-                    expected_size: Some(native.size as u64),
-                });
-            } else if library_classifier_coordinate_is_native(library) {
-                // Forge and newer manifests may represent a native as a
-                // four-part coordinate (group:artifact:version:natives-*),
-                // with its metadata in downloads.artifact rather than the
-                // legacy downloads.classifiers map. Keep that artifact in
-                // libraries/ so native preparation can consume it directly.
-                let Some(artifact) = library
+            {
+                let native = library
                     .downloads
                     .as_ref()
-                    .and_then(|downloads| downloads.artifact.as_ref())
-                    .filter(|artifact| !artifact.url.is_empty())
-                else {
-                    continue;
-                };
-                let artifact_path =
-                    native_library_artifact_path(library, &classifier)?;
-                natives.push(RequiredArtifact {
-                    relative_path: Path::new("libraries").join(&artifact_path),
-                    destination: state
-                        .directories
-                        .libraries_dir()
-                        .join(&artifact_path),
-                    expected_sha1: Some(artifact.sha1.clone()),
-                    expected_size: Some(artifact.size as u64),
-                });
+                    .and_then(|downloads| downloads.classifiers.as_ref())
+                    .and_then(|classifiers| classifiers.get(&classifier));
+                if let Some(native) = native {
+                    natives.push(RequiredArtifact {
+                        relative_path: local_native_library_path(
+                            library,
+                            native,
+                            &classifier,
+                        )?,
+                        destination: state
+                            .directories
+                            .caches_dir()
+                            .join("minecraft-natives")
+                            .join(format!("{}.jar", native.sha1)),
+                        expected_sha1: Some(native.sha1.clone()),
+                        expected_size: Some(native.size as u64),
+                    });
+                } else if library_classifier_coordinate_is_native(library) {
+                    // Forge and newer manifests may represent a native as a
+                    // four-part coordinate (group:artifact:version:natives-*),
+                    // with its metadata in downloads.artifact rather than the
+                    // legacy downloads.classifiers map. Keep that artifact in
+                    // libraries/ so native preparation can consume it directly.
+                    if let Some(artifact) = library
+                        .downloads
+                        .as_ref()
+                        .and_then(|downloads| downloads.artifact.as_ref())
+                        .filter(|artifact| !artifact.url.is_empty())
+                    {
+                        let artifact_path =
+                            native_library_artifact_path(library, &classifier)?;
+                        natives.push(RequiredArtifact {
+                            relative_path: Path::new("libraries")
+                                .join(&artifact_path),
+                            destination: state
+                                .directories
+                                .libraries_dir()
+                                .join(&artifact_path),
+                            expected_sha1: Some(artifact.sha1.clone()),
+                            expected_size: Some(artifact.size as u64),
+                        });
+                    }
+                }
             }
-            continue;
         }
 
-        let artifact_path = daedalus::get_path_from_artifact(&library.name)?;
-        let (expected_sha1, expected_size) = if let Some(artifact) = library
-            .downloads
-            .as_ref()
-            .and_then(|downloads| downloads.artifact.as_ref())
-            .filter(|artifact| !artifact.url.is_empty())
-        {
-            (Some(artifact.sha1.clone()), Some(artifact.size as u64))
-        } else {
-            (legacy_library_sha1(library).map(str::to_string), None)
-        };
-        libraries.push(RequiredArtifact {
-            relative_path: local_library_path(&library.name)?,
-            destination: state.directories.libraries_dir().join(&artifact_path),
-            expected_sha1,
-            expected_size,
-        });
+        // Java artifact (regular JAR). Mixed libraries carry both.
+        if needs_java_artifact(library) {
+            let artifact_path =
+                daedalus::get_path_from_artifact(&library.name)?;
+            let (expected_sha1, expected_size) = if let Some(artifact) = library
+                .downloads
+                .as_ref()
+                .and_then(|downloads| downloads.artifact.as_ref())
+                .filter(|artifact| !artifact.url.is_empty())
+            {
+                (Some(artifact.sha1.clone()), Some(artifact.size as u64))
+            } else {
+                (legacy_library_sha1(library).map(str::to_string), None)
+            };
+            libraries.push(RequiredArtifact {
+                relative_path: local_library_path(&library.name)?,
+                destination: state
+                    .directories
+                    .libraries_dir()
+                    .join(&artifact_path),
+                expected_sha1,
+                expected_size,
+            });
+        }
     }
 
     Ok((libraries, natives))

--- a/packages/app-lib/src/launcher/args.rs
+++ b/packages/app-lib/src/launcher/args.rs
@@ -88,11 +88,14 @@ pub fn get_class_paths(
                 .to_string())
         })
         .chain(libraries.into_iter().rev().map(|library| {
-            get_lib_path(
-                libraries_path,
-                &library.name,
-                crate::launcher::download::is_native_library(library),
-            )
+            // A merged library carrying both a Java artifact and native
+            // classifiers (e.g. LWJGL) must have its JAR present on disk.
+            // Pure native libraries (no Java artifact) remain tolerated
+            // when absent, matching the pre-existing classpath behaviour.
+            let allow_not_exist =
+                crate::launcher::download::is_native_library(library)
+                    && !crate::launcher::download::needs_java_artifact(library);
+            get_lib_path(libraries_path, &library.name, allow_not_exist)
         }))
         .process_results(|iter| {
             iter.unique().join(classpath_separator(java_arch))

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -652,6 +652,7 @@ pub(crate) fn needs_java_artifact(library: &Library) -> bool {
         .and_then(|downloads| downloads.artifact.as_ref());
     if library.natives.is_some()
         && artifact.is_none_or(|artifact| artifact.url.is_empty())
+        && library.url.is_none()
     {
         return false;
     }
@@ -2731,6 +2732,20 @@ mod tests {
             .unwrap()[0],
             format!("https://maven.legacyfabric.net/{artifact_path}")
         );
+    }
+
+    #[test]
+    fn native_library_with_legacy_repository_keeps_java_artifact_task() {
+        let library: Library = serde_json::from_value(serde_json::json!({
+            "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4",
+            "url": "https://libraries.minecraft.net/",
+            "natives": {
+                "windows": "natives-windows"
+            }
+        }))
+        .unwrap();
+
+        assert!(needs_java_artifact(&library));
     }
 
     #[test]

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -660,6 +660,23 @@ pub(crate) fn needs_java_artifact(library: &Library) -> bool {
         || library.url.is_some()
 }
 
+fn java_artifact_applies(
+    library: &Library,
+    java_arch: &str,
+    minecraft_updated: bool,
+) -> bool {
+    library.downloadable
+        && needs_java_artifact(library)
+        && library.rules.as_ref().is_none_or(|rules| {
+            parse_rules(
+                rules,
+                java_arch,
+                &QuickPlayType::None,
+                minecraft_updated,
+            )
+        })
+}
+
 fn library_classifier(library_name: &str) -> Option<&str> {
     let mut coordinates = library_name.split(':');
     coordinates.next()?;
@@ -2065,7 +2082,7 @@ pub async fn download_libraries(
     // Deduplicate by target path so repeated manifest entries download once.
     let mut seen_java_paths = std::collections::HashSet::new();
     for library in libraries {
-        if !needs_java_artifact(library) {
+        if !java_artifact_applies(library, java_arch, minecraft_updated) {
             continue;
         }
         let target = d::get_path_from_artifact(&library.name)
@@ -2746,6 +2763,30 @@ mod tests {
         .unwrap();
 
         assert!(needs_java_artifact(&library));
+    }
+
+    #[test]
+    fn java_artifact_rules_are_applied_before_path_deduplication() {
+        let blocked: Library = serde_json::from_value(serde_json::json!({
+            "name": "example:library:1.0",
+            "rules": [{"action": "allow", "features": {"is_demo_user": true}}],
+            "downloads": {"artifact": {
+                "url": "https://example.invalid/library.jar",
+                "sha1": "", "size": 1
+            }}
+        }))
+        .unwrap();
+        let allowed: Library = serde_json::from_value(serde_json::json!({
+            "name": "example:library:1.0",
+            "downloads": {"artifact": {
+                "url": "https://example.invalid/library.jar",
+                "sha1": "", "size": 1
+            }}
+        }))
+        .unwrap();
+
+        assert!(!java_artifact_applies(&blocked, "x86_64", true));
+        assert!(java_artifact_applies(&allowed, "x86_64", true));
     }
 
     #[test]

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -655,7 +655,8 @@ pub(crate) fn needs_java_artifact(library: &Library) -> bool {
     {
         return false;
     }
-    artifact.is_some_and(|artifact| !artifact.url.is_empty()) || library.url.is_some()
+    artifact.is_some_and(|artifact| !artifact.url.is_empty())
+        || library.url.is_some()
 }
 
 fn library_classifier(library_name: &str) -> Option<&str> {

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -2324,7 +2324,7 @@ pub async fn download_libraries(
                                 local_source,
                                 &local_relative,
                                 &path,
-                                None,
+                                legacy_library_sha1(library),
                                 None,
                                 progress.as_ref(),
                                 context.clone(),
@@ -2333,7 +2333,7 @@ pub async fn download_libraries(
                                     download_minecraft_file_with_candidates(
                                         st,
                                         &urls,
-                                        None,
+                                        legacy_library_sha1(library),
                                         None,
                                         &path,
                                         ResourceClass::Loader,
@@ -2698,12 +2698,21 @@ mod tests {
                 "linux": "natives-linux",
                 "osx": "natives-osx",
                 "windows": "natives-windows"
-            }
+            },
+            "checksums": ["05fac94380a70241f23780e7aef62b190894238f"]
         }))
         .unwrap();
 
         assert!(library.natives_os_key_and_classifiers("x86_64").is_none());
         let classifier = library_native_classifier(&library, "x86_64").unwrap();
+        assert_eq!(
+            legacy_library_sha1(&library),
+            Some("05fac94380a70241f23780e7aef62b190894238f")
+        );
+        assert_eq!(
+            legacy_library_content_validation("lwjgl-platform.jar"),
+            ContentValidation::Jar
+        );
         let artifact_path =
             classified_library_artifact_path(&library.name, &classifier)
                 .unwrap();

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -630,6 +630,20 @@ pub(crate) fn is_native_library(library: &Library) -> bool {
             .is_some_and(|classifier| classifier.starts_with("natives-"))
 }
 
+/// Whether this library carries a Java artifact (regular JAR) that must be
+/// downloaded and placed on the classpath. A library can have both a Java
+/// artifact and native classifiers after manifest merging (LWJGL is the
+/// canonical example); the two are independent and must not be treated as
+/// mutually exclusive.
+pub(crate) fn needs_java_artifact(library: &Library) -> bool {
+    library
+        .downloads
+        .as_ref()
+        .and_then(|downloads| downloads.artifact.as_ref())
+        .is_some()
+        || library.url.is_some()
+}
+
 fn library_classifier(library_name: &str) -> Option<&str> {
     let mut coordinates = library_name.split(':');
     coordinates.next()?;
@@ -889,6 +903,7 @@ fn missing_library_bytes(
             continue;
         }
 
+        // Native library size for this platform, if any.
         if is_native_library(library) {
             if let Some(classifier) =
                 library_native_classifier(library, java_arch)
@@ -900,21 +915,22 @@ fn missing_library_bytes(
             {
                 total += native.size as u64;
             }
-        } else {
+        }
+
+        // Java artifact size. Mixed libraries carry both.
+        if needs_java_artifact(library) {
             let artifact_path = d::get_path_from_artifact(&library.name)?;
             let path = st.directories.libraries_dir().join(&artifact_path);
 
-            if path.exists() && !force {
-                continue;
-            }
-
-            if let Some(artifact) = library
-                .downloads
-                .as_ref()
-                .and_then(|downloads| downloads.artifact.as_ref())
-                && !artifact.url.is_empty()
-            {
-                total += artifact.size as u64;
+            if !path.exists() || force {
+                if let Some(artifact) = library
+                    .downloads
+                    .as_ref()
+                    .and_then(|downloads| downloads.artifact.as_ref())
+                    && !artifact.url.is_empty()
+                {
+                    total += artifact.size as u64;
+                }
             }
         }
     }
@@ -2016,301 +2032,333 @@ pub async fn download_libraries(
         io::create_dir_all(st.directories.libraries_dir()),
         io::create_dir_all(st.directories.version_natives_dir(version))
     }?;
-    let mut libraries_for_download: Vec<_> = libraries
-        .iter()
-        .filter(|library| !is_native_library(library))
-        .collect();
-    libraries_for_download.extend(native_libraries_to_download(
-        libraries,
-        java_arch,
-        minecraft_updated,
-    )?);
-    let num_files = libraries_for_download.len();
+
+    // Plan individual file download tasks instead of treating each
+    // Library as mutually exclusive "normal or native". A merged library
+    // (e.g. LWJGL after manifest merging) may carry both a Java artifact
+    // and a native classifier for this platform; both become independent
+    // concurrent tasks so neither is starved by the other.
+    enum LibraryDownloadTask<'a> {
+        JavaArtifact(&'a Library),
+        NativeArtifact(&'a Library),
+    }
+
+    let mut tasks: Vec<LibraryDownloadTask<'_>> = Vec::new();
+
+    // Java artifact tasks: every library with a downloadable Java JAR.
+    // Deduplicate by target path so repeated manifest entries download once.
+    let mut seen_java_paths = std::collections::HashSet::new();
+    for library in libraries {
+        if !needs_java_artifact(library) {
+            continue;
+        }
+        let target = d::get_path_from_artifact(&library.name)
+            .unwrap_or_else(|_| library.name.clone());
+        if seen_java_paths.insert(target) {
+            tasks.push(LibraryDownloadTask::JavaArtifact(library));
+        }
+    }
+
+    // Native artifact tasks: reuse the existing native planner, which
+    // handles rules, classifier existence and SHA-1 deduplication.
+    for library in
+        native_libraries_to_download(libraries, java_arch, minecraft_updated)?
+    {
+        tasks.push(LibraryDownloadTask::NativeArtifact(library));
+    }
+
+    let num_files = tasks.len();
     loading_try_for_each_concurrent(
-		stream::iter(libraries_for_download).map(Ok::<&Library, crate::Error>),
+		stream::iter(tasks).map(Ok::<LibraryDownloadTask<'_>, crate::Error>),
 		crate::util::download::task_concurrency_limit(&st).map(|limit| limit.saturating_mul(2)),
         loading_bar,
         loading_amount,
         num_files,
         None,
-        |library| {
+        |task| {
             let progress = progress.clone();
             async move {
-            if let Some(rules) = &library.rules
-                && !parse_rules(
-                    rules,
-                    java_arch,
-                    &QuickPlayType::None,
-                    minecraft_updated,
-                )
-            {
-                tracing::trace!("Skipped library {}", &library.name);
-                return Ok(());
-            }
+                let library = match &task {
+                    LibraryDownloadTask::JavaArtifact(lib) => *lib,
+                    LibraryDownloadTask::NativeArtifact(lib) => *lib,
+                };
 
-            if !library.downloadable {
-                tracing::trace!(
-                    "Skipped non-downloadable library {}",
-                    &library.name
-                );
-                return Ok(());
-            }
+                if let Some(rules) = &library.rules
+                    && !parse_rules(
+                        rules,
+                        java_arch,
+                        &QuickPlayType::None,
+                        minecraft_updated,
+                    )
+                {
+                    tracing::trace!("Skipped library {}", &library.name);
+                    return Ok(());
+                }
 
-            if is_native_library(library) {
-                let Some(classifier) =
-                    library_native_classifier(library, java_arch)
-                else {
+                if !library.downloadable {
                     tracing::trace!(
-                        "Skipped native library without a classifier for this platform: {}",
+                        "Skipped non-downloadable library {}",
                         &library.name
                     );
                     return Ok(());
-                };
-                let native = library
-                    .downloads
-                    .as_ref()
-                    .and_then(|downloads| downloads.classifiers.as_ref())
-                    .and_then(|classifiers| classifiers.get(&classifier));
-                let _native_archive_path = if let Some(native) = native {
-                    let path = st
-                        .directories
-                        .caches_dir()
-                        .join("minecraft-natives")
-                        .join(format!("{}.jar", native.sha1));
-                    let context = InstallErrorContext::new(
-                        "download Minecraft native library",
-                    )
-                    .minecraft_version(version.to_string())
-                    .file_path(library.name.clone())
-                    .target_path(path.display().to_string())
-                    .build();
-                    let local_relative =
-                        local_native_library_path(library, native, &classifier)?;
-                    let reused = download_or_reuse_local(
-                        st,
-                        local_source,
-                        &local_relative,
-                        &path,
-                        Some(&native.sha1),
-                        Some(native.size as u64),
-                        progress.as_ref(),
-                        context.clone(),
-                        force,
-                        || {
-                            download_minecraft_file(
+
+                }
+                match task {
+                    LibraryDownloadTask::JavaArtifact(library) => {
+                    let artifact_path = d::get_path_from_artifact(&library.name)?;
+                    let path = st.directories.libraries_dir().join(&artifact_path);
+
+                    if path.exists() && !force {
+                        // already present; skip Java artifact download but continue to natives
+                    } else if let Some(d::minecraft::LibraryDownloads {
+                        artifact: Some(ref artifact),
+                        ..
+                    }) = library.downloads
+                        && !artifact.url.is_empty()
+                    {
+                        let local_relative = local_library_path(&library.name)?;
+                        let context = InstallErrorContext::new(
+                            "download Minecraft library",
+                        )
+                        .minecraft_version(version.to_string())
+                        .file_path(library.name.clone())
+                        .target_path(path.display().to_string())
+                        .build();
+                        let reused = download_or_reuse_local(
+                            st,
+                            local_source,
+                            &local_relative,
+                            &path,
+                            Some(&artifact.sha1),
+                            Some(artifact.size as u64),
+                            progress.as_ref(),
+                            context.clone(),
+                            force,
+                            || {
+                                download_minecraft_file(
+                                    st,
+                                    &artifact.url,
+                                    Some(&artifact.sha1),
+                                    Some(artifact.size as u64),
+                                    &path,
+                                    ResourceClass::MinecraftLibrary,
+                                    ContentValidation::None,
+                                    force,
+                                    progress.clone(),
+                                    context,
+                                )
+                            },
+                        )
+                        .await?;
+                        if reused {
+                            tracing::trace!(
+                                "Reused library {} to path {:?}",
+                                &library.name,
+                                &path
+                            );
+                        } else {
+                            tracing::trace!(
+                                "Fetched library {} to path {:?}",
+                                &library.name,
+                                &path
+                            );
+                        }
+                    } else {
+                        let Some(urls) = legacy_library_download_urls(
+                            library.url.as_deref(),
+                            &artifact_path,
+                        ) else {
+                            return Err(crate::ErrorKind::LauncherError(format!(
+                                "No safe Maven repository is known for required library {}",
+                                library.name
+                            ))
+                            .into());
+                        };
+
+                        let local_relative = local_library_path(&library.name)?;
+                        let context = InstallErrorContext::new(
+                            "download loader library",
+                        )
+                        .minecraft_version(version.to_string())
+                        .file_path(library.name.clone())
+                        .target_path(path.display().to_string())
+                        .build();
+                        let reused = download_or_reuse_local(
+                            st,
+                            local_source,
+                            &local_relative,
+                            &path,
+                            legacy_library_sha1(library),
+                            None,
+                            progress.as_ref(),
+                            context.clone(),
+                            force,
+                            || {
+                                download_minecraft_file_with_candidates(
+                                    st,
+                                    &urls,
+                                    legacy_library_sha1(library),
+                                    None,
+                                    &path,
+                                    ResourceClass::Loader,
+                                    legacy_library_content_validation(&artifact_path),
+                                    force,
+                                    progress.clone(),
+                                    context,
+                                )
+                            },
+                        )
+                        .await?;
+                        if reused {
+                            tracing::debug!(
+                                "Reused legacy library {} to path {:?}",
+                                &library.name,
+                                &path
+                            );
+                        } else {
+                            tracing::debug!(
+                                "Fetched legacy library {} to path {:?}",
+                                &library.name,
+                                &path
+                            );
+                        }
+                    }
+                    }
+                    LibraryDownloadTask::NativeArtifact(library) => {
+                    if let Some(classifier) =
+                        library_native_classifier(library, java_arch)
+                    {
+                        let native = library
+                            .downloads
+                            .as_ref()
+                            .and_then(|downloads| downloads.classifiers.as_ref())
+                            .and_then(|classifiers| classifiers.get(&classifier));
+                        let _native_archive_path = if let Some(native) = native {
+                            let path = st
+                                .directories
+                                .caches_dir()
+                                .join("minecraft-natives")
+                                .join(format!("{}.jar", native.sha1));
+                            let context = InstallErrorContext::new(
+                                "download Minecraft native library",
+                            )
+                            .minecraft_version(version.to_string())
+                            .file_path(library.name.clone())
+                            .target_path(path.display().to_string())
+                            .build();
+                            let local_relative =
+                                local_native_library_path(library, native, &classifier)?;
+                            let reused = download_or_reuse_local(
                                 st,
-                                &native.url,
+                                local_source,
+                                &local_relative,
+                                &path,
                                 Some(&native.sha1),
                                 Some(native.size as u64),
-                                &path,
-                                ResourceClass::MinecraftLibrary,
-                                ContentValidation::Jar,
+                                progress.as_ref(),
+                                context.clone(),
                                 force,
-                                progress.clone(),
-                                context,
+                                || {
+                                    download_minecraft_file(
+                                        st,
+                                        &native.url,
+                                        Some(&native.sha1),
+                                        Some(native.size as u64),
+                                        &path,
+                                        ResourceClass::MinecraftLibrary,
+                                        ContentValidation::Jar,
+                                        force,
+                                        progress.clone(),
+                                        context,
+                                    )
+                                },
                             )
-                        },
-                    )
-                    .await?;
-                    if reused {
-                        tracing::trace!("Reused native {}", &library.name);
-                    }
-                    path
-                } else {
-                    let artifact_path = native_library_artifact_path(
-                        library,
-                        &classifier,
-                    )?;
-                    let path =
-                        st.directories.libraries_dir().join(&artifact_path);
-                    let Some(urls) = legacy_library_download_urls(
-                        library.url.as_deref(),
-                        &artifact_path,
-                    ) else {
-                        return Err(crate::ErrorKind::LauncherError(format!(
-                            "No safe Maven repository is known for required native library {}",
-                            library.name
-                        ))
-                        .into());
-                    };
-                    let local_relative =
-                        Path::new("libraries").join(&artifact_path);
-                    let context = InstallErrorContext::new(
-                        "download loader native library",
-                    )
-                    .minecraft_version(version.to_string())
-                    .file_path(format!("{}:{classifier}", library.name))
-                    .urls(urls.clone())
-                    .target_path(path.display().to_string())
-                    .build();
-                    let reused = download_or_reuse_local(
-                        st,
-                        local_source,
-                        &local_relative,
-                        &path,
-                        None,
-                        None,
-                        progress.as_ref(),
-                        context.clone(),
-                        force,
-                        || {
-                            download_minecraft_file_with_candidates(
+                            .await?;
+                            if reused {
+                                tracing::trace!("Reused native {}", &library.name);
+                            }
+                            path
+                        } else {
+                            let artifact_path = native_library_artifact_path(
+                                library,
+                                &classifier,
+                            )?;
+                            let path =
+                                st.directories.libraries_dir().join(&artifact_path);
+                            let Some(urls) = legacy_library_download_urls(
+                                library.url.as_deref(),
+                                &artifact_path,
+                            ) else {
+                                return Err(crate::ErrorKind::LauncherError(format!(
+                                    "No safe Maven repository is known for required native library {}",
+                                    library.name
+                                ))
+                                .into());
+                            };
+                            let local_relative =
+                                Path::new("libraries").join(&artifact_path);
+                            let context = InstallErrorContext::new(
+                                "download loader native library",
+                            )
+                            .minecraft_version(version.to_string())
+                            .file_path(format!("{}:{classifier}", library.name))
+                            .urls(urls.clone())
+                            .target_path(path.display().to_string())
+                            .build();
+                            let reused = download_or_reuse_local(
                                 st,
-                                &urls,
+                                local_source,
+                                &local_relative,
+                                &path,
                                 None,
                                 None,
-                                &path,
-                                ResourceClass::Loader,
-                                ContentValidation::Jar,
+                                progress.as_ref(),
+                                context.clone(),
                                 force,
-                                progress.clone(),
-                                context,
+                                || {
+                                    download_minecraft_file_with_candidates(
+                                        st,
+                                        &urls,
+                                        None,
+                                        None,
+                                        &path,
+                                        ResourceClass::Loader,
+                                        ContentValidation::Jar,
+                                        force,
+                                        progress.clone(),
+                                        context,
+                                    )
+                                },
                             )
-                        },
-                    )
-                    .await?;
-                    if reused {
-                        tracing::debug!(
-                            "Reused legacy native {} to path {:?}",
-                            &library.name,
-                            &path
-                        );
-                    } else {
-                        tracing::debug!(
-                            "Fetched legacy native {} to path {:?}",
-                            &library.name,
-                            &path
-                        );
-                    }
-                    path
-                };
+                            .await?;
+                            if reused {
+                                tracing::debug!(
+                                    "Reused legacy native {} to path {:?}",
+                                    &library.name,
+                                    &path
+                                );
+                            } else {
+                                tracing::debug!(
+                                    "Fetched legacy native {} to path {:?}",
+                                    &library.name,
+                                    &path
+                                );
+                            }
+                            path
+                        };
 
-                tracing::debug!("Downloaded native {}", &library.name);
-            } else {
-                let artifact_path = d::get_path_from_artifact(&library.name)?;
-                let path = st.directories.libraries_dir().join(&artifact_path);
-
-                if path.exists() && !force {
-                    return Ok(());
-                }
-
-                if let Some(d::minecraft::LibraryDownloads {
-                    artifact: Some(ref artifact),
-                    ..
-                }) = library.downloads
-                    && !artifact.url.is_empty()
-                {
-                    let local_relative = local_library_path(&library.name)?;
-                    let context = InstallErrorContext::new(
-                        "download Minecraft library",
-                    )
-                    .minecraft_version(version.to_string())
-                    .file_path(library.name.clone())
-                    .target_path(path.display().to_string())
-                    .build();
-                    let reused = download_or_reuse_local(
-                        st,
-                        local_source,
-                        &local_relative,
-                        &path,
-                        Some(&artifact.sha1),
-                        Some(artifact.size as u64),
-                        progress.as_ref(),
-                        context.clone(),
-                        force,
-                        || {
-                            download_minecraft_file(
-                                st,
-                                &artifact.url,
-                                Some(&artifact.sha1),
-                                Some(artifact.size as u64),
-                                &path,
-                                ResourceClass::MinecraftLibrary,
-                                ContentValidation::None,
-                                force,
-                                progress.clone(),
-                                context,
-                            )
-                        },
-                    )
-                    .await?;
-                    if reused {
-                        tracing::trace!(
-                            "Reused library {} to path {:?}",
-                            &library.name,
-                            &path
-                        );
+                        tracing::debug!("Downloaded native {}", &library.name);
                     } else {
                         tracing::trace!(
-                            "Fetched library {} to path {:?}",
-                            &library.name,
-                            &path
-                        );
-                    }
-                } else {
-                    let Some(urls) = legacy_library_download_urls(
-                        library.url.as_deref(),
-                        &artifact_path,
-                    ) else {
-                        return Err(crate::ErrorKind::LauncherError(format!(
-                            "No safe Maven repository is known for required library {}",
-                            library.name
-                        ))
-                        .into());
-                    };
-
-                    let local_relative = local_library_path(&library.name)?;
-                    let context = InstallErrorContext::new(
-                        "download loader library",
-                    )
-                    .minecraft_version(version.to_string())
-                    .file_path(library.name.clone())
-                    .target_path(path.display().to_string())
-                    .build();
-                    let reused = download_or_reuse_local(
-                        st,
-                        local_source,
-                        &local_relative,
-                        &path,
-                        legacy_library_sha1(library),
-                        None,
-                        progress.as_ref(),
-                        context.clone(),
-                        force,
-                        || {
-                            download_minecraft_file_with_candidates(
-                                st,
-                                &urls,
-                                legacy_library_sha1(library),
-                                None,
-                                &path,
-                                ResourceClass::Loader,
-                                legacy_library_content_validation(&artifact_path),
-                                force,
-                                progress.clone(),
-                                context,
-                            )
-                        },
-                    )
-                    .await?;
-                    if reused {
-                        tracing::debug!(
-                            "Reused legacy library {} to path {:?}",
-                            &library.name,
-                            &path
-                        );
-                    } else {
-                        tracing::debug!(
-                            "Fetched legacy library {} to path {:?}",
-                            &library.name,
-                            &path
+                            "Skipped native library without a classifier for this platform: {}",
+                            &library.name
                         );
                     }
                 }
-            }
+                }
 
-            tracing::debug!("Loaded library {}", library.name);
-            Ok(())
+                tracing::debug!("Loaded library {}", library.name);
+                Ok(())
             }
         },
     )

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -650,14 +650,16 @@ pub(crate) fn needs_java_artifact(library: &Library) -> bool {
         .downloads
         .as_ref()
         .and_then(|downloads| downloads.artifact.as_ref());
+    let legacy_url =
+        library.url.as_deref().filter(|url| !url.trim().is_empty());
     if library.natives.is_some()
-        && artifact.is_none_or(|artifact| artifact.url.is_empty())
-        && library.url.is_none()
+        && artifact.is_none_or(|artifact| artifact.url.trim().is_empty())
+        && legacy_url.is_none()
     {
         return false;
     }
-    artifact.is_some_and(|artifact| !artifact.url.is_empty())
-        || library.url.is_some()
+    artifact.is_some_and(|artifact| !artifact.url.trim().is_empty())
+        || legacy_url.is_some()
 }
 
 fn java_artifact_applies(
@@ -2311,6 +2313,61 @@ pub async fn download_libraries(
                                 tracing::trace!("Reused native {}", &library.name);
                             }
                             path
+                        } else if library_classifier(&library.name)
+                            .is_some_and(|value| value.starts_with("natives-"))
+                            && let Some(artifact) = library
+                                .downloads
+                                .as_ref()
+                                .and_then(|downloads| downloads.artifact.as_ref())
+                                .filter(|artifact| !artifact.url.trim().is_empty())
+                        {
+                            let artifact_path =
+                                native_library_artifact_path(library, &classifier)?;
+                            let path = st
+                                .directories
+                                .libraries_dir()
+                                .join(&artifact_path);
+                            let local_relative =
+                                Path::new("libraries").join(&artifact_path);
+                            let context = InstallErrorContext::new(
+                                "download Minecraft native library",
+                            )
+                            .minecraft_version(version.to_string())
+                            .file_path(format!("{}:{classifier}", library.name))
+                            .target_path(path.display().to_string())
+                            .build();
+                            let reused = download_or_reuse_local(
+                                st,
+                                local_source,
+                                &local_relative,
+                                &path,
+                                Some(&artifact.sha1),
+                                Some(artifact.size as u64),
+                                progress.as_ref(),
+                                context.clone(),
+                                force,
+                                || {
+                                    download_minecraft_file(
+                                        st,
+                                        &artifact.url,
+                                        Some(&artifact.sha1),
+                                        Some(artifact.size as u64),
+                                        &path,
+                                        ResourceClass::MinecraftLibrary,
+                                        ContentValidation::Jar,
+                                        force,
+                                        progress.clone(),
+                                        context,
+                                    )
+                                },
+                            )
+                            .await?;
+                            if reused {
+                                tracing::trace!("Reused native {}", &library.name);
+                            } else {
+                                tracing::trace!("Fetched native {}", &library.name);
+                            }
+                            path
                         } else {
                             let artifact_path = native_library_artifact_path(
                                 library,
@@ -2343,7 +2400,7 @@ pub async fn download_libraries(
                                 local_source,
                                 &local_relative,
                                 &path,
-                                legacy_library_sha1(library),
+                                None,
                                 None,
                                 progress.as_ref(),
                                 context.clone(),
@@ -2352,7 +2409,7 @@ pub async fn download_libraries(
                                     download_minecraft_file_with_candidates(
                                         st,
                                         &urls,
-                                        legacy_library_sha1(library),
+                                        None,
                                         None,
                                         &path,
                                         ResourceClass::Loader,
@@ -2787,6 +2844,18 @@ mod tests {
 
         assert!(!java_artifact_applies(&blocked, "x86_64", true));
         assert!(java_artifact_applies(&allowed, "x86_64", true));
+    }
+
+    #[test]
+    fn empty_legacy_repository_is_not_a_java_artifact_source() {
+        let library: Library = serde_json::from_value(serde_json::json!({
+            "name": "example:native:1.0",
+            "url": "",
+            "natives": {"windows": "natives-windows"}
+        }))
+        .unwrap();
+
+        assert!(!needs_java_artifact(&library));
     }
 
     #[test]

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -646,21 +646,16 @@ pub(crate) fn needs_java_artifact(library: &Library) -> bool {
     }
     // Legacy pure-native libraries carry a natives map but no downloads.artifact;
     // their main JAR is not downloaded by the original installer either.
+    let artifact = library
+        .downloads
+        .as_ref()
+        .and_then(|downloads| downloads.artifact.as_ref());
     if library.natives.is_some()
-        && library
-            .downloads
-            .as_ref()
-            .and_then(|downloads| downloads.artifact.as_ref())
-            .is_none()
+        && artifact.is_none_or(|artifact| artifact.url.is_empty())
     {
         return false;
     }
-    library
-        .downloads
-        .as_ref()
-        .and_then(|downloads| downloads.artifact.as_ref())
-        .is_some()
-        || library.url.is_some()
+    artifact.is_some_and(|artifact| !artifact.url.is_empty()) || library.url.is_some()
 }
 
 fn library_classifier(library_name: &str) -> Option<&str> {

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -636,6 +636,25 @@ pub(crate) fn is_native_library(library: &Library) -> bool {
 /// canonical example); the two are independent and must not be treated as
 /// mutually exclusive.
 pub(crate) fn needs_java_artifact(library: &Library) -> bool {
+    // Four-part native coordinates (group:artifact:version:natives-*) store
+    // their native archive metadata in downloads.artifact, which is not a
+    // Java JAR. Exclude them so they only produce NativeArtifact tasks.
+    if library_classifier(&library.name)
+        .is_some_and(|classifier| classifier.starts_with("natives-"))
+    {
+        return false;
+    }
+    // Legacy pure-native libraries carry a natives map but no downloads.artifact;
+    // their main JAR is not downloaded by the original installer either.
+    if library.natives.is_some()
+        && library
+            .downloads
+            .as_ref()
+            .and_then(|downloads| downloads.artifact.as_ref())
+            .is_none()
+    {
+        return false;
+    }
     library
         .downloads
         .as_ref()

--- a/packages/daedalus/src/modded.rs
+++ b/packages/daedalus/src/modded.rs
@@ -389,6 +389,7 @@ pub fn merge_partial_version(
             .iter_mut()
             .find(|existing: &&mut Library| existing.name == library.name)
         {
+            existing.include_in_classpath |= library.include_in_classpath;
             if existing.natives.is_none() {
                 existing.natives = library.natives.clone();
             }


### PR DESCRIPTION
## Problem

After manifest merging, a library can carry both a Java artifact and native classifiers (e.g. LWJGL GLFW in 1.16.5). The previous code treated any library with natives as native-only, skipping the Java JAR download while putting its missing path on the classpath, causing Forge to fail with GLFWFramebufferSizeCallbackI not found.

## Fix

Plan per-file download tasks instead of mutually exclusive library types:

- download.rs: LibraryDownloadTask enum (JavaArtifact/NativeArtifact), Java tasks dedup by target path, native tasks reuse existing SHA-1 dedup, all tasks share the same concurrent queue
- args.rs: allow_not_exist = is_native_library && !needs_java_artifact — merged libraries require their JAR, pure native libraries remain tolerated
- import_plan.rs: same independent-task logic for instance import
- missing_library_bytes: count both Java and native artifacts

## Verification

- cargo check passes
- 24 download + 6 args + 13 import_plan tests all pass
- Cold-cache Forge 1.16.5 install produces both JAR and natives; game launches without GLFW errors

## Sourcery 总结

为合并后的库独立下载并配置 Java 和原生构件，确保 Forge 安装获得完整的 LWJGL 依赖项。

Bug 修复：
- 确保同时包含 Java 构件和原生分类器的库能够下载并保留这两个文件，避免 Forge 启动时缺少 LWJGL 类。

功能增强：
- 将 Java 和原生库构件视为独立的下载与导入要求，并进行适当的去重和类路径处理。
- 计算缺失库的下载大小时，同时包含 Java 和原生构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

独立下载并配置合并的 Java 和原生库构件，确保 Forge 安装能够获得完整的 LWJGL 依赖项。

错误修复：
- 确保将 Java 构件与原生分类器结合的库下载并保留两个文件，防止 Forge 启动时缺少 LWJGL 类。

改进：
- 将 Java 和原生库构件视为独立的下载和导入要求，并进行适当的去重和类路径处理。
- 计算缺失库的下载大小时，同时包含 Java 和原生构件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Download and configure merged Java and native library artifacts independently so Forge installations receive complete LWJGL dependencies.

Bug Fixes:
- Ensure libraries that combine Java artifacts with native classifiers download and retain both files, preventing missing LWJGL classes during Forge launches.

Enhancements:
- Treat Java and native library artifacts as independent download and import requirements, with appropriate deduplication and classpath handling.
- Include both Java and native artifacts when calculating missing library download sizes.

</details>

</details>