### PR TITLE
feat: 支持跟随系统强调色

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "ashpd"
+version = "0.13.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111"
+dependencies = [
+ "enumflags2",
+ "futures-util",
+ "getrandom 0.4.3",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6819,7 +6833,9 @@ dependencies = [
 name = "theseus_gui"
 version = "1.9.6-beta.1"
 dependencies = [
+ "ashpd",
  "async_zip",
+ "block2",
  "bytes",
  "cc",
  "chrono",
@@ -6836,6 +6852,8 @@ dependencies = [
  "libc",
  "native-dialog",
  "notify",
+ "objc2-app-kit",
+ "objc2-foundation",
  "paste",
  "path-util",
  "quartz_nbt",
@@ -6998,6 +7016,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -8753,6 +8772,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid 1.24.0",

--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -385,6 +385,7 @@ const closeRequestInProgress = ref(false)
 let allowWindowClose = false
 let unlistenCloseRequested: (() => void) | undefined
 let unlistenLightweightModeError: (() => void) | undefined
+let unlistenSystemAccentColor: (() => void) | undefined
 const minecraftCrashModal = ref()
 const javaDownloadConfirmationModal = ref()
 const pendingUpdateAnnouncementVersion = ref(null)
@@ -559,6 +560,7 @@ onUnmounted(async () => {
 	window.removeEventListener('keydown', handleGlobalKeydown, true)
 	unlistenCloseRequested?.()
 	unlistenLightweightModeError?.()
+	unlistenSystemAccentColor?.()
 	document.querySelector('body').removeEventListener('click', handleClick)
 	document.querySelector('body').removeEventListener('auxclick', handleAuxClick)
 	window.removeEventListener(DIRECT_LINKS_SYNCED_EVENT, handleDirectLinkSyncReport)
@@ -1092,6 +1094,7 @@ async function setupApp() {
 	if (os.value !== 'MacOS') await getCurrentWindow().setDecorations(native_decorations)
 
 	themeStore.setThemeState(theme)
+	await initializeSystemAccentColor()
 	themeStore.setAccentColor(accent_color)
 	themeStore.collapsedNavigation = collapsed_navigation
 	themeStore.advancedRendering = advanced_rendering
@@ -1177,6 +1180,32 @@ async function setupApp() {
 		generateSkinPreviews(skins, capes)
 	} catch (error) {
 		console.warn('Failed to generate skin previews in app setup.', error)
+	}
+}
+
+type SystemAccentColorPayload = {
+	hex: string
+	r: number
+	g: number
+	b: number
+}
+
+async function initializeSystemAccentColor() {
+	try {
+		unlistenSystemAccentColor = await listen<SystemAccentColorPayload>(
+			'system-accent-color-changed',
+			({ payload }) => themeStore.setSystemAccentColor(payload.hex),
+		)
+	} catch (error) {
+		console.warn('Failed to listen for system accent color changes', error)
+	}
+
+	try {
+		const color = await invoke<SystemAccentColorPayload>('plugin:system-accent|system_accent_color')
+		themeStore.setSystemAccentColor(color.hex)
+	} catch (error) {
+		themeStore.setSystemAccentUnavailable()
+		console.warn('Failed to read the system accent color', error)
 	}
 }
 

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -31,6 +31,7 @@ import {
 	type AccentColor,
 	type CloseBehavior,
 	type ColorTheme,
+	DEFAULT_CUSTOM_ACCENT_COLOR,
 	deriveAccentVariants,
 	type FeatureFlag,
 	hexToHsl,
@@ -99,6 +100,18 @@ const messages = defineMessages({
 	accentColorCustom: {
 		id: 'app.appearance-settings.accent-color.custom',
 		defaultMessage: 'Custom',
+	},
+	accentColorSystem: {
+		id: 'app.appearance-settings.accent-color.system',
+		defaultMessage: 'Follow system',
+	},
+	accentColorSystemUnsupported: {
+		id: 'app.appearance-settings.accent-color.system-unsupported',
+		defaultMessage: 'System unsupported',
+	},
+	accentColorSystemUnsupportedLabel: {
+		id: 'app.appearance-settings.accent-color.system-unsupported-label',
+		defaultMessage: 'Follow system: System unsupported',
 	},
 	accentColorCustomHue: {
 		id: 'app.appearance-settings.accent-color.custom-hue',
@@ -363,7 +376,10 @@ const accentColorOptions: Array<{
 ]
 
 const isCustomAccent = computed(() => settings.value.accent_color.startsWith('custom:'))
-const customAccentHex = ref(parseCustomAccentColor(settings.value.accent_color) ?? '#db2777')
+const isSystemAccent = computed(() => settings.value.accent_color === 'system')
+const customAccentHex = ref(
+	parseCustomAccentColor(settings.value.accent_color) ?? DEFAULT_CUSTOM_ACCENT_COLOR,
+)
 const customAccentHexInput = ref(customAccentHex.value)
 const customAccentHue = computed(() => Math.round(hexToHsl(customAccentHex.value).h))
 const customAccentPreview = computed(() => deriveAccentVariants(customAccentHex.value))
@@ -534,7 +550,7 @@ watch(
 			</template>
 			<div class="flex flex-col gap-4 p-4 @container">
 				<div
-					class="grid grid-cols-6 gap-1 @2xl:gap-2"
+					class="grid grid-cols-4 gap-1 @2xl:gap-2 @4xl:grid-cols-7"
 					role="radiogroup"
 					:aria-label="formatMessage(messages.accentColorTitle)"
 				>
@@ -566,6 +582,50 @@ watch(
 							v-if="settings.accent_color === accentColor.value"
 							class="ml-auto hidden size-4 shrink-0 @4xl:block"
 						/>
+					</button>
+					<button
+						type="button"
+						role="radio"
+						:disabled="themeStore.systemAccentSupported !== true"
+						:aria-checked="isSystemAccent"
+						:aria-label="
+							formatMessage(
+								themeStore.systemAccentSupported === false
+									? messages.accentColorSystemUnsupportedLabel
+									: messages.accentColorSystem,
+							)
+						"
+						class="flex min-w-0 items-center justify-center gap-2 rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
+						:class="
+							themeStore.systemAccentSupported !== true
+								? 'cursor-not-allowed border-surface-4 bg-surface-2 text-secondary opacity-60'
+								: isSystemAccent
+									? 'border-brand bg-brand-highlight text-brand'
+									: 'border-surface-4 bg-surface-3 text-secondary hover:border-surface-5 hover:text-contrast'
+						"
+						@click="
+							() => {
+								themeStore.setAccentColor('system')
+								settings.accent_color = 'system'
+							}
+						"
+					>
+						<span
+							class="size-4 shrink-0 rounded-full ring-2 ring-white/20"
+							:style="{
+								backgroundColor: themeStore.systemAccentColor ?? 'var(--color-pink)',
+							}"
+						/>
+						<span class="hidden min-w-0 flex-col truncate text-start leading-tight @xl:flex">
+							<span class="truncate">{{ formatMessage(messages.accentColorSystem) }}</span>
+							<span
+								v-if="themeStore.systemAccentSupported === false"
+								class="truncate text-xs font-normal"
+							>
+								{{ formatMessage(messages.accentColorSystemUnsupported) }}
+							</span>
+						</span>
+						<CheckIcon v-if="isSystemAccent" class="ml-auto hidden size-4 shrink-0 @4xl:block" />
 					</button>
 					<button
 						type="button"

--- a/apps/app-frontend/src/helpers/types.d.ts
+++ b/apps/app-frontend/src/helpers/types.d.ts
@@ -196,7 +196,7 @@ type AppSettings = {
 	max_concurrent_writes: number
 
 	theme: 'dark' | 'light' | 'oled' | 'system'
-	accent_color: 'pink' | 'orange' | 'green' | 'blue' | 'purple' | `custom:#${string}`
+	accent_color: 'pink' | 'orange' | 'green' | 'blue' | 'purple' | 'system' | `custom:#${string}`
 	default_page: 'Home' | 'DiscoverContent' | 'Library'
 	collapsed_navigation: boolean
 	advanced_rendering: boolean

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -407,6 +407,15 @@
   "app.appearance-settings.accent-color.purple": {
     "message": "Purple"
   },
+  "app.appearance-settings.accent-color.system": {
+    "message": "Follow system"
+  },
+  "app.appearance-settings.accent-color.system-unsupported": {
+    "message": "System unsupported"
+  },
+  "app.appearance-settings.accent-color.system-unsupported-label": {
+    "message": "Follow system: System unsupported"
+  },
   "app.appearance-settings.accent-color.title": {
     "message": "Accent color"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -407,6 +407,15 @@
   "app.appearance-settings.accent-color.purple": {
     "message": "紫色"
   },
+  "app.appearance-settings.accent-color.system": {
+    "message": "跟随系统"
+  },
+  "app.appearance-settings.accent-color.system-unsupported": {
+    "message": "系统不支持"
+  },
+  "app.appearance-settings.accent-color.system-unsupported-label": {
+    "message": "跟随系统：系统不支持"
+  },
   "app.appearance-settings.accent-color.title": {
     "message": "强调色"
   },

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -380,6 +380,15 @@
   "app.appearance-settings.accent-color.purple": {
     "message": "紫色"
   },
+  "app.appearance-settings.accent-color.system": {
+    "message": "跟隨系統"
+  },
+  "app.appearance-settings.accent-color.system-unsupported": {
+    "message": "系統不支援"
+  },
+  "app.appearance-settings.accent-color.system-unsupported-label": {
+    "message": "跟隨系統：系統不支援"
+  },
   "app.appearance-settings.accent-color.title": {
     "message": "強調色"
   },

--- a/apps/app-frontend/src/store/theme.test.ts
+++ b/apps/app-frontend/src/store/theme.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { applySystemAccentHue, DEFAULT_CUSTOM_ACCENT_COLOR, hexToHsl } from './theme.ts'
+
+test('applies the system hue with the custom accent saturation and lightness', () => {
+	const system = hexToHsl('#0078d4')
+	const custom = hexToHsl(DEFAULT_CUSTOM_ACCENT_COLOR)
+	const result = hexToHsl(applySystemAccentHue('#0078d4'))
+
+	assert.ok(Math.abs(result.h - system.h) < 1)
+	assert.ok(Math.abs(result.s - custom.s) < 1)
+	assert.ok(Math.abs(result.l - custom.l) < 1)
+})
+
+test('preserves hue values at the red boundary', () => {
+	const result = hexToHsl(applySystemAccentHue('#ff0000'))
+
+	assert.ok(result.h < 1 || result.h > 359)
+})

--- a/apps/app-frontend/src/store/theme.ts
+++ b/apps/app-frontend/src/store/theme.ts
@@ -22,13 +22,14 @@ export const DEFAULT_FEATURE_FLAGS = {
 
 export const THEME_OPTIONS = ['dark', 'light', 'oled', 'system'] as const
 export const ACCENT_COLOR_OPTIONS = ['pink', 'orange', 'green', 'blue', 'purple'] as const
+export const DEFAULT_CUSTOM_ACCENT_COLOR = '#db2777'
 
 export type FeatureFlag = keyof typeof DEFAULT_FEATURE_FLAGS
 export type FeatureFlags = Record<FeatureFlag, boolean>
 export type ColorTheme = (typeof THEME_OPTIONS)[number]
 export type AccentColor = (typeof ACCENT_COLOR_OPTIONS)[number]
 export type CustomAccentColor = `custom:#${string}`
-export type AccentColorSetting = AccentColor | CustomAccentColor
+export type AccentColorSetting = AccentColor | 'system' | CustomAccentColor
 export type HomeLayout = 'standard' | 'minimal'
 export type CloseBehavior = 'ask' | 'close' | 'lightweight'
 
@@ -83,6 +84,12 @@ export function hslToHex(h: number, s: number, l: number): string {
 	return `#${toHex(r)}${toHex(g)}${toHex(b)}`
 }
 
+export function applySystemAccentHue(systemHex: string): string {
+	const { h } = hexToHsl(systemHex)
+	const { s, l } = hexToHsl(DEFAULT_CUSTOM_ACCENT_COLOR)
+	return hslToHex(h, s, l)
+}
+
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
 
 /**
@@ -103,6 +110,8 @@ export function deriveAccentVariants(hex: string): { light: string; dark: string
 export type ThemeStore = {
 	selectedTheme: ColorTheme
 	selectedAccentColor: AccentColorSetting
+	systemAccentColor: string | null
+	systemAccentSupported: boolean | null
 	advancedRendering: boolean
 	hideNametagSkinsPage: boolean
 	toggleSidebar: boolean
@@ -125,6 +134,8 @@ export type ThemeStore = {
 export const DEFAULT_THEME_STORE: ThemeStore = {
 	selectedTheme: 'dark',
 	selectedAccentColor: 'pink',
+	systemAccentColor: null,
+	systemAccentSupported: null,
 	advancedRendering: true,
 	hideNametagSkinsPage: false,
 	toggleSidebar: false,
@@ -158,6 +169,7 @@ export const useTheming = defineStore('themeStore', {
 		},
 		setAccentColor(newAccentColor: AccentColorSetting) {
 			if (
+				newAccentColor === 'system' ||
 				parseCustomAccentColor(newAccentColor) !== null ||
 				ACCENT_COLOR_OPTIONS.includes(newAccentColor as AccentColor)
 			) {
@@ -172,17 +184,38 @@ export const useTheming = defineStore('themeStore', {
 			}
 			html.classList.remove('accent-custom')
 
-			const customHex = parseCustomAccentColor(this.selectedAccentColor)
+			const customHex =
+				parseCustomAccentColor(this.selectedAccentColor) ??
+				(this.selectedAccentColor === 'system' ? this.systemAccentColor : null)
 			if (customHex) {
 				const variants = deriveAccentVariants(customHex)
 				html.style.setProperty('--custom-accent-light', variants.light)
 				html.style.setProperty('--custom-accent-dark', variants.dark)
 				html.classList.add('accent-custom')
+			} else if (this.selectedAccentColor === 'system') {
+				html.style.removeProperty('--custom-accent-light')
+				html.style.removeProperty('--custom-accent-dark')
+				html.classList.add('accent-pink')
 			} else {
 				html.style.removeProperty('--custom-accent-light')
 				html.style.removeProperty('--custom-accent-dark')
 				html.classList.add(`accent-${this.selectedAccentColor}`)
 			}
+		},
+		setSystemAccentColor(systemHex: string) {
+			if (!/^#[0-9a-fA-F]{6}$/.test(systemHex)) {
+				this.setSystemAccentUnavailable()
+				return
+			}
+
+			this.systemAccentColor = applySystemAccentHue(systemHex)
+			this.systemAccentSupported = true
+			if (this.selectedAccentColor === 'system') this.setAccentColor('system')
+		},
+		setSystemAccentUnavailable() {
+			this.systemAccentColor = null
+			this.systemAccentSupported = false
+			if (this.selectedAccentColor === 'system') this.setAccentColor('system')
 		},
 		setThemeClass() {
 			const html = document.getElementsByTagName('html')[0]

--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -69,11 +69,32 @@ cc = { workspace = true }
 tauri-build = { workspace = true, features = ["codegen"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+ashpd = { version = "0.13.13", features = ["settings"] }
 tauri-plugin-updater = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+  "NSColor",
+  "NSColorSpace",
+  "objc2-core-foundation",
+] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+  "NSNotification",
+  "NSOperation",
+  "NSString",
+  "block2",
+] }
 
 [target."cfg(windows)".dependencies.windows]
 workspace = true
-features = ["Win32_Graphics_Dwm", "Win32_System_Com", "Win32_UI_Shell"]
+features = [
+  "Foundation",
+  "UI_ViewManagement",
+  "Win32_Graphics_Dwm",
+  "Win32_System_Com",
+  "Win32_UI_Shell",
+]
 
 [features]
 # by default Tauri runs in production mode

--- a/apps/app/build.rs
+++ b/apps/app/build.rs
@@ -85,8 +85,11 @@ fn main() {
     println!("cargo:rerun-if-changed=src/seed_map/cubiomes_bridge.c");
     println!("cargo:rerun-if-changed=src/seed_map/cubiomes_bridge.h");
     println!("cargo:rerun-if-changed=vendor/cubiomes");
-    #[cfg(not(target_os = "windows"))]
-    println!("cargo:rustc-link-lib=m");
+    // Build scripts run for the host, so use Cargo's target metadata rather
+    // than `cfg(target_os = ...)` when deciding whether libm is needed.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        println!("cargo:rustc-link-lib=m");
+    }
 
     // Sadly, there is no better way to do it right now
     // You could try parsing source code here and detecting #[tauri::command]
@@ -637,6 +640,14 @@ fn main() {
                 "storage",
                 InlinedPlugin::new()
                     .commands(&["storage_scan_start", "storage_open_paths"])
+                    .default_permission(
+                        DefaultPermissionRule::AllowAllCommands,
+                    ),
+            )
+            .plugin(
+                "system-accent",
+                InlinedPlugin::new()
+                    .commands(&["system_accent_color"])
                     .default_permission(
                         DefaultPermissionRule::AllowAllCommands,
                     ),

--- a/apps/app/capabilities/plugins.json
+++ b/apps/app/capabilities/plugins.json
@@ -167,6 +167,7 @@
 		"ai:default",
 		"translation:default",
 		"storage:default",
+		"system-accent:default",
 		"utils:default",
 		"worlds:default",
 		"drop:default",

--- a/apps/app/src/api/mod.rs
+++ b/apps/app/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod servers;
 pub mod settings;
 pub mod shortcuts;
 pub mod storage;
+pub mod system_accent;
 pub mod tags;
 pub mod telemetry;
 pub mod terracotta;

--- a/apps/app/src/api/system_accent.rs
+++ b/apps/app/src/api/system_accent.rs
@@ -1,0 +1,241 @@
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Runtime};
+
+const ACCENT_COLOR_CHANGED: &str = "system-accent-color-changed";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccentColor {
+    hex: String,
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+impl AccentColor {
+    fn new(r: u8, g: u8, b: u8) -> Self {
+        Self {
+            hex: format!("#{r:02X}{g:02X}{b:02X}"),
+            r,
+            g,
+            b,
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", test))]
+fn unit_to_u8(value: f64) -> Result<u8, String> {
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        return Err(format!("Invalid RGB component: {value}"));
+    }
+
+    Ok((value * 255.0).round() as u8)
+}
+
+fn emit_accent_color<R: Runtime>(app: &AppHandle<R>, color: AccentColor) {
+    if let Err(error) = app.emit(ACCENT_COLOR_CHANGED, color) {
+        tracing::warn!("Failed to emit system accent color: {error}");
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn read_accent_color() -> Result<AccentColor, String> {
+    use windows::UI::ViewManagement::{UIColorType, UISettings};
+
+    let settings = UISettings::new()
+        .map_err(|error| format!("Failed to initialize UISettings: {error}"))?;
+    let color =
+        settings
+            .GetColorValue(UIColorType::Accent)
+            .map_err(|error| {
+                format!("Failed to read Windows accent color: {error}")
+            })?;
+
+    Ok(AccentColor::new(color.R, color.G, color.B))
+}
+
+#[cfg(target_os = "windows")]
+fn start_accent_color_watcher<R: Runtime>(app: AppHandle<R>) {
+    std::thread::spawn(move || {
+        use windows::{
+            Foundation::TypedEventHandler, UI::ViewManagement::UISettings,
+            core::IInspectable,
+        };
+
+        let settings = match UISettings::new() {
+            Ok(settings) => settings,
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to initialize system accent color watcher: {error}"
+                );
+                return;
+            }
+        };
+        let app_handle = app.clone();
+        let handler = TypedEventHandler::<UISettings, IInspectable>::new(
+            move |_sender, _args| {
+                if let Ok(color) = read_accent_color() {
+                    emit_accent_color(&app_handle, color);
+                }
+                Ok(())
+            },
+        );
+        let token = match settings.ColorValuesChanged(&handler) {
+            Ok(token) => token,
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to listen for Windows accent color changes: {error}"
+                );
+                return;
+            }
+        };
+
+        std::thread::park();
+        let _ = settings.RemoveColorValuesChanged(token);
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn read_accent_color() -> Result<AccentColor, String> {
+    use objc2_app_kit::{NSColor, NSColorSpace};
+
+    let color = NSColor::controlAccentColor();
+    let srgb = NSColorSpace::sRGBColorSpace();
+    let color = color.colorUsingColorSpace(&srgb).ok_or_else(|| {
+        "Unable to convert the macOS accent color to sRGB".to_string()
+    })?;
+
+    Ok(AccentColor::new(
+        unit_to_u8(color.redComponent() as f64)?,
+        unit_to_u8(color.greenComponent() as f64)?,
+        unit_to_u8(color.blueComponent() as f64)?,
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn start_accent_color_watcher<R: Runtime>(app: AppHandle<R>) {
+    use std::ptr::NonNull;
+
+    use block2::RcBlock;
+    use objc2_app_kit::NSSystemColorsDidChangeNotification;
+    use objc2_foundation::{
+        NSNotification, NSNotificationCenter, NSOperationQueue,
+    };
+
+    let center = NSNotificationCenter::defaultCenter();
+    let queue = NSOperationQueue::mainQueue();
+    let block: RcBlock<dyn Fn(NonNull<NSNotification>)> =
+        RcBlock::new(move |_notification| {
+            if let Ok(color) = read_accent_color() {
+                emit_accent_color(&app, color);
+            }
+        });
+
+    unsafe {
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSSystemColorsDidChangeNotification),
+            None,
+            Some(&queue),
+            &block,
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn read_accent_color() -> Result<AccentColor, String> {
+    use ashpd::desktop::settings::Settings;
+
+    let settings = Settings::new().await.map_err(|error| {
+        format!("Unable to connect to the XDG portal: {error}")
+    })?;
+    let color = settings.accent_color().await.map_err(|error| {
+        format!("XDG portal does not provide accent-color: {error}")
+    })?;
+
+    Ok(AccentColor::new(
+        unit_to_u8(color.red())?,
+        unit_to_u8(color.green())?,
+        unit_to_u8(color.blue())?,
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn start_accent_color_watcher<R: Runtime>(app: AppHandle<R>) {
+    tauri::async_runtime::spawn(async move {
+        use ashpd::desktop::settings::Settings;
+        use futures::StreamExt;
+
+        let settings = match Settings::new().await {
+            Ok(settings) => settings,
+            Err(error) => {
+                tracing::warn!("Unable to connect to the XDG portal: {error}");
+                return;
+            }
+        };
+        let stream = match settings.receive_accent_color_changed().await {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::warn!(
+                    "Unable to listen for XDG accent-color changes: {error}"
+                );
+                return;
+            }
+        };
+
+        futures::pin_mut!(stream);
+        while let Some(color) = stream.next().await {
+            let color = match (
+                unit_to_u8(color.red()),
+                unit_to_u8(color.green()),
+                unit_to_u8(color.blue()),
+            ) {
+                (Ok(r), Ok(g), Ok(b)) => AccentColor::new(r, g, b),
+                _ => continue,
+            };
+            emit_accent_color(&app, color);
+        }
+    });
+}
+
+#[tauri::command]
+async fn system_accent_color() -> Result<AccentColor, String> {
+    #[cfg(target_os = "windows")]
+    return read_accent_color();
+
+    #[cfg(target_os = "macos")]
+    return read_accent_color();
+
+    #[cfg(target_os = "linux")]
+    return read_accent_color().await;
+
+    #[allow(unreachable_code)]
+    Err("Unsupported operating system".to_string())
+}
+
+pub fn init<R: Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    tauri::plugin::Builder::new("system-accent")
+        .setup(|app, _api| {
+            start_accent_color_watcher(app.clone());
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![system_accent_color])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized_rgb_components_are_rounded() {
+        assert_eq!(unit_to_u8(0.0).unwrap(), 0);
+        assert_eq!(unit_to_u8(0.5).unwrap(), 128);
+        assert_eq!(unit_to_u8(1.0).unwrap(), 255);
+    }
+
+    #[test]
+    fn invalid_normalized_rgb_components_are_rejected() {
+        for value in [-0.1, 1.1, f64::NAN, f64::INFINITY] {
+            assert!(unit_to_u8(value).is_err());
+        }
+    }
+}

--- a/apps/app/src/api/system_accent.rs
+++ b/apps/app/src/api/system_accent.rs
@@ -3,6 +3,12 @@ use tauri::{AppHandle, Emitter, Runtime};
 
 const ACCENT_COLOR_CHANGED: &str = "system-accent-color-changed";
 
+#[cfg(target_os = "macos")]
+thread_local! {
+    static STOP_ACCENT_COLOR_WATCHER: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AccentColor {
     hex: String,
@@ -130,15 +136,36 @@ fn start_accent_color_watcher<R: Runtime>(app: AppHandle<R>) {
             }
         });
 
-    unsafe {
+    let observer = unsafe {
         center.addObserverForName_object_queue_usingBlock(
             Some(NSSystemColorsDidChangeNotification),
             None,
             Some(&queue),
             &block,
-        );
-    }
+        )
+    };
+    let stop = Box::new(move || unsafe {
+        center.removeObserver((&*observer).as_ref());
+    });
+
+    STOP_ACCENT_COLOR_WATCHER.with(|watcher| {
+        if let Some(stop) = watcher.borrow_mut().replace(stop) {
+            stop();
+        }
+    });
 }
+
+#[cfg(target_os = "macos")]
+fn stop_accent_color_watcher() {
+    STOP_ACCENT_COLOR_WATCHER.with(|watcher| {
+        if let Some(stop) = watcher.borrow_mut().take() {
+            stop();
+        }
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+fn stop_accent_color_watcher() {}
 
 #[cfg(target_os = "linux")]
 async fn read_accent_color() -> Result<AccentColor, String> {
@@ -217,6 +244,7 @@ pub fn init<R: Runtime>() -> tauri::plugin::TauriPlugin<R> {
             start_accent_color_watcher(app.clone());
             Ok(())
         })
+        .on_drop(|_| stop_accent_color_watcher())
         .invoke_handler(tauri::generate_handler![system_accent_color])
         .build()
 }

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -830,6 +830,7 @@ fn main() {
         .plugin(api::planet_minecraft::init())
         .plugin(api::settings::init())
         .plugin(api::storage::init())
+        .plugin(api::system_accent::init())
         .plugin(api::seed_map::init())
         .plugin(api::schematic_preview::init())
         .plugin(api::shortcuts::init())

--- a/packages/app-lib/src/state/settings.rs
+++ b/packages/app-lib/src/state/settings.rs
@@ -775,6 +775,7 @@ pub enum AccentColor {
     Green,
     Blue,
     Purple,
+    System,
     Custom(String),
 }
 
@@ -786,6 +787,7 @@ impl AccentColor {
             AccentColor::Green => "green",
             AccentColor::Blue => "blue",
             AccentColor::Purple => "purple",
+            AccentColor::System => "system",
             AccentColor::Custom(value) => {
                 if Self::is_valid_custom(value) {
                     value
@@ -802,6 +804,7 @@ impl AccentColor {
             "green" => AccentColor::Green,
             "blue" => AccentColor::Blue,
             "purple" => AccentColor::Purple,
+            "system" => AccentColor::System,
             other => match Self::parse_custom(other) {
                 Some(custom) => custom,
                 None => AccentColor::Pink,
@@ -956,6 +959,7 @@ mod tests {
         assert_eq!(AccentColor::from_string("green"), AccentColor::Green);
         assert_eq!(AccentColor::from_string("blue"), AccentColor::Blue);
         assert_eq!(AccentColor::from_string("purple"), AccentColor::Purple);
+        assert_eq!(AccentColor::from_string("system"), AccentColor::System);
     }
 
     #[test]
@@ -988,6 +992,10 @@ mod tests {
             "\"blue\""
         );
         assert_eq!(
+            serde_json::to_string(&AccentColor::System).unwrap(),
+            "\"system\""
+        );
+        assert_eq!(
             serde_json::to_string(&custom).unwrap(),
             "\"custom:#db2777\""
         );
@@ -1007,6 +1015,8 @@ mod tests {
         assert_eq!(color, AccentColor::Custom("custom:#1bd96a".to_owned()));
         let preset: AccentColor = serde_json::from_str("\"purple\"").unwrap();
         assert_eq!(preset, AccentColor::Purple);
+        let system: AccentColor = serde_json::from_str("\"system\"").unwrap();
+        assert_eq!(system, AccentColor::System);
     }
 
     #[test]


### PR DESCRIPTION
## 概述

本 PR 新增“跟随系统”强调色选项，使应用可以读取并实时响应 Windows、macOS 和 Linux 的系统强调色变化。

新增的持久化设置值为 `system`，但**现有默认值及所有异常回退仍保持为 ****`pink`**。当用户选择“跟随系统”时，仅提取系统强调色的 **Hue**，并固定使用现有默认自定义色 `#db2777` 的 **Saturation / Lightness** 生成最终主题色，以保持现有主题的视觉一致性。

应用启动时会先注册系统强调色变化监听，再读取当前系统颜色，避免初始化期间遗漏颜色变化。若平台接口读取失败，则保留用户已经保存的 `system` 设置，但运行时回退为粉色；设置页同时将“跟随系统”选项标记为不支持并禁止点击。

## 主要改动

### 1. 新增 system-accent Tauri 插件

新增符合现有 Tauri plugin 结构的 `system-accent` 后端模块，统一向前端提供系统强调色读取和变化通知。

接口：

* Command：`plugin:system-accent|system_accent_color`
* Event：`system-accent-color-changed`
* Payload：`{ hex: string; r: number; g: number; b: number }`

各平台实现：

* **Windows 10/11**

  * 使用现有 `windows 0.61.3`
  * 通过 `UISettings.GetColorValue(Accent)` 获取颜色
  * 通过 `ColorValuesChanged` 监听实时变化
  * 仅补充必要 feature，不升级 workspace 锁定版本

* **macOS**

  * 使用 `NSColor.controlAccentColor`
  * 将颜色转换到 sRGB
  * 监听 `NSSystemColorsDidChangeNotification`

* **Linux**

  * 添加 target-specific `ashpd 0.13.13`
  * 仅通过 XDG Desktop Portal 的 `accent_color()` 和对应变化流获取颜色
  * 不额外探测 GNOME/KDE，也不添加其他 fallback

后端会统一校验并归一化 RGB 分量。读取、颜色转换或事件监听失败时只记录错误，不阻止应用启动。

同时更新 `Cargo.lock`，不修改无关依赖。

### 2. 设置与主题状态支持 `system`

将 Rust 和 TypeScript 中的强调色设置类型扩展为：

`accent_color: 'system'`

数据库继续使用现有文本字段，不新增迁移。

以下行为保持不变：

* 数据库默认值：`pink`
* Pinia 默认值：`pink`
* 未知设置值回退：`pink`

主题 store 新增：

* 当前系统强调色的瞬时状态
* 当前平台是否支持系统强调色的状态

实际读取到的系统颜色**不会写入持久化设置**。

当设置值为 `system` 时，主题颜色按以下方式生成：

`H(system) + S(#db2777) + L(#db2777)`

即：

1. 从系统 RGB / Hex 中提取 Hue
2. 固定采用 `#db2777` 的 Saturation 和 Lightness
3. 使用现有 `hslToHex()` 生成主题色
4. 使用现有 `deriveAccentVariants()` 派生浅色和深色主题变量

在 `App.vue` 初始化时：

1. 先注册 `system-accent-color-changed` 监听
2. 再调用 `system_accent_color` 获取初始值
3. 系统颜色发生变化时，仅当当前设置为 `system` 才立即刷新主题
4. 应用卸载时注销前端事件监听

若系统接口调用失败：

* 标记当前平台为不支持
* 运行时使用 `pink`
* 若用户已保存 `system`，不会擅自覆盖该设置

### 3. 设置页新增“跟随系统”选项

在：

**设置 → 界面与外观 → 强调色**

中增加与现有预设样式一致的“跟随系统”单选按钮。

支持状态下：

* 显示由当前系统 Hue 生成的颜色预览
* 点击后保存 `system`
* 立即应用系统强调色

不支持状态下：

* 禁用按钮
* 保留“跟随系统”名称
* 在按钮内显示“系统不支持”
* 窄布局同步提供完整的可访问名称

由于强调色选项从 6 个增加到 7 个，对网格做最小必要调整以避免文字溢出，不修改设置页其他结构或样式。

本 PR 不修改：

* 默认选中的强调色
* 更新公告
* onboarding

## 接口与行为约定

| 项目            | 值                                                  |
| ------------- | -------------------------------------------------- |
| Tauri Command | `plugin:system-accent\|system_accent_color`        |
| Tauri Event   | `system-accent-color-changed`                      |
| Payload       | `{ hex: string; r: number; g: number; b: number }` |
| 新增持久化值        | `accent_color = "system"`                          |
| 默认值           | `pink`                                             |
| 失败回退          | `pink`                                             |
| 系统色生成公式       | `H(system) + S(#db2777) + L(#db2777)`              |

## Sourcery 摘要

支持跟随操作系统的强调色，同时保留现有主题默认值和回退行为。

新功能：
- 添加系统强调色选项，根据操作系统的强调色生成应用主题，并在其发生变化时更新。
- 通过新的 Tauri 插件支持在 Windows、macOS 和 Linux 上获取系统强调色及其变更通知。
- 在外观设置中展示系统强调色选项、平台支持状态和实时预览。

错误修复：
- 当无法访问系统强调色，或设置包含未知值时，保留现有的粉色默认值和运行时回退行为。
- 修正构建脚本中用于链接 libm 的平台检测。

增强功能：
- 扩展持久化和内存中的强调色设置，以支持系统值，同时不更改现有默认值或数据库迁移。
- 将系统色相应用于默认自定义强调色的饱和度和亮度，使系统生成的颜色与现有主题保持一致。

构建：
- 添加平台特定依赖，并更新锁定文件，以集成系统强调色功能。

测试：
- 添加对系统强调色色相生成、色相边界处理、RGB 归一化以及系统设置序列化/解析的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在受支持的桌面平台上添加跟随系统强调色的功能，同时保留现有主题默认值和回退行为。

新功能：
- 添加“跟随系统强调色”选项，根据操作系统的强调色生成应用主题，并在系统强调色发生变化时更新主题。
- 通过新的 Tauri 插件，支持在 Windows、macOS 和 Linux 上读取并监控系统强调色。
- 在外观设置中显示系统强调色选项、实时预览和平台支持状态。

错误修复：
- 当系统强调色不可用，或设置包含未知值时，保留现有的粉色默认值和运行时回退行为。
- 修正用于链接 libm 的构建脚本平台检测。

增强功能：
- 扩展持久化和内存中的强调色处理，以支持系统值，同时不更改现有默认值，也不需要数据库迁移。
- 应用系统色相，同时保留默认自定义强调色的饱和度和亮度，以确保视觉一致性。

构建：
- 添加特定于平台的依赖项，并更新锁定文件以支持系统强调色。

测试：
- 添加对系统强调色色相生成、色相边界处理、RGB 归一化，以及系统强调色序列化和解析的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add system accent color following across supported desktop platforms while preserving existing theme defaults and fallback behavior.

New Features:
- Add a Follow system accent color option that derives the application theme from the operating system accent color and updates when it changes.
- Support reading and monitoring system accent colors on Windows, macOS, and Linux through a new Tauri plugin.
- Show the system accent option with live preview and platform support status in appearance settings.

Bug Fixes:
- Preserve the existing pink default and runtime fallback when system accent colors are unavailable or settings contain unknown values.
- Correct build-script platform detection for linking libm.

Enhancements:
- Extend persisted and in-memory accent color handling to support the system value without changing existing defaults or requiring a database migration.
- Apply the system hue while retaining the default custom accent saturation and lightness for visual consistency.

Build:
- Add platform-specific dependencies and update the lockfile for system accent color support.

Tests:
- Add coverage for system accent hue generation, hue boundary handling, RGB normalization, and system accent color serialization and parsing.

</details>

</details>