### PR TITLE
feat(content): 渲染内容名称中的 Minecraft 格式代码

### DIFF
--- a/apps/app-frontend/src/components/instance/dependencies/DependencyGraphModal.vue
+++ b/apps/app-frontend/src/components/instance/dependencies/DependencyGraphModal.vue
@@ -16,11 +16,13 @@ import {
 	type ContentItem,
 	defineMessages,
 	DropdownSelect,
+	MinecraftFormattedText,
 	NewModal,
 	StyledInput,
 	Toggle,
 	useVIntl,
 } from '@modrinth/ui'
+import { autoCleanToText } from '@sfirew/minecraft-motd-parser'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 
@@ -778,14 +780,15 @@ defineExpose({ show, hide, setItems })
 								<template v-if="row.nodeId && graph.nodeById.get(row.nodeId)">
 									<Avatar
 										:src="graph.nodeById.get(row.nodeId)?.iconUrl"
-										:alt="graph.nodeById.get(row.nodeId)?.title"
+										:alt="autoCleanToText(graph.nodeById.get(row.nodeId)?.title ?? '')"
 										size="2.5rem"
 										no-shadow
 									/>
 									<div class="min-w-0 flex-1">
-										<div class="truncate font-semibold text-contrast">
-											{{ graph.nodeById.get(row.nodeId)?.title }}
-										</div>
+										<MinecraftFormattedText
+											:text="graph.nodeById.get(row.nodeId)?.title ?? ''"
+											class="block truncate font-semibold text-contrast"
+										/>
 										<div class="mt-0.5 truncate text-xs text-secondary">
 											{{
 												graph.nodeById.get(row.nodeId)?.versionNumber ??
@@ -946,9 +949,17 @@ defineExpose({ show, hide, setItems })
 										@click.stop="selectNode(node.id)"
 									>
 										<span class="dependency-graph-port dependency-graph-port-input" />
-										<Avatar :src="node.iconUrl" :alt="node.title" size="2.75rem" no-shadow />
+										<Avatar
+											:src="node.iconUrl"
+											:alt="autoCleanToText(node.title)"
+											size="2.75rem"
+											no-shadow
+										/>
 										<div class="min-w-0 flex-1">
-											<div class="truncate text-sm font-bold text-contrast">{{ node.title }}</div>
+											<MinecraftFormattedText
+												:text="node.title"
+												class="block truncate text-sm font-bold text-contrast"
+											/>
 											<div class="mt-0.5 truncate text-xs text-secondary">
 												{{ statusLabel(node) ?? sourceLabel(node) }}
 											</div>
@@ -975,8 +986,13 @@ defineExpose({ show, hide, setItems })
 										class="flex max-w-52 items-center gap-2 rounded-lg border border-solid border-surface-4 bg-surface-1 px-2 py-1.5 text-left text-xs text-secondary transition-colors hover:border-brand hover:text-contrast"
 										@click="selectNode(node.id)"
 									>
-										<Avatar :src="node.iconUrl" :alt="node.title" size="1.5rem" no-shadow />
-										<span class="truncate">{{ node.title }}</span>
+										<Avatar
+											:src="node.iconUrl"
+											:alt="autoCleanToText(node.title)"
+											size="1.5rem"
+											no-shadow
+										/>
+										<MinecraftFormattedText :text="node.title" class="truncate" />
 									</button>
 								</div>
 							</div>
@@ -989,18 +1005,25 @@ defineExpose({ show, hide, setItems })
 					class="flex min-h-0 w-full shrink-0 flex-col gap-4 overflow-y-auto border-0 border-t border-solid border-surface-4 bg-surface-1 p-5 lg:w-[310px] lg:border-l lg:border-t-0"
 				>
 					<div class="flex items-center gap-3">
-						<Avatar :src="selectedNode.iconUrl" :alt="selectedNode.title" size="3rem" no-shadow />
+						<Avatar
+							:src="selectedNode.iconUrl"
+							:alt="autoCleanToText(selectedNode.title)"
+							size="3rem"
+							no-shadow
+						/>
 						<div class="min-w-0">
 							<RouterLink
 								v-if="nodeLink(selectedNode)"
 								:to="{ path: nodeLink(selectedNode), query: nodeLinkQuery() }"
 								class="block truncate font-semibold text-contrast hover:underline"
 							>
-								{{ selectedNode.title }}
+								<MinecraftFormattedText :text="selectedNode.title" />
 							</RouterLink>
-							<span v-else class="block truncate font-semibold text-contrast">{{
-								selectedNode.title
-							}}</span>
+							<MinecraftFormattedText
+								v-else
+								:text="selectedNode.title"
+								class="block truncate font-semibold text-contrast"
+							/>
 							<span class="text-sm text-secondary">{{ sourceLabel(selectedNode) }}</span>
 						</div>
 					</div>
@@ -1029,7 +1052,7 @@ defineExpose({ show, hide, setItems })
 							class="truncate text-left text-sm text-brand hover:underline"
 							@click="selectNode(edge.target)"
 						>
-							{{ graph.nodeById.get(edge.target)?.title }}
+							<MinecraftFormattedText :text="graph.nodeById.get(edge.target)?.title ?? ''" />
 						</button>
 						<span
 							v-if="!graph.edgesBySource.get(selectedNode.id)?.length"
@@ -1048,7 +1071,7 @@ defineExpose({ show, hide, setItems })
 							class="truncate text-left text-sm text-brand hover:underline"
 							@click="selectNode(edge.source)"
 						>
-							{{ graph.nodeById.get(edge.source)?.title }}
+							<MinecraftFormattedText :text="graph.nodeById.get(edge.source)?.title ?? ''" />
 						</button>
 						<span
 							v-if="!graph.edgesByTarget.get(selectedNode.id)?.length"

--- a/apps/app-frontend/src/components/ui/modal/ContentToggleDependenciesModal.vue
+++ b/apps/app-frontend/src/components/ui/modal/ContentToggleDependenciesModal.vue
@@ -4,9 +4,12 @@ import {
 	ButtonStyled,
 	commonMessages,
 	defineMessages,
+	IntlFormatted,
+	MinecraftFormattedText,
 	NewModal,
 	useVIntl,
 } from '@modrinth/ui'
+import { autoCleanToText } from '@sfirew/minecraft-motd-parser'
 import { ref } from 'vue'
 
 export interface ContentToggleDependencyItem {
@@ -99,12 +102,14 @@ defineExpose({ show })
 	>
 		<div v-if="data" class="flex flex-col gap-4">
 			<p class="m-0 text-primary">
-				{{
-					formatMessage(data.bulk ? messages.bulkBody : messages.singleBody, {
-						project: data.primaryTitle,
-						count: data.related.length,
-					})
-				}}
+				<IntlFormatted
+					:message-id="data.bulk ? messages.bulkBody : messages.singleBody"
+					:values="{ count: data.related.length }"
+				>
+					<template #project>
+						<MinecraftFormattedText :text="data.primaryTitle" />
+					</template>
+				</IntlFormatted>
 			</p>
 
 			<div v-if="data.related.length > 0" class="flex flex-col gap-2">
@@ -118,13 +123,16 @@ defineExpose({ show })
 				>
 					<Avatar
 						:src="item.iconUrl"
-						:alt="item.title"
+						:alt="autoCleanToText(item.title)"
 						size="2.5rem"
 						:tint-by="item.title"
 						no-shadow
 					/>
 					<div class="flex min-w-0 flex-col gap-0.5">
-						<span class="truncate font-semibold text-contrast">{{ item.title }}</span>
+						<MinecraftFormattedText
+							:text="item.title"
+							class="truncate font-semibold text-contrast"
+						/>
 						<span v-if="item.versionNumber" class="truncate text-sm text-secondary">
 							{{ item.versionNumber }}
 						</span>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,6 +46,7 @@
 		"@modrinth/api-client": "workspace:*",
 		"@modrinth/assets": "workspace:*",
 		"@modrinth/utils": "workspace:*",
+		"@sfirew/minecraft-motd-parser": "^1.1.6",
 		"@tanstack/vue-query": "5.90.7",
 		"@tauri-apps/plugin-dialog": "^2.2.1",
 		"@tresjs/cientos": "^4.3.0",

--- a/packages/ui/src/components/base/MinecraftFormattedText.vue
+++ b/packages/ui/src/components/base/MinecraftFormattedText.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { autoToHTML } from '@sfirew/minecraft-motd-parser'
+import { computed } from 'vue'
+
+const props = defineProps<{
+	text: string
+}>()
+
+const renderedText = computed(() => autoToHTML(props.text))
+</script>
+
+<template>
+	<!-- eslint-disable-next-line vue/no-v-html -->
+	<span v-html="renderedText" />
+</template>

--- a/packages/ui/src/components/base/index.ts
+++ b/packages/ui/src/components/base/index.ts
@@ -21,7 +21,6 @@ export type {
 	ButtonVisualProps,
 } from './buttons/types'
 export { default as ButtonStyled } from './ButtonStyled.vue'
-export { default as ScrollToTopButton } from './ScrollToTopButton.vue'
 export { default as Card } from './Card.vue'
 export { default as Checkbox } from './Checkbox.vue'
 export { default as Chips } from './Chips.vue'
@@ -65,6 +64,7 @@ export { default as LoadingBar } from './LoadingBar.vue'
 export { default as LoadingIndicator } from './LoadingIndicator.vue'
 export { default as ManySelect } from './ManySelect.vue'
 export { default as MarkdownEditor } from './MarkdownEditor.vue'
+export { default as MinecraftFormattedText } from './MinecraftFormattedText.vue'
 export type {
 	MultiSelectItem,
 	MultiSelectOption,
@@ -87,6 +87,7 @@ export { default as RadialHeader } from './RadialHeader.vue'
 export { default as RadioButtons } from './RadioButtons.vue'
 export { default as ReadyTransition } from './ReadyTransition.vue'
 export { default as ScrollablePanel } from './ScrollablePanel.vue'
+export { default as ScrollToTopButton } from './ScrollToTopButton.vue'
 export { default as SelectionCard } from './SelectionCard.vue'
 export { default as ServerNotice } from './ServerNotice.vue'
 export { default as SettingsLabel } from './SettingsLabel.vue'

--- a/packages/ui/src/layouts/shared/content-tab/components/ContentCardItem.vue
+++ b/packages/ui/src/layouts/shared/content-tab/components/ContentCardItem.vue
@@ -14,6 +14,7 @@ import {
 	UndoIcon,
 	UserIcon,
 } from '@modrinth/assets'
+import { autoCleanToText } from '@sfirew/minecraft-motd-parser'
 import { useMagicKeys } from '@vueuse/core'
 import { computed, getCurrentInstance, ref } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
@@ -23,6 +24,7 @@ import Avatar from '#ui/components/base/Avatar.vue'
 import BulletDivider from '#ui/components/base/BulletDivider.vue'
 import ButtonStyled from '#ui/components/base/ButtonStyled.vue'
 import Checkbox from '#ui/components/base/Checkbox.vue'
+import MinecraftFormattedText from '#ui/components/base/MinecraftFormattedText.vue'
 import type { Option as OverflowMenuOption } from '#ui/components/base/OverflowMenu.vue'
 import TeleportOverflowMenu from '#ui/components/base/TeleportOverflowMenu.vue'
 import Toggle from '#ui/components/base/Toggle.vue'
@@ -195,6 +197,7 @@ const fileNameRef = ref<HTMLElement | null>(null)
 
 const isDisabled = computed(() => props.disabled || props.installing)
 const isToggleDisabled = computed(() => isDisabled.value || props.toggleDisabled)
+const plainProjectTitle = computed(() => autoCleanToText(props.project.title))
 
 const interactiveSelectors = 'a, button, input, select, [role="checkbox"], [role="button"]'
 
@@ -236,7 +239,7 @@ const deleteHovered = ref(false)
 				v-if="showCheckbox"
 				:model-value="selected ?? false"
 				:indeterminate="groupCheckboxIndeterminate"
-				:aria-label="formatMessage(messages.selectProject, { project: project.title })"
+				:aria-label="formatMessage(messages.selectProject, { project: plainProjectTitle })"
 				class="shrink-0"
 				@update:model-value="(value, event) => emit('select', value, event)"
 			/>
@@ -244,7 +247,7 @@ const deleteHovered = ref(false)
 			<div class="flex min-w-0 items-center gap-3">
 				<Avatar
 					:src="project.icon_url"
-					:alt="project.title"
+					:alt="plainProjectTitle"
 					size="3rem"
 					no-shadow
 					class="rounded-2xl border border-surface-5"
@@ -270,7 +273,7 @@ const deleteHovered = ref(false)
 								{ 'hover:underline': projectLink },
 							]"
 						>
-							{{ project.title }}
+							<MinecraftFormattedText :text="project.title" />
 						</AutoLink>
 						<span
 							v-if="groupKind === 'world'"
@@ -472,7 +475,7 @@ const deleteHovered = ref(false)
 			<Checkbox
 				v-if="showCheckbox"
 				:model-value="selected ?? false"
-				:aria-label="formatMessage(messages.selectProject, { project: project.title })"
+				:aria-label="formatMessage(messages.selectProject, { project: plainProjectTitle })"
 				class="shrink-0"
 				@update:model-value="(value, event) => emit('select', value, event)"
 			/>
@@ -493,7 +496,7 @@ const deleteHovered = ref(false)
 				>
 					<Avatar
 						:src="project.icon_url"
-						:alt="project.title"
+						:alt="plainProjectTitle"
 						size="3rem"
 						no-shadow
 						class="rounded-2xl border border-surface-5"
@@ -523,7 +526,7 @@ const deleteHovered = ref(false)
 							class="truncate font-semibold leading-6 text-contrast !decoration-contrast"
 							:class="{ 'hover:underline': projectLink }"
 						>
-							{{ project.title }}
+							<MinecraftFormattedText :text="project.title" />
 						</AutoLink>
 						<TriangleAlertIcon
 							v-if="postUpgradeWarningTooltip"
@@ -740,7 +743,7 @@ const deleteHovered = ref(false)
 				"
 				:model-value="enabled"
 				:disabled="isToggleDisabled"
-				:aria-label="project.title"
+				:aria-label="plainProjectTitle"
 				class="my-auto"
 				@update:model-value="(val) => emit('update:enabled', val as boolean)"
 			/>

--- a/packages/ui/src/layouts/shared/content-tab/components/ContentSelectionBar.vue
+++ b/packages/ui/src/layouts/shared/content-tab/components/ContentSelectionBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { PowerIcon, PowerOffIcon, XIcon } from '@modrinth/assets'
+import { autoCleanToText, autoToHTML } from '@sfirew/minecraft-motd-parser'
 import { computed } from 'vue'
 
 import Avatar from '#ui/components/base/Avatar.vue'
@@ -135,6 +136,14 @@ function resolveItemId(item: ContentItem) {
 	return props.getItemId?.(item) ?? item.file_path ?? item.file_name ?? item.id
 }
 
+function resolveItemTitle(item: ContentItem) {
+	return item.project?.title ?? item.file_name
+}
+
+function itemTitleTooltip(item: ContentItem) {
+	return { content: autoToHTML(resolveItemTitle(item)), html: true }
+}
+
 const allDisabled = computed(
 	() =>
 		!props.selectedItems.some((item) => canToggleContentItem(item) && isEnabledContentItem(item)),
@@ -199,13 +208,13 @@ const bulkProgressMessage = computed(() => {
 				<div
 					v-for="(item, index) in visibleItems"
 					:key="resolveItemId(item)"
-					v-tooltip="item.project?.title ?? item.file_name"
+					v-tooltip="itemTitleTooltip(item)"
 					class="absolute top-0 flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg border-[1.5px] border-solid border-surface-3 bg-surface-4"
 					:style="{ left: `${index * iconStackOffset}px`, zIndex: visibleItems.length - index }"
 				>
 					<Avatar
 						:src="item.project?.icon_url"
-						:alt="item.project?.title ?? item.file_name"
+						:alt="autoCleanToText(resolveItemTitle(item))"
 						:tint-by="resolveItemId(item)"
 						size="100%"
 						no-shadow

--- a/packages/ui/src/layouts/shared/content-tab/components/modals/ContentDependencyWarningModal.vue
+++ b/packages/ui/src/layouts/shared/content-tab/components/modals/ContentDependencyWarningModal.vue
@@ -3,15 +3,20 @@
 		<div class="flex flex-col gap-6">
 			<SymlinkWarningAdmonition :symlink-target="symlinkTarget" />
 			<Admonition type="critical" :header="formatMessage(messages.admonitionHeader)">
-				{{
-					visibleItems.length === 1
-						? formatMessage(messages.singleAdmonitionBody, {
-								project:
-									visibleItems[0]?.project.title ?? formatMessage(commonMessages.unknownLabel),
-								context: contextLabel,
-							})
-						: formatMessage(messages.bulkAdmonitionBody, { context: contextLabel })
-				}}
+				<IntlFormatted
+					v-if="visibleItems.length === 1"
+					:message-id="messages.singleAdmonitionBody"
+					:values="{ context: contextLabel }"
+				>
+					<template #project>
+						<MinecraftFormattedText
+							:text="visibleItems[0]?.project.title ?? formatMessage(commonMessages.unknownLabel)"
+						/>
+					</template>
+				</IntlFormatted>
+				<template v-else>
+					{{ formatMessage(messages.bulkAdmonitionBody, { context: contextLabel }) }}
+				</template>
 			</Admonition>
 
 			<div v-if="visibleItems.length > 0" class="flex flex-col gap-2">
@@ -105,11 +110,11 @@
 										<span
 											v-for="dependency in dependent.dependencies"
 											:key="dependency.id"
-											:title="dependency.project.title"
+											v-tooltip="{ content: autoToHTML(dependency.project.title), html: true }"
 										>
-											<span class="truncate text-xs text-secondary mr-0.5"
-												>({{ dependency.project.title }})</span
-											>
+											<span class="mr-0.5 truncate text-xs text-secondary">
+												(<MinecraftFormattedText :text="dependency.project.title" />)
+											</span>
 										</span>
 									</span>
 								</template>
@@ -180,11 +185,14 @@
 
 <script setup lang="ts">
 import { TrashIcon, XIcon } from '@modrinth/assets'
+import { autoToHTML } from '@sfirew/minecraft-motd-parser'
 import { computed, nextTick, ref } from 'vue'
 
 import Admonition from '#ui/components/base/Admonition.vue'
 import ButtonStyled from '#ui/components/base/ButtonStyled.vue'
 import Checkbox from '#ui/components/base/Checkbox.vue'
+import IntlFormatted from '#ui/components/base/IntlFormatted.vue'
+import MinecraftFormattedText from '#ui/components/base/MinecraftFormattedText.vue'
 import NewModal from '#ui/components/modal/NewModal.vue'
 import { defineMessages, useVIntl } from '#ui/composables/i18n'
 import { useScrollIndicator } from '#ui/composables/scroll-indicator'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,9 @@ importers:
       '@modrinth/utils':
         specifier: workspace:*
         version: link:../utils
+      '@sfirew/minecraft-motd-parser':
+        specifier: ^1.1.6
+        version: 1.1.6
       '@tanstack/vue-query':
         specifier: 5.90.7
         version: 5.90.7(vue@3.5.27(typescript@5.9.3))


### PR DESCRIPTION
## 概述

使用 `@sfirew/minecraft-md-parser` 渲染实例内容名称中的 Minecraft 格式代码。

覆盖实例内容主表格、整合包内容、批量选择提示、依赖确认弹窗和依赖关系图。

## 主要变更

- 在 `@modrinth/ui` 中新增轻量的 `MinecraftFormattedText` 组件
- 使用 `autoToHTML` 渲染可见的内容名称
- 对 `alt` 和 `aria-label` 等纯文本属性使用 `autoCleanToText`
- Tooltip 使用解析器生成并转义的 HTML
- 搜索、排序、链接、分享、通知和埋点继续使用原始标题
- 复用锁文件中已有的 `1.1.6` 版本，不升级解析器

## 安全性

`v-html` 仅接收 `autoToHTML` 的输出。解析器会转义原始标题中的 HTML 字符。

已验证包含 `<img onerror=...>` 的标题只会显示为文本，不会生成可执行元素。

## 验证

- [x] 普通标题的显示结果保持不变
- [x] 使用 `§aGreen §lBold §rNormal` 验证颜色、粗体、重置及格式符隐藏
- [x] 验证潜在恶意 HTML 会被转义
- [x] 对本次修改的 UI 和应用文件执行定向 ESLint 检查
- [x] 运行 `git diff --check`
- [x] 运行 `pnpm prepr:frontend:lib`

## 范围说明

本次 PR 有意保持最小化修改，不会：

- 修改标题原始数据或业务逻辑
- 支持 `&` 格式代码或额外的十六进制规则
- 格式化实例名称、文件名或版本号
- 修改本地化资源、onboarding 或发布公告

## Sourcery 摘要

在相关前端界面中显示 Minecraft 格式化的内容名称，同时保留安全的纯文本可访问性和应用程序值。

新功能：
- 在内容列表、选择界面、依赖项对话框和依赖关系图中渲染内容名称的 Minecraft 格式代码。

增强功能：
- 添加可复用的 UI 组件，用于显示格式化的 Minecraft 文本，同时保留纯文本标签和可访问性属性。
- 在工具提示和本地化的依赖项消息中渲染格式化的内容名称，同时不更改应用程序行为所使用的原始标题。

构建：
- 将 Minecraft MOTD 解析器添加为 UI 软件包依赖项，并更新锁定文件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在相关前端界面中渲染 Minecraft 格式化的内容名称，同时保留安全的纯文本无障碍访问体验和应用值。

新功能：
- 在内容列表、选择控件、依赖项对话框和依赖关系图中渲染内容名称的 Minecraft 格式代码。

增强功能：
- 添加可复用的 UI 组件，用于显示格式化的 Minecraft 文本，同时为无障碍属性和应用值保留清理后的纯文本。
- 在依赖项消息和工具提示中显示格式化名称，同时不改变搜索、排序、链接、分享、通知或分析行为。

构建：
- 将 Minecraft MOTD 解析器添加为 UI 软件包依赖项，并更新锁定文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render Minecraft-formatted content names throughout the relevant frontend interfaces while preserving safe plain-text accessibility and application values.

New Features:
- Render Minecraft formatting codes in content names across content lists, selection controls, dependency dialogs, and dependency graphs.

Enhancements:
- Add a reusable UI component for formatted Minecraft text while preserving cleaned plain text for accessibility attributes and application values.
- Display formatted names in dependency messages and tooltips without changing search, sorting, linking, sharing, notifications, or analytics behavior.

Build:
- Add the Minecraft MOTD parser as a UI package dependency and update the lockfile.

</details>

</details>