### PR TITLE
fix(installer): 修复未勾选“完成后启动”仍自动启动的问题

### DIFF
--- a/apps/app/nsis/installer.nsi
+++ b/apps/app/nsis/installer.nsi
@@ -115,6 +115,7 @@ Var InstallerBodyFont
 Var InstallerTitleFont
 Var InstallerSmallFont
 Var StatusFile
+Var NoRunAfterInstall
 
 !macro AxlStyleControl CONTROL FOREGROUND BACKGROUND
   SetCtlColors ${CONTROL} ${FOREGROUND} ${BACKGROUND}
@@ -903,6 +904,11 @@ Function .onInit
     StrCpy $NoDesktopShortcutMode 1
   ${EndIf}
 
+  ${GetOptions} $CMDLINE "/NO_RUN_AFTER_INSTALL" $0
+  ${IfNot} ${Errors}
+    StrCpy $NoRunAfterInstall 1
+  ${EndIf}
+
   ${GetOptions} $CMDLINE "/STATUS_FILE=" $StatusFile
   ${If} ${Errors}
     StrCpy $StatusFile ""
@@ -1238,14 +1244,18 @@ Function .onInstSuccess
   Push 100
   Call ReportInstallerProgress
 
-  ; Check for `/R` flag only in silent and passive installers because
-  ; GUI installer has a toggle for the user to (re)start the app
-  ${If} $PassiveMode = 1
-  ${OrIf} ${Silent}
-    ${GetOptions} $CMDLINE "/R" $R0
-    ${IfNot} ${Errors}
-      ${GetOptions} $CMDLINE "/ARGS" $R0
-      nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "$R0"
+  ; Installer-ui runs the silent core and starts the app itself based on the
+  ; user's "Launch when complete" choice, so never auto-launch there.
+  ${If} $NoRunAfterInstall <> 1
+    ; Check for `/R` flag only in silent and passive installers because
+    ; GUI installer has a toggle for the user to (re)start the app
+    ${If} $PassiveMode = 1
+    ${OrIf} ${Silent}
+      ${GetOptions} $CMDLINE "/R" $R0
+      ${IfNot} ${Errors}
+        ${GetOptions} $CMDLINE "/ARGS" $R0
+        nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "$R0"
+      ${EndIf}
     ${EndIf}
   ${EndIf}
 FunctionEnd

--- a/apps/installer-ui/src/windows.rs
+++ b/apps/installer-ui/src/windows.rs
@@ -521,6 +521,7 @@ fn installer_arguments(
         nsis_value_option("INSTALL_DIR", request.install_dir.trim()),
         nsis_value_option("RESOURCE_DIR", request.resource_dir.trim()),
         nsis_value_option("STATUS_FILE", &status_path.to_string_lossy()),
+        "/NO_RUN_AFTER_INSTALL".to_string(),
     ];
     if !request.desktop_shortcut {
         arguments.push("/NO_DESKTOP_SHORTCUT".to_string());


### PR DESCRIPTION
## 修复内容

修复 #489：安装/更新时取消勾选"完成后启动"后，启动器仍会在安装完成后自动启动。

## 实测根因

在 Windows 上对 1.9.6-beta.1 安装包（与 modern 安装包 SHA-256 完全一致）做了受控复现：

- 静默安装并传入 `RESOURCE_DIR`（installer-ui 实际就是这样调用内层安装器的）→ 安装完成后启动器必然自动启动；
- 同样的静默安装，去掉 `RESOURCE_DIR` 参数 → 启动器不会启动。

原因在 `installer.nsi` 的 `.onInstSuccess`：它用 `${GetOptions} $CMDLINE "/R" $R0` 检测重启标志，但该匹配会把 `/RESOURCE_DIR=...` 误判为 `/R`，于是无论用户是否勾选"完成后启动"，内层静默安装都会在完成时启动启动器。这也解释了此前现象：安装界面（launch_after=false 分支）正常显示"完成"并保持打开，同时安装核心又独立把启动器拉了起来。

## 修改

- installer-ui 发起的内层静默安装新增 `/NO_RUN_AFTER_INSTALL` 标记；
- NSIS `.onInstSuccess` 检测到该标记时跳过自动启动——启动与否完全交由 installer-ui 按用户勾选状态决定（勾选时由界面启动并退出，未勾选时仅显示完成页）；
- 更新器（Tauri updater，静默 + `/R`）与经典回退界面流程不传该标记，行为保持不变。

## 验证说明

根因与修复方向已在本机通过上述 A/B 复现实验确认（带/不带 `RESOURCE_DIR` 对比）。当前环境无法编译 NSIS 安装包，最终安装包行为建议由 CI/维护者在 Windows 上复核一次。

## Sourcery 摘要

通过防止安装完成后意外启动应用程序，确保安装程序 UI 的启动偏好设置得到遵循。

错误修复：
- 当安装程序 UI 的“完成后启动”选项未勾选时，阻止安装程序核心自动启动应用程序。

改进：
- 在更新程序和经典回退安装流程中保持应用程序启动行为不变，同时允许安装程序 UI 控制启动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure installer UI launch preferences are respected by preventing unintended application startup after installation.

Bug Fixes:
- Prevent the installer core from automatically launching the application when the installer UI's “Launch when complete” option is unchecked.

Enhancements:
- Keep application launch behavior unchanged for updater and classic fallback installation flows while allowing the installer UI to control launch behavior.

</details>