### PR TITLE
feat(server): 适配 Forge 控制台的 JLine 自动补全

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
@@ -1512,6 +1518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,7 +1628,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.3+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1809,6 +1821,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -3651,13 +3674,25 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -4133,7 +4168,7 @@ checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -4463,6 +4498,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,7 +4708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4693,7 +4749,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
@@ -5531,6 +5587,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5597,6 +5664,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -6769,6 +6852,7 @@ dependencies = [
  "path-util",
  "phf 0.13.1",
  "png 0.18.1",
+ "portable-pty",
  "quartz_nbt",
  "quick-xml 0.38.4",
  "rand 0.8.5",
@@ -6808,7 +6892,7 @@ dependencies = [
  "whoami",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "winreg",
+ "winreg 0.55.0",
  "xz2",
  "zbus",
  "zhconv",
@@ -8591,6 +8675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ paste = "1.0.15"
 path-util = { path = "packages/path-util" }
 phf = { version = "0.13.1", features = ["macros"] }
 png = "0.18.0"
+portable-pty = "0.9.0"
 quartz_nbt = "0.2.9"
 quick-xml = "0.38.3"
 rand = "=0.8.5"  # Locked on 0.8 until p256 updates to 0.9

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
@@ -9,6 +9,7 @@ import {
 } from '@modrinth/ui'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
+import { ServerConsoleBuffer } from '@/composables/server-console-buffer'
 import {
 	hydrateLog,
 	type ServerView,
@@ -46,10 +47,12 @@ let consumedLines = 0
 // duplicating the earliest startup lines.
 let hydrating = false
 let unsubscribeConsoleOutput: (() => void) | null = null
-const pendingConsoleOutput: Uint8Array[] = []
+const PENDING_CONSOLE_OUTPUT_CAPACITY = 64 * 1024
+let pendingConsoleOutput = new ServerConsoleBuffer(PENDING_CONSOLE_OUTPUT_CAPACITY)
 
 function flushConsoleOutput() {
-	for (const data of pendingConsoleOutput.splice(0)) jlineInput.value?.write(data)
+	for (const data of pendingConsoleOutput.values()) jlineInput.value?.write(data)
+	pendingConsoleOutput = new ServerConsoleBuffer(PENDING_CONSOLE_OUTPUT_CAPACITY)
 }
 
 watch(
@@ -151,7 +154,7 @@ watch(
 	() => props.server.running,
 	async (running, previousRunning) => {
 		if (!running) {
-			pendingConsoleOutput.length = 0
+			pendingConsoleOutput = new ServerConsoleBuffer(PENDING_CONSOLE_OUTPUT_CAPACITY)
 			return
 		}
 		if (previousRunning) return

--- a/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
+++ b/apps/app-frontend/src/components/multiplayer/servers/ServerConsole.vue
@@ -3,12 +3,18 @@ import {
 	ConsolePageLayout,
 	createConsoleState,
 	defineMessages,
+	JLineCommandInput,
 	provideConsoleManager,
 	useVIntl,
 } from '@modrinth/ui'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
-import { hydrateLog, type ServerView, useServers } from '@/composables/useServers'
+import {
+	hydrateLog,
+	type ServerView,
+	subscribeServerConsoleOutput,
+	useServers,
+} from '@/composables/useServers'
 import { servers } from '@/helpers/servers'
 
 const props = defineProps<{
@@ -17,6 +23,10 @@ const props = defineProps<{
 
 const { formatMessage } = useVIntl()
 const messages = defineMessages({
+	forgeCommandPlaceholder: {
+		id: 'app.servers.console.forge-command-placeholder',
+		defaultMessage: 'Send a command - Tab completion supported',
+	},
 	notRunning: {
 		id: 'app.servers.console.not-running',
 		defaultMessage: 'The server is not running',
@@ -27,12 +37,35 @@ const { logLines, sendCommand } = useServers()
 const consoleState = createConsoleState()
 const loading = ref(true)
 const hasLogs = computed(() => consoleState.output.value.length > 0)
+const isForge = computed(() => props.server.serverType === 'forge')
+const jlineInput = ref<InstanceType<typeof JLineCommandInput> | null>(null)
 let consumedLines = 0
 // Guards the live length-watcher from double-appending while we rebuild the
 // console from the buffer during (re)hydration. Without it, the async
 // hydrate fetch and the streamed `logLines` updates race, dropping or
 // duplicating the earliest startup lines.
 let hydrating = false
+let unsubscribeConsoleOutput: (() => void) | null = null
+const pendingConsoleOutput: Uint8Array[] = []
+
+function flushConsoleOutput() {
+	for (const data of pendingConsoleOutput.splice(0)) jlineInput.value?.write(data)
+}
+
+watch(
+	() => props.server.id,
+	(serverId) => {
+		unsubscribeConsoleOutput?.()
+		unsubscribeConsoleOutput = subscribeServerConsoleOutput(serverId, (data) => {
+			if (jlineInput.value) {
+				jlineInput.value.write(data)
+			} else {
+				pendingConsoleOutput.push(data)
+			}
+		})
+	},
+	{ immediate: true },
+)
 
 async function hydrateAndDisplay() {
 	hydrating = true
@@ -71,12 +104,16 @@ function stopSync() {
 }
 
 onMounted(async () => {
+	flushConsoleOutput()
 	await hydrateAndDisplay()
 	loading.value = false
 	startSync()
 })
 
-onUnmounted(stopSync)
+onUnmounted(() => {
+	stopSync()
+	unsubscribeConsoleOutput?.()
+})
 
 watch(
 	() => (logLines[props.server.id] ?? []).length,
@@ -113,7 +150,13 @@ const consoleLayout = ref<InstanceType<typeof ConsolePageLayout> | null>(null)
 watch(
 	() => props.server.running,
 	async (running, previousRunning) => {
-		if (!running || previousRunning) return
+		if (!running) {
+			pendingConsoleOutput.length = 0
+			return
+		}
+		if (previousRunning) return
+		await nextTick()
+		flushConsoleOutput()
 		consoleState.clear()
 		consumedLines = 0
 		// Drop the previous run's lines from the shared buffer too; the backend
@@ -150,6 +193,17 @@ provideConsoleManager({
 		class="flex flex-col pb-3"
 		:class="hasLogs ? 'h-[calc(100dvh-80px)] shrink-0' : 'h-full min-h-[240px]'"
 	>
-		<ConsolePageLayout ref="consoleLayout" />
+		<ConsolePageLayout ref="consoleLayout" :custom-command-input="isForge">
+			<template #command-input="{ disabled }">
+				<JLineCommandInput
+					ref="jlineInput"
+					:disabled="disabled"
+					:placeholder="formatMessage(messages.forgeCommandPlaceholder)"
+					:send-command="handleSendCommand"
+					:send-input="(data) => servers.sendConsoleInput(server.id, data)"
+					:resize-console="(cols, rows) => servers.resizeConsole(server.id, cols, rows)"
+				/>
+			</template>
+		</ConsolePageLayout>
 	</div>
 </template>

--- a/apps/app-frontend/src/composables/server-console-buffer.test.ts
+++ b/apps/app-frontend/src/composables/server-console-buffer.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ServerConsoleBuffer } from './server-console-buffer.ts'
+
+test('bounds buffered console output without rescanning prior chunks', () => {
+	const buffer = new ServerConsoleBuffer(5)
+	buffer.push(Uint8Array.from([1, 2]))
+	buffer.push(Uint8Array.from([3, 4]))
+	buffer.push(Uint8Array.from([5, 6]))
+
+	assert.equal(buffer.size, 4)
+	assert.deepEqual(
+		[...buffer.values()].map((chunk) => [...chunk]),
+		[
+			[3, 4],
+			[5, 6],
+		],
+	)
+})
+
+test('keeps only the tail of a chunk larger than the capacity', () => {
+	const buffer = new ServerConsoleBuffer(3)
+	buffer.push(Uint8Array.from([1, 2, 3, 4, 5]))
+
+	assert.equal(buffer.size, 3)
+	assert.deepEqual(
+		[...buffer.values()].map((chunk) => [...chunk]),
+		[[3, 4, 5]],
+	)
+})

--- a/apps/app-frontend/src/composables/server-console-buffer.ts
+++ b/apps/app-frontend/src/composables/server-console-buffer.ts
@@ -1,0 +1,41 @@
+export class ServerConsoleBuffer {
+	private readonly chunks: Uint8Array[] = []
+	private readonly capacity: number
+	private head = 0
+	private byteLength = 0
+
+	constructor(capacity: number) {
+		this.capacity = capacity
+	}
+
+	push(data: Uint8Array) {
+		if (data.length >= this.capacity) {
+			this.chunks.length = 0
+			this.chunks.push(data.slice(-this.capacity))
+			this.head = 0
+			this.byteLength = this.capacity
+			return
+		}
+
+		this.chunks.push(data)
+		this.byteLength += data.length
+		while (this.byteLength > this.capacity && this.head < this.chunks.length - 1) {
+			this.byteLength -= this.chunks[this.head++]!.length
+		}
+
+		if (this.head >= 1024 && this.head * 2 >= this.chunks.length) {
+			this.chunks.splice(0, this.head)
+			this.head = 0
+		}
+	}
+
+	*values(): IterableIterator<Uint8Array> {
+		for (let index = this.head; index < this.chunks.length; index++) {
+			yield this.chunks[index]!
+		}
+	}
+
+	get size() {
+		return this.byteLength
+	}
+}

--- a/apps/app-frontend/src/composables/useServers.ts
+++ b/apps/app-frontend/src/composables/useServers.ts
@@ -3,11 +3,14 @@ import { injectNotificationManager } from '@modrinth/ui'
 import { computed, reactive, ref } from 'vue'
 
 import {
+	base64ToBytes,
 	serverEventListener,
 	type ServerExitReason,
 	type ServerInfoData,
 	servers,
 } from '@/helpers/servers'
+
+import { ServerConsoleBuffer } from './server-console-buffer'
 
 const LOG_CAPACITY = 5000
 
@@ -32,6 +35,9 @@ const serverList = ref<ServerInfoData[]>([])
 const logLines = reactive<Record<string, string[]>>({})
 const isRefreshing = ref(false)
 let listenerPromise: Promise<() => void> | null = null
+const consoleOutputListeners = new Map<string, Set<(data: Uint8Array) => void>>()
+const consoleOutputBuffers = new Map<string, ServerConsoleBuffer>()
+const CONSOLE_OUTPUT_CAPACITY = 64 * 1024
 
 export interface ServerView extends ServerInfoData {
 	status: ServerStatus
@@ -59,15 +65,40 @@ async function ensureListener() {
 		listenerPromise = serverEventListener((serverId, payload) => {
 			if (payload.event === 'log') {
 				void appendLog(serverId, payload.line)
+			} else if (payload.event === 'console_output') {
+				const data = base64ToBytes(payload.data)
+				const buffer =
+					consoleOutputBuffers.get(serverId) ?? new ServerConsoleBuffer(CONSOLE_OUTPUT_CAPACITY)
+				buffer.push(data)
+				consoleOutputBuffers.set(serverId, buffer)
+				for (const listener of consoleOutputListeners.get(serverId) ?? []) {
+					listener(data)
+				}
 			} else if (payload.event === 'started') {
 				void refresh()
 			} else if (payload.event === 'stopped') {
+				consoleOutputBuffers.delete(serverId)
 				void refresh()
 				if (payload.reason) exitReasonHandler?.(serverId, payload.reason)
 			}
 		})
 	}
 	return listenerPromise
+}
+
+export function subscribeServerConsoleOutput(
+	serverId: string,
+	listener: (data: Uint8Array) => void,
+): () => void {
+	const listeners = consoleOutputListeners.get(serverId) ?? new Set()
+	listeners.add(listener)
+	consoleOutputListeners.set(serverId, listeners)
+	for (const data of consoleOutputBuffers.get(serverId)?.values() ?? []) listener(data)
+	void ensureListener()
+	return () => {
+		listeners.delete(listener)
+		if (listeners.size === 0) consoleOutputListeners.delete(serverId)
+	}
 }
 
 export async function hydrateLog(serverId: string) {

--- a/apps/app-frontend/src/helpers/servers.ts
+++ b/apps/app-frontend/src/helpers/servers.ts
@@ -40,6 +40,7 @@ export type ServerExitReason = 'eula'
 
 export type ServerEventPayload =
 	| { event: 'log'; line: string }
+	| { event: 'console_output'; data: string }
 	| { event: 'download_progress'; downloaded: number; total?: number }
 	| { event: 'started' }
 	| { event: 'stopped'; crashed: boolean; reason?: ServerExitReason }
@@ -108,6 +109,13 @@ export const servers = {
 	) => invoke<void>(command('servers_start'), { serverId, ...options }),
 	sendCommand: (serverId: string, commandText: string) =>
 		invoke<void>(command('servers_send_command'), { serverId, command: commandText }),
+	sendConsoleInput: (serverId: string, data: Uint8Array) =>
+		invoke<void>(command('servers_send_console_input'), {
+			serverId,
+			data: bytesToBase64(data),
+		}),
+	resizeConsole: (serverId: string, cols: number, rows: number) =>
+		invoke<void>(command('servers_resize_console'), { serverId, cols, rows }),
 	stop: (serverId: string) => invoke<void>(command('servers_stop'), { serverId }),
 	kill: (serverId: string) => invoke<void>(command('servers_kill'), { serverId }),
 	killPortProcess: (port: number) => invoke<void>(command('servers_kill_port_process'), { port }),
@@ -116,6 +124,16 @@ export const servers = {
 	getLogBuffer: (serverId: string) =>
 		invoke<string[]>(command('servers_get_log_buffer'), { serverId }),
 	clearLog: (serverId: string) => invoke<void>(command('servers_clear_log'), { serverId }),
+}
+
+export function base64ToBytes(data: string): Uint8Array {
+	return Uint8Array.from(atob(data), (character) => character.charCodeAt(0))
+}
+
+function bytesToBase64(data: Uint8Array): string {
+	let binary = ''
+	for (const byte of data) binary += String.fromCharCode(byte)
+	return btoa(binary)
 }
 
 export async function serverEventListener(

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6056,6 +6056,9 @@
   "app.servers.card.type": {
     "message": "{type} · {version}"
   },
+  "app.servers.console.forge-command-placeholder": {
+    "message": "Send a command - Tab completion supported"
+  },
   "app.servers.console.not-running": {
     "message": "The server is not running"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6113,6 +6113,9 @@
   "app.servers.console.command-echo": {
     "message": "> {command}"
   },
+  "app.servers.console.forge-command-placeholder": {
+    "message": "发送命令，支持 Tab 补全"
+  },
   "app.servers.console.not-running": {
     "message": "服务器未运行"
   },

--- a/apps/app/build.rs
+++ b/apps/app/build.rs
@@ -764,6 +764,8 @@ fn main() {
                         "servers_install_modpack",
                         "servers_start",
                         "servers_send_command",
+                        "servers_send_console_input",
+                        "servers_resize_console",
                         "servers_stop",
                         "servers_kill",
                         "servers_kill_port_process",

--- a/apps/app/src/api/servers.rs
+++ b/apps/app/src/api/servers.rs
@@ -18,6 +18,8 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             servers_install_modpack,
             servers_start,
             servers_send_command,
+            servers_send_console_input,
+            servers_resize_console,
             servers_stop,
             servers_kill,
             servers_kill_port_process,
@@ -164,6 +166,23 @@ pub async fn servers_send_command(
     command: &str,
 ) -> Result<()> {
     Ok(servers::send_command(server_id, command).await?)
+}
+
+#[tauri::command]
+pub async fn servers_send_console_input(
+    server_id: &str,
+    data: &str,
+) -> Result<()> {
+    Ok(servers::send_console_input(server_id, data).await?)
+}
+
+#[tauri::command]
+pub async fn servers_resize_console(
+    server_id: &str,
+    cols: u16,
+    rows: u16,
+) -> Result<()> {
+    Ok(servers::resize_console(server_id, cols, rows).await?)
 }
 
 #[tauri::command]

--- a/packages/app-lib/Cargo.toml
+++ b/packages/app-lib/Cargo.toml
@@ -64,6 +64,7 @@ paste = { workspace = true }
 path-util = { workspace = true }
 phf = { workspace = true }
 png = { workspace = true }
+portable-pty = { workspace = true }
 quartz_nbt = { workspace = true, features = ["serde"] }
 quick-xml = { workspace = true, features = ["async-tokio", "serialize"] }
 rand = { workspace = true }

--- a/packages/app-lib/java/.gitignore
+++ b/packages/app-lib/java/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore IDE/compiler output written outside Gradle's build directory
+/bin/

--- a/packages/app-lib/src/api/servers.rs
+++ b/packages/app-lib/src/api/servers.rs
@@ -13,7 +13,9 @@ mod ports;
 
 pub use self::files::{download_file, read_file, write_file};
 pub use self::forge::install_forge;
-pub use self::lifecycle::{kill, send_command, start, stop};
+pub use self::lifecycle::{
+    kill, resize_console, send_command, send_console_input, start, stop,
+};
 pub use self::logs::{clear_log, get_log_buffer};
 pub use self::manage::{create, delete, get, list, set_icon, update_settings};
 pub use self::manifest::{ModpackInfo, ServerInfo, ServerManifest};

--- a/packages/app-lib/src/api/servers/lifecycle.rs
+++ b/packages/app-lib/src/api/servers/lifecycle.rs
@@ -4,8 +4,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use base64::Engine;
 use chrono::Utc;
 use dashmap::{DashMap, DashSet};
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
 use std::sync::LazyLock;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, Command};
@@ -17,7 +19,8 @@ use crate::util::io::IOError;
 use crate::{ErrorKind, Result};
 
 use super::logs::{
-    analyze_exit_reason, stream_server_output, tail_server_log_file,
+    analyze_exit_reason, stream_server_output, stream_server_pty_output,
+    tail_server_log_file,
 };
 use super::manifest::{
     read_manifest, resolve_jar_name, server_path, write_manifest,
@@ -25,11 +28,58 @@ use super::manifest::{
 
 const DEFAULT_MEMORY_MB: u32 = 2048;
 const STOP_TIMEOUT_SECS: u64 = 60;
+const MAX_CONSOLE_ROWS: u16 = 8192;
 
 struct ServerProcess {
-    child: tokio::sync::Mutex<Child>,
-    stdin: tokio::sync::Mutex<ChildStdin>,
+    child: tokio::sync::Mutex<ServerChild>,
+    input: tokio::sync::Mutex<ServerInput>,
+    pty_master: Option<tokio::sync::Mutex<Box<dyn MasterPty + Send>>>,
     stop_requested: AtomicBool,
+}
+
+enum ServerChild {
+    Piped(Child),
+    Pty(Box<dyn portable_pty::Child + Send + Sync>),
+}
+
+enum ServerInput {
+    Piped(ChildStdin),
+    Pty(Box<dyn std::io::Write + Send>),
+}
+
+impl ServerInput {
+    async fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Piped(stdin) => {
+                stdin.write_all(data).await?;
+                stdin.flush().await
+            }
+            Self::Pty(writer) => {
+                writer.write_all(data)?;
+                writer.flush()
+            }
+        }
+    }
+}
+
+impl ServerChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<bool>> {
+        match self {
+            Self::Piped(child) => {
+                child.try_wait().map(|status| status.map(|s| s.success()))
+            }
+            Self::Pty(child) => {
+                child.try_wait().map(|status| status.map(|s| s.success()))
+            }
+        }
+    }
+
+    async fn kill(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Piped(child) => child.kill().await,
+            Self::Pty(child) => child.kill(),
+        }
+    }
 }
 
 static SERVER_PROCESSES: LazyLock<DashMap<String, Arc<ServerProcess>>> =
@@ -77,7 +127,7 @@ async fn start_inner(
 ) -> Result<()> {
     let dir = server_path(server_id).await?;
     let mut manifest = read_manifest(&dir).await?;
-    let launch_args = if manifest.server_type == "forge" {
+    let launch_args = if uses_pty_transport(&manifest.server_type) {
         forge_launch_args(&dir)?
     } else {
         let jar_name = resolve_jar_name(&manifest);
@@ -107,45 +157,110 @@ async fn start_inner(
             .map_err(|e| IOError::with_path(e, &eula_path))?;
     }
 
-    let mut command = Command::new(&java);
-    command.arg(format!("-Xmx{memory}M"));
-    for arg in jvm_args.unwrap_or_else(|| manifest.jvm_args.clone()) {
-        command.arg(arg);
+    let mut args = vec![format!("-Xmx{memory}M")];
+    if uses_pty_transport(&manifest.server_type) {
+        args.push("-Dorg.jline.reader.props.list-max=0".to_string());
     }
-    for arg in launch_args {
-        command.arg(arg);
-    }
-    command.current_dir(&dir);
-    // Dynamic-loader injection variables (Steam overlays, debugging tools,
-    // Dynamic-loader injection variables (Steam overlays, debugging tools,
-    // stale shell exports) lengthen every dyld failure message the JVM
-    // produces, which is exactly what trips the JNA < 5.13 macOS assertion;
-    // they have no business affecting a managed server either.
-    for variable in [
+    args.extend(jvm_args.unwrap_or_else(|| manifest.jvm_args.clone()));
+    args.extend(launch_args);
+    let removed_environment = [
         "DYLD_LIBRARY_PATH",
         "DYLD_FALLBACK_LIBRARY_PATH",
         "DYLD_FRAMEWORK_PATH",
         "DYLD_FALLBACK_FRAMEWORK_PATH",
         "DYLD_INSERT_LIBRARIES",
-    ] {
-        command.env_remove(variable);
-    }
-    command.stdout(std::process::Stdio::piped());
-    command.stderr(std::process::Stdio::piped());
-    command.stdin(std::process::Stdio::piped());
-    command.kill_on_drop(true);
+    ];
 
-    let mut child = command.spawn().map_err(|e| {
-        ErrorKind::LauncherError(format!("Failed to start server process: {e}"))
-            .as_error()
-    })?;
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-    let stdin = child.stdin.take();
+    let (mut child, input, pty_master, stdout, stderr, pty_reader) =
+        if uses_pty_transport(&manifest.server_type) {
+            let pair = native_pty_system()
+                .openpty(PtySize {
+                    rows: 12,
+                    cols: 80,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|e| {
+                    ErrorKind::LauncherError(format!(
+                        "Failed to create Forge console PTY: {e}"
+                    ))
+                    .as_error()
+                })?;
+            let reader = pair.master.try_clone_reader().map_err(|e| {
+                ErrorKind::LauncherError(format!(
+                    "Failed to capture Forge console output: {e}"
+                ))
+                .as_error()
+            })?;
+            let writer = pair.master.take_writer().map_err(|e| {
+                ErrorKind::LauncherError(format!(
+                    "Failed to capture Forge console input: {e}"
+                ))
+                .as_error()
+            })?;
+            let mut command = CommandBuilder::new(&java);
+            command.args(&args);
+            command.cwd(&dir);
+            command.env("TERM", "xterm-256color");
+            for variable in removed_environment {
+                command.env_remove(variable);
+            }
+            let child = pair.slave.spawn_command(command).map_err(|e| {
+                ErrorKind::LauncherError(format!(
+                    "Failed to start Forge server process: {e}"
+                ))
+                .as_error()
+            })?;
+            (
+                ServerChild::Pty(child),
+                ServerInput::Pty(writer),
+                Some(tokio::sync::Mutex::new(pair.master)),
+                None,
+                None,
+                Some(reader),
+            )
+        } else {
+            let mut command = Command::new(&java);
+            command.args(&args);
+            command.current_dir(&dir);
+            for variable in removed_environment {
+                command.env_remove(variable);
+            }
+            command.stdout(std::process::Stdio::piped());
+            command.stderr(std::process::Stdio::piped());
+            command.stdin(std::process::Stdio::piped());
+            command.kill_on_drop(true);
+
+            let mut child = command.spawn().map_err(|e| {
+                ErrorKind::LauncherError(format!(
+                    "Failed to start server process: {e}"
+                ))
+                .as_error()
+            })?;
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            let stdin = child.stdin.take().ok_or_else(|| {
+                ErrorKind::LauncherError(
+                    "Server stdin could not be captured".to_string(),
+                )
+                .as_error()
+            })?;
+            (
+                ServerChild::Piped(child),
+                ServerInput::Piped(stdin),
+                None,
+                stdout,
+                stderr,
+                None,
+            )
+        };
 
     manifest.last_started_at = Some(Utc::now());
     manifest.last_exit_crashed = false;
-    write_manifest(&dir, &manifest).await?;
+    if let Err(error) = write_manifest(&dir, &manifest).await {
+        let _ = child.kill().await;
+        return Err(error);
+    }
 
     clear_log_buffer(server_id);
 
@@ -200,12 +315,8 @@ async fn start_inner(
 
     let process = Arc::new(ServerProcess {
         child: tokio::sync::Mutex::new(child),
-        stdin: tokio::sync::Mutex::new(stdin.ok_or_else(|| {
-            ErrorKind::LauncherError(
-                "Server stdin could not be captured".to_string(),
-            )
-            .as_error()
-        })?),
+        input: tokio::sync::Mutex::new(input),
+        pty_master,
         stop_requested: AtomicBool::new(false),
     });
     SERVER_PROCESSES.insert(server_id.to_string(), process.clone());
@@ -215,6 +326,9 @@ async fn start_inner(
     }
     if let Some(stderr) = stderr {
         tokio::spawn(stream_server_output(server_id.to_string(), stderr));
+    }
+    if let Some(reader) = pty_reader {
+        tokio::spawn(stream_server_pty_output(server_id.to_string(), reader));
     }
     // The process pipes (above) capture JVM/installer output, but the server's
     // own log4j console output is normally written to logs/latest.log rather
@@ -237,18 +351,92 @@ pub async fn send_command(server_id: &str, command: &str) -> Result<()> {
             ErrorKind::InputError("Server is not running".to_string())
                 .as_error()
         })?;
-    let mut stdin = process.stdin.lock().await;
-    stdin
-        .write_all(format!("{command}\n").as_bytes())
+    let mut input = process.input.lock().await;
+    input
+        .write_all(&command_bytes(command))
         .await
         .map_err(|e| {
             ErrorKind::LauncherError(format!("Failed to send command: {e}"))
                 .as_error()
         })?;
-    stdin.flush().await.map_err(|e| {
+    Ok(())
+}
+
+fn uses_pty_transport(server_type: &str) -> bool {
+    server_type == "forge"
+}
+
+fn command_bytes(command: &str) -> Vec<u8> {
+    format!("{command}\n").into_bytes()
+}
+
+pub async fn send_console_input(server_id: &str, data: &str) -> Result<()> {
+    let process = SERVER_PROCESSES
+        .get(server_id)
+        .map(|entry| entry.value().clone())
+        .ok_or_else(|| {
+            ErrorKind::InputError("Server is not running".to_string())
+                .as_error()
+        })?;
+    if process.pty_master.is_none() {
+        return Err(ErrorKind::InputError(
+            "Raw console input is only available for Forge servers".to_string(),
+        )
+        .as_error());
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data)
+        .map_err(|e| {
+            ErrorKind::InputError(format!("Invalid console input: {e}"))
+                .as_error()
+        })?;
+    if bytes.len() > 64 * 1024 {
+        return Err(ErrorKind::InputError(
+            "Console input exceeds 64 KiB".to_string(),
+        )
+        .as_error());
+    }
+    let mut input = process.input.lock().await;
+    input.write_all(&bytes).await.map_err(|e| {
         ErrorKind::LauncherError(format!("Failed to send command: {e}"))
             .as_error()
     })?;
+    Ok(())
+}
+
+pub async fn resize_console(
+    server_id: &str,
+    cols: u16,
+    rows: u16,
+) -> Result<()> {
+    let process = SERVER_PROCESSES
+        .get(server_id)
+        .map(|entry| entry.value().clone())
+        .ok_or_else(|| {
+            ErrorKind::InputError("Server is not running".to_string())
+                .as_error()
+        })?;
+    let master = process.pty_master.as_ref().ok_or_else(|| {
+        ErrorKind::InputError(
+            "Console resizing is only available for Forge servers".to_string(),
+        )
+        .as_error()
+    })?;
+    master
+        .lock()
+        .await
+        .resize(PtySize {
+            rows: rows.clamp(4, MAX_CONSOLE_ROWS),
+            cols: cols.clamp(20, 500),
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| {
+            ErrorKind::LauncherError(format!(
+                "Failed to resize Forge console: {e}"
+            ))
+            .as_error()
+        })?;
     Ok(())
 }
 
@@ -261,9 +449,8 @@ pub async fn stop(server_id: &str) -> Result<()> {
                 .as_error()
         })?;
     process.stop_requested.store(true, Ordering::SeqCst);
-    let mut stdin = process.stdin.lock().await;
-    let _ = stdin.write_all(b"stop\n").await;
-    let _ = stdin.flush().await;
+    let mut input = process.input.lock().await;
+    let _ = input.write_all(b"stop\n").await;
 
     let watchdog = process.clone();
     let server_id = server_id.to_string();
@@ -303,7 +490,7 @@ async fn monitor_server_process(
         let exit_status = {
             let mut child = process.child.lock().await;
             match child.try_wait() {
-                Ok(Some(status)) => Some(status),
+                Ok(Some(success)) => Some(success),
                 Ok(None) => continue,
                 Err(_) => None,
             }
@@ -313,7 +500,7 @@ async fn monitor_server_process(
         let stop_requested = process.stop_requested.load(Ordering::SeqCst);
         let eula_accepted = read_eula_accepted(&dir).await;
         let crashed = exit_status
-            .map(|status| !status.success() && !stop_requested && eula_accepted)
+            .map(|success| !success && !stop_requested && eula_accepted)
             .unwrap_or(false);
 
         // Classify self-exits from the tail of the console output so the UI
@@ -410,4 +597,45 @@ async fn log_server_step(server_id: &str, message: &str) {
     emit_server(server_id, ServerPayloadType::Log { line })
         .await
         .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn selects_pty_only_for_forge() {
+        assert!(uses_pty_transport("forge"));
+        assert!(!uses_pty_transport("vanilla"));
+        assert!(!uses_pty_transport("fabric"));
+        assert!(!uses_pty_transport("neoforge"));
+    }
+
+    #[test]
+    fn whole_line_commands_end_with_one_newline() {
+        assert_eq!(command_bytes("say hello"), b"say hello\n");
+    }
+
+    #[tokio::test]
+    async fn pty_input_preserves_raw_bytes() {
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut input =
+            ServerInput::Pty(Box::new(SharedWriter(captured.clone())));
+        input.write_all(b"\x1b[D\t\x7f").await.unwrap();
+        assert_eq!(*captured.lock().unwrap(), b"\x1b[D\t\x7f");
+    }
 }

--- a/packages/app-lib/src/api/servers/logs.rs
+++ b/packages/app-lib/src/api/servers/logs.rs
@@ -326,12 +326,12 @@ mod tests {
     fn splits_pty_output_without_losing_partial_or_raw_bytes() {
         let mut pending = Vec::new();
         assert_eq!(
-            take_complete_pty_lines(&mut pending, b"first\r\nsec"),
+            take_complete_pty_lines(&mut pending, b"first\r\nsecond"),
             vec![b"first\r\n".to_vec()]
         );
-        assert_eq!(pending, b"sec");
+        assert_eq!(pending, b"second");
         assert_eq!(
-            take_complete_pty_lines(&mut pending, b"ond\nthird\n"),
+            take_complete_pty_lines(&mut pending, b"\nthird\n"),
             vec![b"second\n".to_vec(), b"third\n".to_vec()]
         );
         assert!(pending.is_empty());

--- a/packages/app-lib/src/api/servers/logs.rs
+++ b/packages/app-lib/src/api/servers/logs.rs
@@ -1,5 +1,6 @@
 //! Console output buffering and streaming for servers.
 
+use base64::Engine;
 use std::path::PathBuf;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
@@ -9,6 +10,8 @@ use crate::api::servers::lifecycle::is_server_running;
 use crate::event::emit::emit_server;
 use crate::event::{ExitReason, ServerPayloadType};
 use crate::state::{clear_log_buffer, push_log_line};
+
+const MAX_PTY_LINE_BYTES: usize = 256 * 1024;
 
 pub async fn get_log_buffer(server_id: &str) -> Result<Vec<String>> {
     Ok(crate::state::get_log_buffer(server_id))
@@ -31,48 +34,120 @@ pub(super) async fn stream_server_output(
         match buf_reader.read_line(&mut line).await {
             Ok(0) | Err(_) => break,
             Ok(_) => {
-                let trimmed = line.trim_end_matches(['\r', '\n']);
-                let cleaned = strip_ansi(trimmed);
-                if cleaned.is_empty() {
-                    continue;
-                }
-                // The server also echoes its log4j output (timestamped lines) to
-                // stdout/stderr in a console format that duplicates every line
-                // already delivered losslessly by `tail_server_log_file` from
-                // `logs/latest.log`. Drop those here so the file tail stays the
-                // single source of truth; only non-logged process output
-                // (bootstrap, patcher progress, JVM warnings) is streamed.
-                if is_timestamped_log_line(&cleaned) {
-                    continue;
-                }
-                // The server echoes entered commands to its own log (e.g.
-                // "> time set 0"), which the file tailer already streams. Skip
-                // those here so they are not duplicated by the stdout pipe.
-                if cleaned.starts_with("> ") {
-                    continue;
-                }
-                push_log_line(&server_id, cleaned.clone());
-                emit_server(
+                process_server_output_line(
                     &server_id,
-                    ServerPayloadType::Log { line: cleaned },
+                    line.trim_end_matches(['\r', '\n']),
+                    &mut jna_hint_emitted,
                 )
-                .await
-                .ok();
-                if !jna_hint_emitted && is_jna_macos_assertion(trimmed) {
-                    jna_hint_emitted = true;
-                    for hint in JNA_CRASH_HINT_LINES {
-                        push_log_line(&server_id, hint.to_string());
-                        emit_server(
-                            &server_id,
-                            ServerPayloadType::Log {
-                                line: hint.to_string(),
-                            },
-                        )
-                        .await
-                        .ok();
+                .await;
+            }
+        }
+    }
+}
+
+pub(super) async fn stream_server_pty_output(
+    server_id: String,
+    mut reader: Box<dyn std::io::Read + Send>,
+) {
+    let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+    tokio::task::spawn_blocking(move || {
+        let mut buffer = vec![0_u8; 8192];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    if sender.blocking_send(buffer[..read].to_vec()).is_err() {
+                        break;
                     }
                 }
             }
+        }
+    });
+
+    let mut pending_line = Vec::new();
+    let mut jna_hint_emitted = false;
+    while let Some(bytes) = receiver.recv().await {
+        emit_server(
+            &server_id,
+            ServerPayloadType::ConsoleOutput {
+                data: base64::engine::general_purpose::STANDARD.encode(&bytes),
+            },
+        )
+        .await
+        .ok();
+
+        for line in take_complete_pty_lines(&mut pending_line, &bytes) {
+            let text = String::from_utf8_lossy(&line);
+            process_server_output_line(
+                &server_id,
+                text.trim_end_matches(['\r', '\n']),
+                &mut jna_hint_emitted,
+            )
+            .await;
+        }
+    }
+    if !pending_line.is_empty() {
+        process_server_output_line(
+            &server_id,
+            &String::from_utf8_lossy(&pending_line),
+            &mut jna_hint_emitted,
+        )
+        .await;
+    }
+}
+
+fn take_complete_pty_lines(
+    pending: &mut Vec<u8>,
+    bytes: &[u8],
+) -> Vec<Vec<u8>> {
+    pending.extend_from_slice(bytes);
+    let Some(last_newline) = pending.iter().rposition(|byte| *byte == b'\n')
+    else {
+        if pending.len() > MAX_PTY_LINE_BYTES {
+            pending.clear();
+        }
+        return Vec::new();
+    };
+
+    let remainder = pending.split_off(last_newline + 1);
+    let completed = std::mem::replace(pending, remainder);
+    let mut lines = Vec::new();
+    for line in completed.split_inclusive(|byte| *byte == b'\n') {
+        if line.len() <= MAX_PTY_LINE_BYTES {
+            lines.push(line.to_vec());
+        }
+    }
+    lines
+}
+
+async fn process_server_output_line(
+    server_id: &str,
+    raw_line: &str,
+    jna_hint_emitted: &mut bool,
+) {
+    let cleaned = strip_ansi(raw_line);
+    if cleaned.is_empty()
+        || is_timestamped_log_line(&cleaned)
+        || cleaned.starts_with("> ")
+    {
+        return;
+    }
+    push_log_line(server_id, cleaned.clone());
+    emit_server(server_id, ServerPayloadType::Log { line: cleaned })
+        .await
+        .ok();
+    if !*jna_hint_emitted && is_jna_macos_assertion(raw_line) {
+        *jna_hint_emitted = true;
+        for hint in JNA_CRASH_HINT_LINES {
+            push_log_line(server_id, hint.to_string());
+            emit_server(
+                server_id,
+                ServerPayloadType::Log {
+                    line: hint.to_string(),
+                },
+            )
+            .await
+            .ok();
         }
     }
 }
@@ -245,6 +320,32 @@ mod tests {
         assert_eq!(strip_ansi("\u{1b}]0;Server console\u{1b}\\done"), "done");
         assert_eq!(strip_ansi("plain text stays"), "plain text stays");
         assert_eq!(strip_ansi("h\u{e9}llo \u{1b}[31mred"), "h\u{e9}llo red");
+    }
+
+    #[test]
+    fn splits_pty_output_without_losing_partial_or_raw_bytes() {
+        let mut pending = Vec::new();
+        assert_eq!(
+            take_complete_pty_lines(&mut pending, b"first\r\nsec"),
+            vec![b"first\r\n".to_vec()]
+        );
+        assert_eq!(pending, b"sec");
+        assert_eq!(
+            take_complete_pty_lines(&mut pending, b"ond\nthird\n"),
+            vec![b"second\n".to_vec(), b"third\n".to_vec()]
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn bounds_unterminated_pty_output() {
+        let mut pending = vec![b'x'; MAX_PTY_LINE_BYTES];
+        assert!(take_complete_pty_lines(&mut pending, b"x").is_empty());
+        assert!(pending.is_empty());
+
+        let oversized = vec![b'x'; MAX_PTY_LINE_BYTES + 1];
+        assert!(take_complete_pty_lines(&mut pending, &oversized).is_empty());
+        assert!(pending.is_empty());
     }
 
     #[test]

--- a/packages/app-lib/src/event/mod.rs
+++ b/packages/app-lib/src/event/mod.rs
@@ -306,6 +306,9 @@ pub enum ServerPayloadType {
     Log {
         line: String,
     },
+    ConsoleOutput {
+        data: String,
+    },
     DownloadProgress {
         downloaded: u64,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/ui/src/layouts/shared/console/components/JLineCommandInput.vue
+++ b/packages/ui/src/layouts/shared/console/components/JLineCommandInput.vue
@@ -148,6 +148,7 @@ const pointerSelecting = ref(false)
 let terminal: Terminal | null = null
 let resizeObserver: ResizeObserver | null = null
 let pendingWrites: Uint8Array[] = []
+let inputWriteQueue = Promise.resolve()
 const encoder = new TextEncoder()
 const TERMINAL_ROWS = 12
 const INITIAL_CANDIDATE_TERMINAL_ROWS = 512
@@ -523,12 +524,14 @@ function handleCompositionEnd(event: CompositionEvent) {
 	}
 }
 
-async function sendText(text: string) {
-	try {
-		await props.sendInput(encoder.encode(text))
-	} catch {
-		// A stop can race the final keystroke; the next server start remounts the input.
-	}
+function sendText(text: string) {
+	const data = encoder.encode(text)
+	inputWriteQueue = inputWriteQueue
+		.then(() => props.sendInput(data))
+		.catch(() => {
+			// A stop can race the final keystroke; keep the queue usable for the next write.
+		})
+	return inputWriteQueue
 }
 
 function selectCandidate(target: JLineCandidate) {

--- a/packages/ui/src/layouts/shared/console/components/JLineCommandInput.vue
+++ b/packages/ui/src/layouts/shared/console/components/JLineCommandInput.vue
@@ -1,0 +1,678 @@
+<template>
+	<div ref="root" class="relative w-full font-mono text-base">
+		<StyledInput
+			v-if="!enhanced"
+			v-model="fallbackValue"
+			:icon="TerminalSquareIcon"
+			:placeholder="placeholder"
+			:disabled="disabled"
+			wrapper-class="w-full"
+			input-class="!h-9"
+			autocomplete="off"
+			:spellcheck="false"
+			@keydown.enter="submitFallback"
+		/>
+		<div
+			v-else
+			class="relative min-h-9 overflow-hidden rounded-xl bg-surface-4 pl-10 pr-3 ring-brand-shadow focus-within:ring-4"
+		>
+			<TerminalSquareIcon
+				class="pointer-events-none absolute left-3 top-2 h-5 w-5 text-secondary"
+				aria-hidden="true"
+			/>
+			<div
+				class="pointer-events-none min-h-9 whitespace-pre-wrap break-all py-2 font-medium leading-5 text-primary"
+				aria-hidden="true"
+			>
+				<span v-for="(segment, index) in styledInput" :key="index" :style="segment.style">{{
+					segment.text
+				}}</span>
+			</div>
+			<textarea
+				ref="input"
+				:value="prompt?.value ?? ''"
+				:placeholder="placeholder"
+				:disabled="disabled"
+				rows="1"
+				class="absolute inset-0 h-full min-h-9 w-full resize-none overflow-hidden border-0 bg-transparent py-2 pl-10 pr-3 font-mono font-medium leading-5 text-transparent caret-[var(--color-text-default)] outline-none placeholder:text-secondary"
+				autocomplete="off"
+				autocorrect="off"
+				autocapitalize="off"
+				:spellcheck="false"
+				@keydown="handleKeydown"
+				@click="syncPointerCursor"
+				@pointerdown="pointerSelecting = true"
+				@beforeinput="handleBeforeInput"
+				@paste="handlePaste"
+				@compositionstart="handleCompositionStart"
+				@compositionend="handleCompositionEnd"
+			/>
+		</div>
+		<div
+			v-if="candidates.length"
+			class="absolute bottom-full left-0 z-20 mb-2 flex w-full min-w-64 max-w-lg flex-col overflow-hidden rounded-lg border border-solid border-surface-4 bg-surface-3 shadow-lg"
+		>
+			<div class="border-0 border-b border-solid border-surface-4 p-2">
+				<StyledInput
+					v-model="candidateSearchQuery"
+					:icon="SearchIcon"
+					:placeholder="formatMessage(messages.searchCompletions)"
+					wrapper-class="w-full"
+					input-class="!h-9 font-sans"
+					autocomplete="off"
+					:spellcheck="false"
+					clearable
+					@keydown.down.prevent="moveCandidateFocus(1)"
+					@keydown.up.prevent="moveCandidateFocus(-1)"
+					@keydown.tab.prevent="moveCandidateFocus($event.shiftKey ? -1 : 1)"
+					@keydown.enter.prevent="selectFocusedCandidate"
+					@keydown.escape.prevent="closeCandidateSearch"
+				/>
+			</div>
+			<div
+				v-if="filteredCandidates.length"
+				role="listbox"
+				class="flex max-h-56 flex-col gap-1 overflow-y-auto overscroll-contain p-2"
+			>
+				<button
+					v-for="(candidate, index) in filteredCandidates"
+					:key="`${candidate.row}:${candidate.column}:${candidate.text}`"
+					type="button"
+					role="option"
+					:aria-selected="index === focusedCandidateIndex"
+					:data-completion-focused="index === focusedCandidateIndex"
+					class="min-h-9 min-w-0 shrink-0 rounded-md border-0 px-3 py-2 text-left font-mono text-sm transition-colors hover:bg-surface-4"
+					:class="
+						index === focusedCandidateIndex
+							? 'bg-surface-4 text-contrast'
+							: 'bg-transparent text-primary'
+					"
+					:style="candidateStyleToCss(candidate, index === focusedCandidateIndex)"
+					@mouseenter="focusedCandidateIndex = index"
+					@mousedown.prevent
+					@click="selectCandidate(candidate)"
+				>
+					<span class="block truncate">{{ candidate.text }}</span>
+				</button>
+			</div>
+			<div v-else class="px-3 py-4 text-center font-sans text-sm text-secondary">
+				{{ formatMessage(messages.noCompletions) }}
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { SearchIcon, TerminalSquareIcon } from '@modrinth/assets'
+import type { IBufferCell, Terminal } from '@xterm/xterm'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import StyledInput from '#ui/components/base/StyledInput.vue'
+import { defineMessages, useVIntl } from '#ui/composables/i18n'
+
+import {
+	applyJLineCandidate,
+	createJLineLineReplacementSequence,
+	extractJLinePrompt,
+	jlineKeySequence,
+	type JLineCandidate,
+	type JLineCell,
+	type JLineCellStyle,
+	type JLineRow,
+	parseJLineCandidateConfirmation,
+	parseJLineCandidates,
+	replaceJLineSelection,
+} from '../jline'
+
+const props = defineProps<{
+	disabled?: boolean
+	placeholder?: string
+	sendInput: (data: Uint8Array) => void | Promise<void>
+	sendCommand: (command: string) => void | Promise<void>
+	resizeConsole: (cols: number, rows: number) => void | Promise<void>
+}>()
+
+const root = ref<HTMLElement | null>(null)
+const input = ref<HTMLTextAreaElement | null>(null)
+const fallbackValue = ref('')
+const prompt = ref<ReturnType<typeof extractJLinePrompt>>(null)
+const shellPrompt = ref<ReturnType<typeof extractJLinePrompt>>(null)
+const completionPrompt = ref<ReturnType<typeof extractJLinePrompt>>(null)
+const candidates = ref<JLineCandidate[]>([])
+const candidateSearchQuery = ref('')
+const focusedCandidateIndex = ref(-1)
+const enhanced = ref(false)
+const composing = ref(false)
+const menuRequested = ref(false)
+const pointerSelecting = ref(false)
+let terminal: Terminal | null = null
+let resizeObserver: ResizeObserver | null = null
+let pendingWrites: Uint8Array[] = []
+const encoder = new TextEncoder()
+const TERMINAL_ROWS = 12
+const INITIAL_CANDIDATE_TERMINAL_ROWS = 512
+const MAX_CANDIDATE_TERMINAL_ROWS = 8192
+let terminalRows = TERMINAL_ROWS
+let candidateConfirmationPending = false
+let suppressCompositionEnter = false
+let compositionEnterTimer: ReturnType<typeof setTimeout> | null = null
+let compositionSelection: { start: number; end: number } | null = null
+
+const { formatMessage } = useVIntl()
+const messages = defineMessages({
+	searchCompletions: {
+		id: 'console.command-completions.search',
+		defaultMessage: 'Search command completions',
+	},
+	noCompletions: {
+		id: 'console.command-completions.no-results',
+		defaultMessage: 'No matching completions',
+	},
+})
+
+const filteredCandidates = computed(() => {
+	const query = candidateSearchQuery.value.trim().toLowerCase()
+	if (!query) return candidates.value
+	return candidates.value.filter((candidate) => candidate.text.toLowerCase().includes(query))
+})
+
+watch(candidates, (list) => {
+	if (list.length === 0) {
+		candidateSearchQuery.value = ''
+		focusedCandidateIndex.value = -1
+		return
+	}
+	focusedCandidateIndex.value = filteredCandidates.value.length ? 0 : -1
+})
+
+watch(candidateSearchQuery, () => {
+	focusedCandidateIndex.value = filteredCandidates.value.length > 0 ? 0 : -1
+})
+
+const styledInput = computed(() => {
+	if (!prompt.value) return []
+	const cells = prompt.value.rows.flatMap((row) => row.cells).slice(2)
+	const segments: Array<{ text: string; style: Record<string, string> }> = []
+	let remaining = prompt.value.value.length
+	for (const cell of cells) {
+		if (remaining <= 0 || !cell.text) continue
+		const text = cell.text.slice(0, remaining)
+		remaining -= text.length
+		const style = styleToCss(cell.style)
+		const previous = segments.at(-1)
+		if (previous && JSON.stringify(previous.style) === JSON.stringify(style)) {
+			previous.text += text
+		} else {
+			segments.push({ text, style })
+		}
+	}
+	return segments
+})
+
+onMounted(async () => {
+	window.addEventListener('pointerup', finishPointerSelection)
+	window.addEventListener('pointercancel', finishPointerSelection)
+	const { Terminal } = await import('@xterm/xterm')
+	terminal = new Terminal({
+		cols: 80,
+		rows: terminalRows,
+		scrollback: 0,
+		convertEol: false,
+		allowProposedApi: true,
+	})
+	for (const bytes of pendingWrites) terminal.write(bytes, updateFromTerminal)
+	pendingWrites = []
+	resizeObserver = new ResizeObserver(resize)
+	if (root.value) resizeObserver.observe(root.value)
+	resize()
+	await sendText('\x0c')
+})
+
+onBeforeUnmount(() => {
+	if (compositionEnterTimer) window.clearTimeout(compositionEnterTimer)
+	window.removeEventListener('pointerup', finishPointerSelection)
+	window.removeEventListener('pointercancel', finishPointerSelection)
+	resizeObserver?.disconnect()
+	terminal?.dispose()
+})
+
+function write(data: Uint8Array) {
+	if (!terminal) {
+		pendingWrites.push(data)
+		return
+	}
+	terminal.write(data, updateFromTerminal)
+}
+
+function resize() {
+	if (!root.value || !terminal) return
+	const fontSize = Number.parseFloat(getComputedStyle(root.value).fontSize) || 16
+	const cellWidth = fontSize * 0.61
+	const cols = Math.max(20, Math.floor((root.value.clientWidth - 52) / cellWidth))
+	if (terminal.cols !== cols || terminal.rows !== terminalRows) {
+		terminal.resize(cols, terminalRows)
+	}
+	void Promise.resolve(props.resizeConsole(cols, terminalRows)).catch(() => {})
+}
+
+function updateFromTerminal() {
+	if (!terminal) return
+	const restoreFocus = document.activeElement === input.value
+	const buffer = terminal.buffer.active
+	const cursorRow = buffer.baseY + buffer.cursorY
+	const rows: JLineRow[] = []
+	for (let index = buffer.viewportY; index < buffer.viewportY + terminal.rows; index++) {
+		const line = buffer.getLine(index)
+		if (!line) continue
+		const cells: JLineCell[] = []
+		const reusable = buffer.getNullCell()
+		for (let column = 0; column < terminal.cols; column++) {
+			const cell = line.getCell(column, reusable)
+			if (!cell) continue
+			cells.push({
+				text: cell.getWidth() === 0 ? '' : cell.getChars() || ' ',
+				width: cell.getWidth(),
+				style: cellStyle(cell),
+			})
+		}
+		rows.push({ index, wrapped: line.isWrapped, cells })
+	}
+	const nextPrompt = extractJLinePrompt(rows, cursorRow, buffer.cursorX)
+	if (nextPrompt) shellPrompt.value = nextPrompt
+	prompt.value = menuRequested.value && completionPrompt.value ? completionPrompt.value : nextPrompt
+	if (nextPrompt) enhanced.value = true
+	if (menuRequested.value) {
+		const confirmation = parseJLineCandidateConfirmation(rows)
+		if (confirmation && !candidateConfirmationPending) {
+			candidateConfirmationPending = true
+			void confirmCandidateMenu(confirmation.lineCount)
+			return
+		}
+		const parsedCandidates = parseJLineCandidates(rows, cursorRow)
+		if (parsedCandidates.length > 0) {
+			candidateConfirmationPending = false
+			if (!sameCandidates(candidates.value, parsedCandidates)) candidates.value = parsedCandidates
+		} else if (parsedCandidates.length === 0 && candidates.value.length === 0) {
+			if (nextPrompt) {
+				completionPrompt.value = nextPrompt
+				prompt.value = nextPrompt
+			}
+		}
+	}
+	void nextTick(() => {
+		if (!input.value || !prompt.value || composing.value) return
+		if (pointerSelecting.value || hasTextSelection()) return
+		if (restoreFocus) input.value.focus()
+		const cursor = Math.min(prompt.value.cursor, prompt.value.value.length)
+		input.value.setSelectionRange(cursor, cursor)
+	})
+}
+
+function cellStyle(cell: IBufferCell): JLineCellStyle {
+	return {
+		foreground: resolveColor(cell, 'foreground'),
+		background: resolveColor(cell, 'background'),
+		bold: Boolean(cell.isBold()),
+		italic: Boolean(cell.isItalic()),
+		underline: Boolean(cell.isUnderline()),
+		dim: Boolean(cell.isDim()),
+		inverse: Boolean(cell.isInverse()),
+	}
+}
+
+function resolveColor(cell: IBufferCell, kind: 'foreground' | 'background') {
+	const rgb = kind === 'foreground' ? cell.isFgRGB() : cell.isBgRGB()
+	const palette = kind === 'foreground' ? cell.isFgPalette() : cell.isBgPalette()
+	const color = kind === 'foreground' ? cell.getFgColor() : cell.getBgColor()
+	if (rgb) return `#${color.toString(16).padStart(6, '0')}`
+	if (!palette) return undefined
+	return ansiPaletteColor(color)
+}
+
+function styleToCss(style: JLineCellStyle): Record<string, string> {
+	let foreground = style.foreground ?? 'var(--color-text-default)'
+	let background = style.background ?? 'var(--surface-4)'
+	if (style.inverse) [foreground, background] = [background, foreground]
+	return {
+		...(foreground ? { color: foreground } : {}),
+		...(background ? { backgroundColor: background } : {}),
+		...(style.bold ? { fontWeight: '700' } : {}),
+		...(style.italic ? { fontStyle: 'italic' } : {}),
+		...(style.underline ? { textDecoration: 'underline' } : {}),
+		...(style.dim ? { opacity: '0.65' } : {}),
+	}
+}
+
+function candidateStyleToCss(candidate: JLineCandidate, focused: boolean): Record<string, string> {
+	const style = candidate.style
+	return {
+		...(!focused && style.foreground ? { color: style.foreground } : {}),
+		...(style.bold ? { fontWeight: '700' } : {}),
+		...(style.italic ? { fontStyle: 'italic' } : {}),
+		...(style.underline ? { textDecoration: 'underline' } : {}),
+		...(style.dim ? { opacity: '0.65' } : {}),
+	}
+}
+
+function sameCandidates(current: JLineCandidate[], next: JLineCandidate[]) {
+	return (
+		current.length === next.length &&
+		current.every(
+			(candidate, index) =>
+				candidate.text === next[index]?.text &&
+				candidate.row === next[index]?.row &&
+				candidate.column === next[index]?.column,
+		)
+	)
+}
+
+function ansiPaletteColor(index: number): string {
+	if (ANSI_COLORS[index]) return ANSI_COLORS[index]
+	if (index >= 16 && index <= 231) {
+		const value = index - 16
+		const red = Math.floor(value / 36)
+		const green = Math.floor((value % 36) / 6)
+		const blue = value % 6
+		const channel = (part: number) => (part === 0 ? 0 : 55 + part * 40)
+		return `rgb(${channel(red)}, ${channel(green)}, ${channel(blue)})`
+	}
+	const gray = 8 + Math.max(0, Math.min(23, index - 232)) * 10
+	return `rgb(${gray}, ${gray}, ${gray})`
+}
+
+function handleKeydown(event: KeyboardEvent) {
+	if (composing.value || event.isComposing || event.keyCode === 229) return
+	if (event.key === 'Enter' && suppressCompositionEnter) {
+		event.preventDefault()
+		suppressCompositionEnter = false
+		if (compositionEnterTimer) window.clearTimeout(compositionEnterTimer)
+		return
+	}
+	suppressCompositionEnter = false
+	const selection = inputSelection()
+	if (
+		selection &&
+		selection.start !== selection.end &&
+		(event.key === 'Backspace' || event.key === 'Delete')
+	) {
+		event.preventDefault()
+		replaceSelection('', selection.start, selection.end)
+		return
+	}
+	if (candidates.value.length > 0) {
+		if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+			event.preventDefault()
+			moveCandidateFocus(event.key === 'ArrowDown' ? 1 : -1)
+			return
+		}
+		if (event.key === 'Tab') {
+			event.preventDefault()
+			moveCandidateFocus(event.shiftKey ? -1 : 1)
+			return
+		}
+		if (event.key === ' ' || event.key === 'Enter') {
+			event.preventDefault()
+			selectFocusedCandidate()
+			return
+		}
+	}
+	if (event.key === 'Tab' && menuRequested.value && candidates.value.length > 0) {
+		event.preventDefault()
+		return
+	}
+	const sequence = keySequence(event.key)
+	if (!sequence) return
+	event.preventDefault()
+	if (menuRequested.value) {
+		if (event.key === 'Tab') {
+			void sendText(sequence)
+			return
+		}
+		continueFromCompletion(event.key === 'Escape' ? '' : sequence)
+		return
+	}
+	if (event.key === 'Tab' && !menuRequested.value) {
+		completionPrompt.value = prompt.value
+		menuRequested.value = true
+		void openCandidateMenu(sequence)
+		return
+	}
+	clearCompletion()
+	void sendText(sequence)
+}
+
+function syncPointerCursor() {
+	if (!input.value || !prompt.value) return
+	if (hasTextSelection()) return
+	const target = input.value.selectionStart ?? prompt.value.cursor
+	const distance = target - prompt.value.cursor
+	if (distance === 0) return
+	const key = distance < 0 ? 'ArrowLeft' : 'ArrowRight'
+	const sequence = keySequence(key)
+	if (sequence) void sendText(sequence.repeat(Math.abs(distance)))
+}
+
+function keySequence(key: string) {
+	return jlineKeySequence(key, terminal?.modes.applicationCursorKeysMode ?? false)
+}
+
+function handleBeforeInput(event: InputEvent) {
+	if (composing.value || event.inputType === 'insertFromPaste') return
+	const selection = inputSelection()
+	if (event.inputType.startsWith('delete')) {
+		if (!selection) return
+		let { start, end } = selection
+		if (start === end && event.inputType.includes('Backward') && start > 0) start--
+		if (
+			start === end &&
+			event.inputType.includes('Forward') &&
+			end < (prompt.value?.value.length ?? 0)
+		) {
+			end++
+		}
+		if (start === end) return
+		event.preventDefault()
+		replaceSelection('', start, end)
+		return
+	}
+	if (!event.inputType.startsWith('insert') || !event.data) return
+	event.preventDefault()
+	if (selection && (selection.start !== selection.end || menuRequested.value)) {
+		replaceSelection(event.data, selection.start, selection.end)
+		return
+	}
+	clearCompletion()
+	void sendText(event.data)
+}
+
+function handlePaste(event: ClipboardEvent) {
+	const text = event.clipboardData?.getData('text')
+	if (!text) return
+	event.preventDefault()
+	const selection = inputSelection()
+	if (selection && (selection.start !== selection.end || menuRequested.value)) {
+		replaceSelection(text, selection.start, selection.end)
+		return
+	}
+	clearCompletion()
+	void sendText(text)
+}
+
+function handleCompositionStart() {
+	composing.value = true
+	compositionSelection = inputSelection()
+	suppressCompositionEnter = false
+	if (compositionEnterTimer) window.clearTimeout(compositionEnterTimer)
+}
+
+function handleCompositionEnd(event: CompositionEvent) {
+	composing.value = false
+	suppressCompositionEnter = true
+	if (compositionEnterTimer) window.clearTimeout(compositionEnterTimer)
+	compositionEnterTimer = window.setTimeout(() => {
+		suppressCompositionEnter = false
+		compositionEnterTimer = null
+	}, 100)
+	const selection = compositionSelection
+	compositionSelection = null
+	if (event.data && selection && (selection.start !== selection.end || menuRequested.value)) {
+		replaceSelection(event.data, selection.start, selection.end)
+	} else {
+		clearCompletion()
+		if (event.data) void sendText(event.data)
+	}
+}
+
+async function sendText(text: string) {
+	try {
+		await props.sendInput(encoder.encode(text))
+	} catch {
+		// A stop can race the final keystroke; the next server start remounts the input.
+	}
+}
+
+function selectCandidate(target: JLineCandidate) {
+	const base = completionPrompt.value ?? prompt.value
+	const current = shellPrompt.value ?? prompt.value
+	if (!base || !current) return
+	const next = applyJLineCandidate(base, target.text)
+	clearCompletion()
+	void sendText(
+		createJLineLineReplacementSequence(
+			current.value,
+			next,
+			terminal?.modes.applicationCursorKeysMode ?? false,
+		),
+	)
+	input.value?.focus()
+}
+
+function selectFocusedCandidate() {
+	const candidate = filteredCandidates.value[focusedCandidateIndex.value]
+	if (candidate) void selectCandidate(candidate)
+}
+
+function moveCandidateFocus(delta: number) {
+	const count = filteredCandidates.value.length
+	if (count === 0) return
+	focusedCandidateIndex.value = (focusedCandidateIndex.value + delta + count) % count
+	void nextTick(() => {
+		root.value
+			?.querySelector('[data-completion-focused="true"]')
+			?.scrollIntoView({ block: 'nearest' })
+	})
+}
+
+function closeCandidateSearch() {
+	candidateSearchQuery.value = ''
+	input.value?.focus()
+}
+
+function replaceSelection(replacement: string, start: number, end: number) {
+	const displayed = prompt.value
+	const current = shellPrompt.value ?? displayed
+	if (!displayed || !current) return
+	const next = replaceJLineSelection(displayed, start, end, replacement)
+	clearCompletion()
+	void sendText(
+		createJLineLineReplacementSequence(
+			current.value,
+			next,
+			terminal?.modes.applicationCursorKeysMode ?? false,
+		),
+	)
+}
+
+function continueFromCompletion(sequence: string) {
+	const base = completionPrompt.value ?? prompt.value
+	const current = shellPrompt.value ?? prompt.value
+	if (!base || !current) return
+	const next = { value: base.value, cursor: base.cursor }
+	clearCompletion()
+	void sendText(
+		`${createJLineLineReplacementSequence(current.value, next, terminal?.modes.applicationCursorKeysMode ?? false)}${sequence}`,
+	)
+}
+
+async function openCandidateMenu(sequence: string) {
+	if (terminal) {
+		terminalRows = INITIAL_CANDIDATE_TERMINAL_ROWS
+		if (terminal.rows !== terminalRows) terminal.resize(terminal.cols, terminalRows)
+		await Promise.resolve(props.resizeConsole(terminal.cols, terminalRows)).catch(() => {})
+	}
+	await sendText(sequence)
+}
+
+async function confirmCandidateMenu(lineCount: number) {
+	if (!terminal || lineCount <= 0 || lineCount + 4 > MAX_CANDIDATE_TERMINAL_ROWS) {
+		await sendText('n')
+		clearCompletion()
+		return
+	}
+	terminalRows = Math.max(INITIAL_CANDIDATE_TERMINAL_ROWS, lineCount + 4)
+	if (terminal.rows !== terminalRows) terminal.resize(terminal.cols, terminalRows)
+	await Promise.resolve(props.resizeConsole(terminal.cols, terminalRows)).catch(() => {})
+	await sendText('y')
+}
+
+function clearCompletion() {
+	candidateConfirmationPending = false
+	menuRequested.value = false
+	completionPrompt.value = null
+	candidates.value = []
+	candidateSearchQuery.value = ''
+	resetTerminalRows()
+}
+
+function resetTerminalRows() {
+	if (!terminal || terminalRows === TERMINAL_ROWS) return
+	terminalRows = TERMINAL_ROWS
+	if (terminal.rows !== terminalRows) terminal.resize(terminal.cols, terminalRows)
+	void Promise.resolve(props.resizeConsole(terminal.cols, terminalRows)).catch(() => {})
+}
+
+function inputSelection() {
+	if (!input.value) return null
+	return {
+		start: input.value.selectionStart ?? 0,
+		end: input.value.selectionEnd ?? 0,
+	}
+}
+
+function hasTextSelection() {
+	const selection = inputSelection()
+	return Boolean(selection && selection.start !== selection.end)
+}
+
+function finishPointerSelection() {
+	pointerSelecting.value = false
+}
+
+function submitFallback() {
+	const command = fallbackValue.value.trim()
+	if (!command || props.disabled) return
+	void Promise.resolve(props.sendCommand(command)).catch(() => {})
+	fallbackValue.value = ''
+}
+
+defineExpose({ write })
+
+const ANSI_COLORS = [
+	'#1d1f23',
+	'#ff496e',
+	'#1bd96a',
+	'#ffa347',
+	'#4a9eff',
+	'#bc3fbc',
+	'#96a2b0',
+	'#b0bac5',
+	'#42444a',
+	'#ff496e',
+	'#1bd96a',
+	'#ffa347',
+	'#4a9eff',
+	'#bc3fbc',
+	'#96a2b0',
+	'#ffffff',
+]
+</script>

--- a/packages/ui/src/layouts/shared/console/index.ts
+++ b/packages/ui/src/layouts/shared/console/index.ts
@@ -1,3 +1,5 @@
+export { default as JLineCommandInput } from './components/JLineCommandInput.vue'
+export * from './jline'
 export { default as ConsolePageLayout } from './layout.vue'
 export * from './providers'
 export * from './types'

--- a/packages/ui/src/layouts/shared/console/jline.test.ts
+++ b/packages/ui/src/layouts/shared/console/jline.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+	applyJLineCandidate,
+	createJLineCandidateInsertion,
+	createJLineLineReplacementSequence,
+	extractJLinePrompt,
+	jlineKeySequence,
+	JLINE_KEY_SEQUENCES,
+	type JLineRow,
+	parseJLineCandidateConfirmation,
+	parseJLineCandidates,
+	replaceJLineSelection,
+} from './jline.ts'
+
+const row = (index: number, text: string, wrapped = false, inverse = ''): JLineRow => ({
+	index,
+	wrapped,
+	cells: [...text].map((character) => ({
+		text: character,
+		width: 1,
+		style: { inverse: inverse.includes(character) },
+	})),
+})
+
+test('extracts wrapped prompt input and cursor position', () => {
+	const rows = [row(2, '> say a very '), row(3, 'long command', true)]
+	assert.deepEqual(extractJLinePrompt(rows, 3, 4), {
+		value: 'say a very long command',
+		cursor: 15,
+		rows,
+	})
+})
+
+test('rejects a line that is not a JLine prompt', () => {
+	assert.equal(extractJLinePrompt([row(1, 'server output')], 1, 3), null)
+})
+
+test('preserves spaces entered at the end of the command', () => {
+	const rows = [row(1, '> say     ')]
+	assert.equal(extractJLinePrompt(rows, 1, 6)?.value, 'say ')
+})
+
+test('builds a direct edit that replaces the candidate token without executing it', () => {
+	assert.deepEqual(
+		createJLineCandidateInsertion({ value: 'gamerule advance_t', cursor: 18 }, 'advance_weather'),
+		{ deleteBefore: 9, deleteAfter: 0, text: 'advance_weather ' },
+	)
+	assert.deepEqual(createJLineCandidateInsertion({ value: 'give stne 1', cursor: 7 }, 'stone'), {
+		deleteBefore: 2,
+		deleteAfter: 2,
+		text: 'stone',
+	})
+	assert.deepEqual(applyJLineCandidate({ value: 'gamerule keep_inventory ', cursor: 24 }, 'true'), {
+		value: 'gamerule keep_inventory true ',
+		cursor: 29,
+	})
+})
+
+test('replaces selections and creates a deterministic JLine redraw sequence', () => {
+	const edit = replaceJLineSelection({ value: 'gamerule keep_inventory true' }, 0, 28, '')
+	assert.deepEqual(edit, { value: '', cursor: 0 })
+	assert.equal(
+		createJLineLineReplacementSequence('give stne 1', { value: 'give stone 1', cursor: 10 }),
+		`\x01\x0bgive stone 1${JLINE_KEY_SEQUENCES.ArrowLeft.repeat(2)}`,
+	)
+	assert.ok(
+		createJLineLineReplacementSequence('g', { value: 'gamemode ', cursor: 8 }, true).endsWith(
+			'\x1bOD',
+		),
+	)
+})
+
+test('splits candidate columns and preserves terminal coordinates', () => {
+	const candidates = parseJLineCandidates(
+		[row(4, '> give @p '), row(5, 'stone  stick', false, 't')],
+		4,
+	)
+	assert.deepEqual(
+		candidates.map(({ text, row, column, selected }) => ({ text, row, column, selected })),
+		[
+			{ text: 'stone', row: 5, column: 0, selected: true },
+			{ text: 'stick', row: 5, column: 7, selected: true },
+		],
+	)
+})
+
+test('rejects truncated candidate menus and defines terminal key bytes', () => {
+	assert.deepEqual(parseJLineCandidates([row(1, '> g'), row(2, 'one  --More--')], 1), [])
+	assert.equal(JLINE_KEY_SEQUENCES.ArrowLeft, '\x1b[D')
+	assert.equal(jlineKeySequence('ArrowLeft', true), '\x1bOD')
+	assert.equal(JLINE_KEY_SEQUENCES.Backspace, '\x7f')
+})
+
+test('detects Forge candidate confirmation prompts and their expanded row count', () => {
+	assert.deepEqual(
+		parseJLineCandidateConfirmation([
+			row(1, 'Forge: do you wish to see all 51 '),
+			row(2, 'possibilities (13 lines)?', true),
+		]),
+		{ lineCount: 13 },
+	)
+	assert.deepEqual(
+		parseJLineCandidateConfirmation([
+			row(1, '[Server thread/INFO] Forge: display all 2048 possibilities (512 lines)?'),
+		]),
+		{ lineCount: 512 },
+	)
+	assert.equal(
+		parseJLineCandidateConfirmation([
+			row(1, 'Forge: display all 10 possibilities (2 lines)?'),
+			row(2, '> gamerule'),
+		]),
+		null,
+	)
+	assert.equal(parseJLineCandidateConfirmation([row(1, '> gamerule')]), null)
+})

--- a/packages/ui/src/layouts/shared/console/jline.ts
+++ b/packages/ui/src/layouts/shared/console/jline.ts
@@ -1,0 +1,229 @@
+export interface JLineCellStyle {
+	foreground?: string
+	background?: string
+	bold?: boolean
+	italic?: boolean
+	underline?: boolean
+	dim?: boolean
+	inverse?: boolean
+}
+
+export interface JLineCell {
+	text: string
+	width: number
+	style: JLineCellStyle
+}
+
+export interface JLineRow {
+	index: number
+	wrapped: boolean
+	cells: JLineCell[]
+}
+
+export interface JLinePrompt {
+	value: string
+	cursor: number
+	rows: JLineRow[]
+}
+
+export interface JLineCandidate {
+	text: string
+	row: number
+	column: number
+	selected: boolean
+	style: JLineCellStyle
+}
+
+export interface JLineCandidateConfirmation {
+	lineCount: number
+}
+
+export interface JLineCandidateInsertion {
+	deleteBefore: number
+	deleteAfter: number
+	text: string
+}
+
+export interface JLineInputEdit {
+	value: string
+	cursor: number
+}
+
+export const JLINE_KEY_SEQUENCES: Record<string, string> = {
+	Tab: '\t',
+	ArrowUp: '\x1b[A',
+	ArrowDown: '\x1b[B',
+	ArrowRight: '\x1b[C',
+	ArrowLeft: '\x1b[D',
+	Home: '\x1b[H',
+	End: '\x1b[F',
+	Delete: '\x1b[3~',
+	Backspace: '\x7f',
+	Enter: '\r',
+	Escape: '\x1b',
+}
+
+export function jlineKeySequence(key: string, applicationCursorKeys = false): string | undefined {
+	if (applicationCursorKeys) {
+		const applicationSequences: Record<string, string> = {
+			ArrowUp: '\x1bOA',
+			ArrowDown: '\x1bOB',
+			ArrowRight: '\x1bOC',
+			ArrowLeft: '\x1bOD',
+			Home: '\x1bOH',
+			End: '\x1bOF',
+		}
+		if (applicationSequences[key]) return applicationSequences[key]
+	}
+	return JLINE_KEY_SEQUENCES[key]
+}
+
+export function extractJLinePrompt(
+	rows: JLineRow[],
+	cursorRow: number,
+	cursorColumn: number,
+): JLinePrompt | null {
+	const cursorIndex = rows.findIndex((row) => row.index === cursorRow)
+	if (cursorIndex < 0) return null
+	let start = cursorIndex
+	while (start > 0 && rows[start]?.wrapped) start--
+	const logicalRows = rows.slice(start, cursorIndex + 1)
+	const logicalText = logicalRows.map(rowText).join('')
+	if (!logicalText.startsWith('> ')) return null
+	const charactersBeforeCursor =
+		logicalRows
+			.slice(0, -1)
+			.reduce(
+				(total, row) => total + row.cells.reduce((sum, cell) => sum + cell.text.length, 0),
+				0,
+			) +
+		(logicalRows.at(-1)?.cells ?? [])
+			.slice(0, cursorColumn)
+			.reduce((sum, cell) => sum + cell.text.length, 0)
+	const cursor = Math.max(0, charactersBeforeCursor - 2)
+	const commandText = logicalText.slice(2)
+	const valueEnd = Math.max(cursor, commandText.trimEnd().length)
+	return {
+		value: commandText.slice(0, valueEnd),
+		cursor,
+		rows: logicalRows,
+	}
+}
+
+export function createJLineCandidateInsertion(
+	prompt: Pick<JLinePrompt, 'value' | 'cursor'>,
+	candidateText: string,
+): JLineCandidateInsertion {
+	const cursor = Math.max(0, Math.min(prompt.cursor, prompt.value.length))
+	let start = cursor
+	while (start > 0 && !/\s/.test(prompt.value[start - 1]!)) start--
+	let end = cursor
+	while (end < prompt.value.length && !/\s/.test(prompt.value[end]!)) end++
+	const needsTrailingSpace = end === prompt.value.length && !candidateText.endsWith(' ')
+	return {
+		deleteBefore: cursor - start,
+		deleteAfter: end - cursor,
+		text: `${candidateText}${needsTrailingSpace ? ' ' : ''}`,
+	}
+}
+
+export function applyJLineCandidate(
+	prompt: Pick<JLinePrompt, 'value' | 'cursor'>,
+	candidateText: string,
+): JLineInputEdit {
+	const insertion = createJLineCandidateInsertion(prompt, candidateText)
+	const start = prompt.cursor - insertion.deleteBefore
+	const end = prompt.cursor + insertion.deleteAfter
+	return {
+		value: `${prompt.value.slice(0, start)}${insertion.text}${prompt.value.slice(end)}`,
+		cursor: start + insertion.text.length,
+	}
+}
+
+export function replaceJLineSelection(
+	prompt: Pick<JLinePrompt, 'value'>,
+	selectionStart: number,
+	selectionEnd: number,
+	replacement: string,
+): JLineInputEdit {
+	const start = Math.max(0, Math.min(selectionStart, selectionEnd, prompt.value.length))
+	const end = Math.max(start, Math.min(Math.max(selectionStart, selectionEnd), prompt.value.length))
+	return {
+		value: `${prompt.value.slice(0, start)}${replacement}${prompt.value.slice(end)}`,
+		cursor: start + replacement.length,
+	}
+}
+
+export function createJLineLineReplacementSequence(
+	currentValue: string,
+	next: JLineInputEdit,
+	applicationCursorKeys = false,
+): string {
+	const cursor = Math.max(0, Math.min(next.cursor, next.value.length))
+	return (
+		(currentValue ? '\x01\x0b' : '') +
+		next.value +
+		jlineKeySequence('ArrowLeft', applicationCursorKeys)!.repeat(next.value.length - cursor)
+	)
+}
+
+export function parseJLineCandidates(rows: JLineRow[], cursorRow: number): JLineCandidate[] {
+	const candidates: JLineCandidate[] = []
+	for (const row of rows) {
+		if (row.index <= cursorRow) continue
+		const text = rowText(row)
+		if (!text.trim()) continue
+		if (/--more--|\.\.\.$/i.test(text.trim())) return []
+
+		let start = 0
+		while (start < row.cells.length) {
+			while (start < row.cells.length && !row.cells[start]?.text.trim()) start++
+			if (start >= row.cells.length) break
+			let end = start
+			let blankRun = 0
+			while (end < row.cells.length) {
+				if (row.cells[end]?.text.trim()) {
+					blankRun = 0
+				} else {
+					blankRun++
+					if (blankRun >= 2) break
+				}
+				end++
+			}
+			const contentEnd = Math.max(start, end - blankRun + 1)
+			const candidateText = row.cells
+				.slice(start, contentEnd)
+				.map((cell) => cell.text)
+				.join('')
+				.trim()
+			if (candidateText) {
+				const first = row.cells[start]!
+				candidates.push({
+					text: candidateText,
+					row: row.index,
+					column: start,
+					selected: row.cells.slice(start, contentEnd).some((cell) => cell.style.inverse),
+					style: first.style,
+				})
+			}
+			start = end + 1
+		}
+	}
+	return candidates
+}
+
+export function parseJLineCandidateConfirmation(
+	rows: JLineRow[],
+): JLineCandidateConfirmation | null {
+	const text = rows.map(rowText).join(' ').replace(/\s+/g, ' ').trim()
+	const match = text.match(
+		/(?:do you wish to see all|display all)\s+\d+\s+possibilit(?:y|ies)\b.*?\((\d+)\s+lines?\)\?\s*$/i,
+	)
+	if (!match) return null
+	const lineCount = Number.parseInt(match[1] ?? '', 10)
+	return { lineCount: Number.isFinite(lineCount) ? lineCount : 0 }
+}
+
+function rowText(row: JLineRow): string {
+	return row.cells.map((cell) => cell.text).join('')
+}

--- a/packages/ui/src/layouts/shared/console/layout.vue
+++ b/packages/ui/src/layouts/shared/console/layout.vue
@@ -110,8 +110,15 @@
 			</Transition>
 		</div>
 
+		<slot
+			v-if="showCommandInput && customCommandInput"
+			name="command-input"
+			:disabled="commandDisabled"
+			:placeholder="commandPlaceholder"
+			:submit-command="submitProvidedCommand"
+		/>
 		<StyledInput
-			v-if="showCommandInput"
+			v-else-if="showCommandInput"
 			v-model="commandInput"
 			v-tooltip="commandDisabled ? commandDisabledTooltip : undefined"
 			:icon="TerminalSquareIcon"
@@ -198,6 +205,9 @@ import { injectConsoleManager } from './providers'
 import type { LogLevel, LogLine } from './types'
 
 const ctx = injectConsoleManager()
+defineProps<{
+	customCommandInput?: boolean
+}>()
 const client = injectModrinthClient()
 const modalBehavior = injectModalBehavior()
 const pageContext = injectPageContext(null)
@@ -740,6 +750,12 @@ function submitCommand() {
 	commandInput.value = ''
 	// The user just interacted with the console: pin the view to the bottom
 	// so the command echo and its response are visible immediately.
+	viewportRef.value?.scrollToBottom()
+}
+
+function submitProvidedCommand(command: string) {
+	if (!command.trim() || commandDisabled.value || !ctx.sendCommand) return
+	ctx.sendCommand(command.trim())
 	viewportRef.value?.scrollToBottom()
 }
 

--- a/packages/ui/src/locales/en-US/index.json
+++ b/packages/ui/src/locales/en-US/index.json
@@ -314,6 +314,12 @@
   "console.command.server-not-running-placeholder": {
     "defaultMessage": "Server is not running"
   },
+  "console.command-completions.no-results": {
+    "defaultMessage": "No matching completions"
+  },
+  "console.command-completions.search": {
+    "defaultMessage": "Search command completions"
+  },
   "console.crash.export-context": {
     "defaultMessage": "Export crash context"
   },

--- a/packages/ui/src/locales/zh-CN/index.json
+++ b/packages/ui/src/locales/zh-CN/index.json
@@ -290,6 +290,12 @@
   "console.command.server-not-running-placeholder": {
     "defaultMessage": "服务器未运行"
   },
+  "console.command-completions.no-results": {
+    "defaultMessage": "没有匹配的补全项"
+  },
+  "console.command-completions.search": {
+    "defaultMessage": "搜索命令补全项"
+  },
   "console.crash.export-context": {
     "defaultMessage": "导出崩溃上下文"
   },


### PR DESCRIPTION
## Summary

让启动器里的 Forge 服务器命令输入框适配 JLine 的交互式补全功能。

现在在 Forge 控制台里输入命令时，可以直接使用 Tab 自动补全，并在启动器内显示补全候选下拉列表，而不是只能像以前一样单纯把输入内容发送给服务器。

同时保留了原有的命令输入体验，非 Forge 服务端不受影响。

## Motivation

Forge 的命令补全、命令历史、光标移动等功能是由 JLine 提供的，但 JLine 只有在连接到真正的交互式终端时才会启用这些能力。

之前启动器使用普通 stdin/stdout 管道和服务器通信，所以虽然可以发送命令，但拿不到 Forge 自带的 Tab 补全和候选菜单。

这次主要就是补上这一层，让启动器里的输入框能够真正接入 Forge 的 JLine，而不是自己重新实现一套命令补全规则。

## Changes

* Forge 服务器改用 PTY 方式启动，让 JLine 能够正常识别交互式终端。
* 让启动器可以接收和发送 JLine 所需的原始终端输入输出。
* 调整控制台命令输入框，使其能够识别 Forge / JLine 当前的输入状态。
* 支持使用 Tab 触发 Forge 原生的命令自动补全。
* 将 JLine 返回的补全候选项显示成启动器里的候选下拉列表。
* 候选列表支持搜索和选择，避免直接显示 JLine 原本的终端菜单。
* 支持方向键移动光标、选区替换、粘贴、输入法组合输入等常见输入行为。
* 支持 JLine 的命令历史，可以通过历史记录切换之前输入过的命令。
* 处理候选项过多时 JLine 的确认提示，避免 JLine 在后台等待输入导致控制台卡住。
* 重新进入控制台页面时会让终端重新绘制当前输入状态，避免切换页面后自动补全失效。
* 如果当前没有识别到兼容的 JLine 输入提示，则自动退回原来的普通命令输入方式。
* 对终端输出缓存和前端重放缓存增加大小限制，避免长时间运行后持续占用内存。
* 如果 Forge 进程已经启动，但后续服务器信息保存失败，会同步结束该进程，避免残留后台进程。
* 忽略 Java 编译生成的 `.class` 文件，防止本地编译产物被误提交。
* 为新增的补全相关界面添加英文和简体中文文案。

## Compatibility

* 新的 PTY / JLine 处理目前只对 `forge` 类型服务器启用。
* Vanilla、Fabric、Quilt、NeoForge 和其他服务端仍然使用原来的控制台通信方式。
* 非 PTY 服务端不能调用新的原始终端输入和窗口尺寸接口。
* 对输入内容和终端尺寸增加校验和长度限制，避免异常数据进入终端。
* 如果 JLine 一次返回的候选项过多，会主动取消这次候选菜单，而不是让 JLine 一直卡在等待确认的状态。

## Testing

* `cargo fmt --all --check`
* `cargo test -p theseus api::servers:: --lib` — 24 passed
* `pnpm --filter @modrinth/ui test` — 28 passed
* `node --test apps/app-frontend/src/composables/server-console-buffer.test.ts` — 2 passed
* `pnpm --filter @modrinth/app-frontend exec vue-tsc --noEmit`
* `pnpm axolotl:brand-guard`
* `pnpm axolotl:i18n-check`

## Review Notes

这次主要建议关注以下几个部分：

* `packages/app-lib/src/api/servers/lifecycle.rs`

  * Forge PTY 进程的启动、关闭和异常清理是否完整。

* `packages/app-lib/src/api/servers/logs.rs`

  * 原始终端输出的转发和缓存大小限制是否合理。

* `packages/ui/src/layouts/shared/console`

  * JLine 当前输入内容、光标位置和候选项的解析是否稳定。
  * Tab 补全、候选列表、历史记录和输入编辑行为是否符合预期。

* `ServerConsole.vue`

  * Forge 是否正确启用新的 JLine 输入方式。
  * 其他服务端是否仍然保持原来的控制台行为。

## Sourcery 摘要

在不改变其他服务器类型控制台行为的前提下，为 Forge 服务器控制台启用由 JLine 驱动的原生命令补全。

新功能：
- 为 Forge 添加基于 PTY 的专用控制台交互，支持原生 JLine Tab 补全、命令历史记录、光标编辑、候选项选择和终端大小调整。
- 在可搜索的启动器下拉菜单中显示 JLine 补全候选项，同时为其他服务器类型保留标准命令输入方式。

错误修复：
- 防止 JLine 补全菜单卡顿或过大，并限制控制台输出缓冲区大小，避免内存无限增长。
- 如果启动元数据持久化失败，则清理 Forge 进程，避免遗留后台进程。

增强功能：
- 在后端和前端之间传输原始 Forge 终端输入和输出，同时保留非 Forge 服务器现有的控制台行为。
- 支持常见的终端编辑行为，包括选择内容替换、粘贴、IME 组合输入、导航，以及重新进入页面后重绘控制台。

构建：
- 添加 `portable-pty` 依赖，并忽略生成的 Java 类文件。

测试：
- 增加对 PTY 选择和原始输入处理、输出拆分与大小限制、有界控制台缓冲，以及 JLine 提示符、候选项、确认和编辑行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在不改变其他服务器类型控制台行为的情况下，为 Forge 服务器控制台启用原生 JLine 命令补全功能。

新功能：
- 支持 Forge 服务器控制台使用由 JLine 驱动的原生 Tab 补全、命令历史记录、光标编辑、原始终端输入以及可调整大小的 PTY 会话。
- 在可搜索、可选择的启动器下拉菜单中显示 JLine 补全候选项，同时为其他服务器类型保留标准命令输入方式。

错误修复：
- 防止补全菜单过大、控制台缓冲区无限增长，以及启动元数据持久化失败后 Forge 进程成为孤儿进程。

增强功能：
- 在后端与前端之间传输 Forge PTY 输出，同时支持终端编辑、选择替换、粘贴、IME 输入、导航，以及重新访问页面后的控制台重绘。

构建：
- 添加 portable-pty 依赖，并忽略生成的 Java 类文件。

测试：
- 增加对 Forge PTY 选择、原始输入、PTY 输出拆分与限制、有界控制台缓冲，以及 JLine 提示符、补全、确认和编辑行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增 Forge 专用的 PTY 控制台，在保留其他服务器类型现有行为的同时，提供 JLine 原生的交互式命令补全功能。

新功能：
- 为 Forge 服务器控制台启用原生 JLine 命令补全，并支持搜索和选择补全候选项。
- 支持 Forge 控制台历史记录、光标编辑、选区替换、粘贴、IME 输入和终端大小调整。

错误修复：
- 防止过大的补全提示和控制台输出缓冲区导致卡顿或无界内存占用。
- 如果服务器启动期间持久化服务器元数据失败，则清理 Forge 进程。

增强功能：
- 保留 Vanilla、Fabric、Quilt、NeoForge 及其他非 Forge 服务器现有的控制台输入行为。
- 在服务器进程与前端之间传输原始 Forge 终端输入和输出；如果 JLine 不可用，则回退到标准命令输入。

构建：
- 添加 portable-pty 依赖，并忽略生成的 Java 类文件。

测试：
- 增加对 Forge PTY 选择、原始输入处理、PTY 输出拆分与限制、有界缓冲，以及 JLine 提示、补全、确认和编辑行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Forge-specific PTY console that exposes JLine’s native interactive command completion while preserving existing behavior for other server types.

New Features:
- Enable native JLine command completion for Forge server consoles with searchable, selectable completion candidates.
- Support Forge console history, cursor editing, selection replacement, paste, IME input, and terminal resizing.

Bug Fixes:
- Prevent oversized completion prompts and console output buffers from causing stalls or unbounded memory use.
- Clean up a Forge process if server metadata persistence fails during startup.

Enhancements:
- Preserve the existing console input behavior for Vanilla, Fabric, Quilt, NeoForge, and other non-Forge servers.
- Stream raw Forge terminal input and output between the server process and the frontend, with fallback to standard command input when JLine is unavailable.

Build:
- Add the portable-pty dependency and ignore generated Java class files.

Tests:
- Add coverage for Forge PTY selection, raw input handling, PTY output splitting and limits, bounded buffering, and JLine prompt, completion, confirmation, and editing behavior.

</details>

</details>

</details>