### PR TITLE
fix: 修复 Beta 构建首次启动误用 Release 应用数据库

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -5,7 +5,7 @@
 #![recursion_limit = "256"]
 
 use native_dialog::{DialogBuilder, MessageLevel};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::sync::atomic::Ordering;
 use std::{
     env, fs,
@@ -25,13 +25,6 @@ mod lightweight_mode;
 mod mod_translation;
 mod portable;
 mod seed_map;
-
-#[derive(Default, Deserialize, Serialize)]
-struct UpdateChannelState {
-    active_channel: Option<String>,
-    immediate_update_fetch: Option<bool>,
-    updates_paused: Option<bool>,
-}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -233,8 +226,10 @@ async fn initialize_state(app: tauri::AppHandle) -> api::Result<()> {
 }
 
 #[tauri::command]
-fn get_update_channel(app: tauri::AppHandle) -> api::Result<String> {
-    let channel = read_update_channel_state(&app)?
+async fn get_update_channel(app: tauri::AppHandle) -> api::Result<String> {
+    let settings_dir = update_channel_settings_dir(&app)?;
+    let state = theseus::read_update_channel_state(&settings_dir).await?;
+    let channel = state
         .active_channel
         .unwrap_or_else(|| theseus::default_update_channel().to_string());
 
@@ -258,7 +253,7 @@ async fn get_current_app_database_path(
 }
 
 #[tauri::command]
-fn set_update_channel(
+async fn set_update_channel(
     app: tauri::AppHandle,
     channel: String,
 ) -> api::Result<()> {
@@ -269,22 +264,23 @@ fn set_update_channel(
         .into());
     }
 
-    let mut state = read_update_channel_state(&app)?;
+    let settings_dir = update_channel_settings_dir(&app)?;
+    let mut state = theseus::read_update_channel_state(&settings_dir).await?;
     state.active_channel = Some(channel);
-    write_update_channel_state(&app, &state)?;
-    Ok(())
+    write_update_channel_state(&app, &state)
 }
 
 #[tauri::command]
-fn get_update_preferences(
+async fn get_update_preferences(
     app: tauri::AppHandle,
 ) -> api::Result<UpdatePreferences> {
-    let state = read_update_channel_state(&app)?;
-    let effective_channel = state
-        .active_channel
-        .as_deref()
-        .unwrap_or_else(|| theseus::default_update_channel());
-    let is_beta = effective_channel == "beta";
+    let settings_dir = update_channel_settings_dir(&app)?;
+    let state = theseus::read_update_channel_state(&settings_dir).await?;
+    let is_beta = match state.active_channel.as_deref() {
+        Some("beta") => true,
+        Some("release") => false,
+        _ => theseus::default_update_channel() == "beta",
+    };
     Ok(UpdatePreferences {
         immediate_update_fetch: is_beta
             || state.immediate_update_fetch.unwrap_or(false),
@@ -293,56 +289,35 @@ fn get_update_preferences(
 }
 
 #[tauri::command]
-fn set_update_preferences(
+async fn set_update_preferences(
     app: tauri::AppHandle,
     immediate_update_fetch: bool,
     updates_paused: bool,
 ) -> api::Result<()> {
-    let mut state = read_update_channel_state(&app)?;
+    let settings_dir = update_channel_settings_dir(&app)?;
+    let mut state = theseus::read_update_channel_state(&settings_dir).await?;
     state.immediate_update_fetch = Some(immediate_update_fetch);
     state.updates_paused = Some(updates_paused);
     write_update_channel_state(&app, &state)
 }
 
-fn update_channel_state_path(app: &tauri::AppHandle) -> api::Result<PathBuf> {
-    let settings_dir = theseus::DirectoryInfo::initial_settings_dir_path(
-        &app.config().identifier,
-    )
-    .ok_or_else(|| {
-        theseus::Error::from(theseus::ErrorKind::FSError(
-            "Could not find update channel settings directory".to_string(),
-        ))
-    })?;
-    Ok(settings_dir.join("update-channel.json"))
-}
-
-fn read_update_channel_state(
-    app: &tauri::AppHandle,
-) -> api::Result<UpdateChannelState> {
-    let path = update_channel_state_path(app)?;
-    match std::fs::read_to_string(path) {
-        Ok(contents) => serde_json::from_str(&contents).map_err(|error| {
-            theseus::Error::from(theseus::ErrorKind::OtherError(
-                error.to_string(),
+fn update_channel_settings_dir(app: &tauri::AppHandle) -> api::Result<PathBuf> {
+    theseus::DirectoryInfo::initial_settings_dir_path(&app.config().identifier)
+        .ok_or_else(|| {
+            theseus::Error::from(theseus::ErrorKind::FSError(
+                "Could not find update channel settings directory".to_string(),
             ))
             .into()
-        }),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Ok(UpdateChannelState::default())
-        }
-        Err(error) => Err(error.into()),
-    }
+        })
 }
 
 fn write_update_channel_state(
     app: &tauri::AppHandle,
-    state: &UpdateChannelState,
+    state: &theseus::UpdateChannelState,
 ) -> api::Result<()> {
-    let path = update_channel_state_path(app)?;
-    let settings_dir = path
-        .parent()
-        .expect("Update channel state path has a parent directory");
-    std::fs::create_dir_all(settings_dir)?;
+    let settings_dir = update_channel_settings_dir(app)?;
+    let path = theseus::update_channel_state_file_path(&settings_dir);
+    std::fs::create_dir_all(&settings_dir)?;
     let temporary_path = settings_dir.join("update-channel.json.tmp");
     let contents = serde_json::to_vec(state).map_err(|error| {
         theseus::Error::from(theseus::ErrorKind::OtherError(error.to_string()))

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -236,7 +236,7 @@ async fn initialize_state(app: tauri::AppHandle) -> api::Result<()> {
 fn get_update_channel(app: tauri::AppHandle) -> api::Result<String> {
     let channel = read_update_channel_state(&app)?
         .active_channel
-        .unwrap_or_else(|| "release".to_string());
+        .unwrap_or_else(|| theseus::default_update_channel().to_string());
 
     match channel.as_str() {
         "release" | "beta" => Ok(channel),
@@ -280,7 +280,11 @@ fn get_update_preferences(
     app: tauri::AppHandle,
 ) -> api::Result<UpdatePreferences> {
     let state = read_update_channel_state(&app)?;
-    let is_beta = state.active_channel.as_deref() == Some("beta");
+    let effective_channel = state
+        .active_channel
+        .as_deref()
+        .unwrap_or_else(|| theseus::default_update_channel());
+    let is_beta = effective_channel == "beta";
     Ok(UpdatePreferences {
         immediate_update_fetch: is_beta
             || state.immediate_update_fetch.unwrap_or(false),

--- a/packages/app-lib/src/lib.rs
+++ b/packages/app-lib/src/lib.rs
@@ -31,9 +31,10 @@ pub use event::{
 };
 pub use logger::start_logger;
 pub use state::db::{
-    backup_current_app_db_for_update, beta_database_exists,
+    UpdateChannelState, backup_current_app_db_for_update, beta_database_exists,
     copy_database_between_channels, copy_release_database_to_beta,
     current_app_database_path, default_update_channel,
+    read_update_channel_state, update_channel_state_file_path,
 };
 pub use state::{DirectoryInfo, State};
 pub use storage::*;

--- a/packages/app-lib/src/lib.rs
+++ b/packages/app-lib/src/lib.rs
@@ -33,7 +33,7 @@ pub use logger::start_logger;
 pub use state::db::{
     backup_current_app_db_for_update, beta_database_exists,
     copy_database_between_channels, copy_release_database_to_beta,
-    current_app_database_path,
+    current_app_database_path, default_update_channel,
 };
 pub use state::{DirectoryInfo, State};
 pub use storage::*;

--- a/packages/app-lib/src/state/db.rs
+++ b/packages/app-lib/src/state/db.rs
@@ -318,6 +318,15 @@ pub fn default_update_channel() -> &'static str {
 /// database exists while the build's own default channel has none, move it
 /// over so the database follows the build instead of silently starting over
 /// with an empty database in the default channel's directory.
+///
+/// The `-wal` and `-shm` sidecars are moved before the main database, making
+/// the main database rename the commit point of the migration: any partial
+/// or failed attempt leaves the main database in the source directory, so a
+/// later startup either resumes the migration or leaves the source database
+/// intact. A sidecar is only moved when its target does not already exist;
+/// if a target sidecar is present alongside a source sidecar, the main
+/// database is left in place rather than risking a database whose WAL data
+/// would remain behind. Nothing is ever deleted or overwritten.
 async fn reconcile_default_channel_database(
     settings_dir: &Path,
 ) -> crate::Result<()> {
@@ -343,15 +352,32 @@ async fn reconcile_default_channel_database(
 
     let target_dir = settings_dir.join(channel);
     crate::util::io::create_dir_all(&target_dir).await?;
-    tokio::fs::rename(&source, &target).await?;
+
+    let mut unresolved_sidecar = false;
     for suffix in ["-wal", "-shm"] {
         let source_sidecar = sidecar_path(&source, suffix);
-        if source_sidecar.try_exists()? {
-            tokio::fs::rename(source_sidecar, sidecar_path(&target, suffix))
-                .await?;
+        if !source_sidecar.try_exists()? {
+            continue;
         }
+        let target_sidecar = sidecar_path(&target, suffix);
+        if target_sidecar.try_exists()? {
+            tracing::warn!(
+                source = %source_sidecar.display(),
+                destination = %target_sidecar.display(),
+                channel,
+                "Both update channel databases have a {suffix} file; \
+                 leaving the existing database in place"
+            );
+            unresolved_sidecar = true;
+            continue;
+        }
+        tokio::fs::rename(&source_sidecar, &target_sidecar).await?;
+    }
+    if unresolved_sidecar {
+        return Ok(());
     }
 
+    tokio::fs::rename(&source, &target).await?;
     tracing::info!(
         source = %source.display(),
         destination = %target.display(),
@@ -2209,6 +2235,87 @@ mod tests {
             "default data"
         );
         assert_eq!(std::fs::read_to_string(&source_db).unwrap(), "untouched");
+
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_resumes_after_an_interrupted_attempt() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = temporary_settings_dir("reconcile-resume");
+
+        // A previous attempt crashed after moving the -wal sidecar.
+        let source_dir = directory.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_db = source_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&source_db, "existing data").unwrap();
+        let target_dir = directory.join(channel);
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(
+            target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal")),
+            "wal",
+        )
+        .unwrap();
+
+        reconcile_default_channel_database(&directory)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target_dir.join(LEGACY_APP_DB_FILE))
+                .unwrap(),
+            "existing data"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"))
+            )
+            .unwrap(),
+            "wal"
+        );
+        assert!(!source_db.exists());
+
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_keeps_source_when_sidecars_conflict() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = temporary_settings_dir("reconcile-conflict");
+
+        let source_dir = directory.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_db = source_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&source_db, "existing data").unwrap();
+        let source_wal = source_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"));
+        std::fs::write(&source_wal, "source wal").unwrap();
+        let target_dir = directory.join(channel);
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let target_wal = target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"));
+        std::fs::write(&target_wal, "target wal").unwrap();
+
+        reconcile_default_channel_database(&directory)
+            .await
+            .unwrap();
+
+        // Neither the main database nor either WAL file is touched.
+        assert_eq!(
+            std::fs::read_to_string(&source_db).unwrap(),
+            "existing data"
+        );
+        assert_eq!(std::fs::read_to_string(&source_wal).unwrap(), "source wal");
+        assert_eq!(std::fs::read_to_string(&target_wal).unwrap(), "target wal");
+        assert!(!target_dir.join(LEGACY_APP_DB_FILE).exists());
 
         std::fs::remove_dir_all(&directory).unwrap();
     }

--- a/packages/app-lib/src/state/db.rs
+++ b/packages/app-lib/src/state/db.rs
@@ -1,4 +1,5 @@
 use crate::state::DirectoryInfo;
+use fs4::tokio::AsyncFileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
 use sqlx::migrate::{Migration, Migrator};
@@ -16,6 +17,9 @@ const LEGACY_APP_DB_FILE: &str = "app.db";
 // Records an in-flight channel database reconciliation inside the target
 // channel directory; see reconcile_default_channel_database.
 const CHANNEL_RECONCILE_MARKER_FILE: &str = ".channel-reconcile";
+// Serializes concurrent channel database reconciliations across processes
+// (see reconcile_default_channel_database).
+const CHANNEL_RECONCILE_LOCK_FILE: &str = ".channel-reconcile.lock";
 
 const INITIAL_MIGRATION_VERSION: i64 = 20240711194701;
 const COLLIDING_JAVA_DISCOVERY_MIGRATION_VERSION: i64 = 20260722120000;
@@ -192,7 +196,7 @@ pub async fn copy_database_between_channels(
         .ok_or(crate::ErrorKind::FSError(
             "Could not find valid config dir".to_string(),
         ))?;
-    let active_channel = read_update_channel(&settings_dir).await?;
+    let active_channel = resolve_update_channel(&settings_dir).await?;
     if target_channel == active_channel {
         return Err(crate::ErrorKind::InputError(
             "The active database cannot be overwritten while Axolotl is running".to_string(),
@@ -243,11 +247,11 @@ pub async fn backup_current_app_db_for_update(
 }
 
 async fn app_db_path(settings_dir: &Path) -> crate::Result<PathBuf> {
-    let channel = read_update_channel(settings_dir).await?;
+    let channel = resolve_update_channel(settings_dir).await?;
     Ok(settings_dir.join(channel).join(LEGACY_APP_DB_FILE))
 }
 
-async fn read_update_channel(
+async fn resolve_update_channel(
     settings_dir: &Path,
 ) -> crate::Result<&'static str> {
     Ok(read_explicit_update_channel(settings_dir)
@@ -380,6 +384,25 @@ async fn reconcile_default_channel_database(
         return Ok(());
     }
 
+    // Serialize first-run migrations across processes. The OS releases the
+    // lock automatically if we crash mid-migration, and a waiter re-runs the
+    // whole state machine below once it acquires the lock, so an interrupted
+    // attempt by another process is absorbed the same way a crashed one is.
+    let lock_path = settings_dir.join(CHANNEL_RECONCILE_LOCK_FILE);
+    crate::util::io::create_dir_all(settings_dir).await?;
+    let lock_file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .await?;
+    lock_file.lock_exclusive().map_err(|error| {
+        crate::ErrorKind::FSError(format!(
+            "Failed to lock {}: {error}",
+            lock_path.display()
+        ))
+    })?;
+
     let channel = default_update_channel();
     let other_channel = if channel == "release" {
         "beta"
@@ -506,13 +529,13 @@ async fn write_reconcile_marker(
 }
 
 async fn remove_reconcile_marker(marker: &Path) {
-    if let Err(error) = tokio::fs::remove_file(marker).await {
-        if error.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(
-                path = %marker.display(),
-                "Failed to remove channel reconciliation marker: {error}"
-            );
-        }
+    if let Err(error) = tokio::fs::remove_file(marker).await
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            path = %marker.display(),
+            "Failed to remove channel reconciliation marker: {error}"
+        );
     }
 }
 
@@ -2212,7 +2235,7 @@ mod tests {
             None
         );
         assert_eq!(
-            read_update_channel(settings_dir).await.unwrap(),
+            resolve_update_channel(settings_dir).await.unwrap(),
             default_update_channel()
         );
 
@@ -2226,7 +2249,7 @@ mod tests {
             None
         );
         assert_eq!(
-            read_update_channel(settings_dir).await.unwrap(),
+            resolve_update_channel(settings_dir).await.unwrap(),
             default_update_channel()
         );
     }
@@ -2245,7 +2268,10 @@ mod tests {
             read_explicit_update_channel(settings_dir).await.unwrap(),
             Some("release")
         );
-        assert_eq!(read_update_channel(settings_dir).await.unwrap(), "release");
+        assert_eq!(
+            resolve_update_channel(settings_dir).await.unwrap(),
+            "release"
+        );
 
         std::fs::write(
             settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
@@ -2256,7 +2282,7 @@ mod tests {
             read_explicit_update_channel(settings_dir).await.unwrap(),
             Some("beta")
         );
-        assert_eq!(read_update_channel(settings_dir).await.unwrap(), "beta");
+        assert_eq!(resolve_update_channel(settings_dir).await.unwrap(), "beta");
 
         std::fs::write(
             settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
@@ -2264,7 +2290,7 @@ mod tests {
         )
         .unwrap();
         assert!(read_explicit_update_channel(settings_dir).await.is_err());
-        assert!(read_update_channel(settings_dir).await.is_err());
+        assert!(resolve_update_channel(settings_dir).await.is_err());
     }
 
     #[tokio::test]

--- a/packages/app-lib/src/state/db.rs
+++ b/packages/app-lib/src/state/db.rs
@@ -1,4 +1,5 @@
 use crate::state::DirectoryInfo;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
 use sqlx::migrate::{Migration, Migrator};
 use sqlx::sqlite::{
@@ -12,6 +13,9 @@ static MIGRATOR: Migrator = sqlx::migrate!();
 
 const UPDATE_CHANNEL_STATE_FILE: &str = "update-channel.json";
 const LEGACY_APP_DB_FILE: &str = "app.db";
+// Records an in-flight channel database reconciliation inside the target
+// channel directory; see reconcile_default_channel_database.
+const CHANNEL_RECONCILE_MARKER_FILE: &str = ".channel-reconcile";
 
 const INITIAL_MIGRATION_VERSION: i64 = 20240711194701;
 const COLLIDING_JAVA_DISCOVERY_MIGRATION_VERSION: i64 = 20260722120000;
@@ -251,42 +255,78 @@ async fn read_update_channel(
         .unwrap_or_else(default_update_channel))
 }
 
+/// Persisted update channel state of the launcher.
+///
+/// Serialized to `update-channel.json` inside the settings directory (see
+/// [`update_channel_state_file_path`]). A missing file, or a file without an
+/// `active_channel` value, means the user has not chosen a channel yet; see
+/// [`default_update_channel`].
+#[derive(Default, Deserialize, Serialize)]
+pub struct UpdateChannelState {
+    pub active_channel: Option<String>,
+    pub immediate_update_fetch: Option<bool>,
+    pub updates_paused: Option<bool>,
+}
+
+/// Path of the update channel state file inside the settings directory.
+pub fn update_channel_state_file_path(settings_dir: &Path) -> PathBuf {
+    settings_dir.join(UPDATE_CHANNEL_STATE_FILE)
+}
+
+/// Reads the persisted update channel state.
+///
+/// A missing file is reported as the default state; malformed contents are
+/// reported as an error so each caller can decide how strictly to treat them.
+pub async fn read_update_channel_state(
+    settings_dir: &Path,
+) -> crate::Result<UpdateChannelState> {
+    let path = update_channel_state_file_path(settings_dir);
+    match tokio::fs::read_to_string(&path).await {
+        Ok(contents) => serde_json::from_str(&contents).map_err(|error| {
+            crate::ErrorKind::OtherError(format!(
+                "Failed to parse update channel state {}: {error}",
+                path.display()
+            ))
+            .into()
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(UpdateChannelState::default())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Reads the update channel the user explicitly chose, if any.
 ///
 /// Returns `None` when the user has not made a choice yet: either the
 /// `update-channel.json` file is missing, or it carries no `active_channel`
 /// value. This lets fresh installs fall back to the channel of the current
 /// build (see [`default_update_channel`]) instead of always defaulting to the
-/// Release channel.
+/// Release channel. Unreadable or malformed state files are treated as "no
+/// choice" here to keep startup resilient; strict callers can use
+/// [`read_update_channel_state`] directly.
 async fn read_explicit_update_channel(
     settings_dir: &Path,
 ) -> crate::Result<Option<&'static str>> {
-    let path = settings_dir.join(UPDATE_CHANNEL_STATE_FILE);
-    let contents = match tokio::fs::read_to_string(&path).await {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(None);
-        }
-        Err(error) => return Err(error.into()),
-    };
-    let channel = serde_json::from_str::<serde_json::Value>(&contents)
+    let Some(channel) = read_update_channel_state(settings_dir)
+        .await
         .ok()
-        .and_then(|value| {
-            value
-                .get("active_channel")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
-        });
+        .and_then(|state| state.active_channel)
+    else {
+        return Ok(None);
+    };
 
-    match channel.as_deref() {
-        Some("release") => Ok(Some("release")),
-        Some("beta") => Ok(Some("beta")),
-        None => Ok(None),
-        Some(other) => Err(crate::ErrorKind::FSError(format!(
-            "Invalid update channel {other:?} in {}",
-            path.display()
-        ))
-        .into()),
+    match channel.as_str() {
+        "release" => Ok(Some("release")),
+        "beta" => Ok(Some("beta")),
+        other => {
+            let path = update_channel_state_file_path(settings_dir);
+            Err(crate::ErrorKind::FSError(format!(
+                "Invalid update channel {other:?} in {}",
+                path.display()
+            ))
+            .into())
+        }
     }
 }
 
@@ -305,6 +345,10 @@ fn default_update_channel_for(version: &str) -> &'static str {
 
 /// Default update channel of the current build, used whenever the user has
 /// not explicitly chosen an update channel.
+///
+/// Derived at compile time from this crate's version (`CARGO_PKG_VERSION`),
+/// which the release workflow keeps in sync with the app version. Untagged
+/// development builds therefore inherit the channel of the most recent tag.
 pub fn default_update_channel() -> &'static str {
     default_update_channel_for(env!("CARGO_PKG_VERSION"))
 }
@@ -320,13 +364,15 @@ pub fn default_update_channel() -> &'static str {
 /// with an empty database in the default channel's directory.
 ///
 /// The `-wal` and `-shm` sidecars are moved before the main database, making
-/// the main database rename the commit point of the migration: any partial
-/// or failed attempt leaves the main database in the source directory, so a
-/// later startup either resumes the migration or leaves the source database
-/// intact. A sidecar is only moved when its target does not already exist;
-/// if a target sidecar is present alongside a source sidecar, the main
-/// database is left in place rather than risking a database whose WAL data
-/// would remain behind. Nothing is ever deleted or overwritten.
+/// the main database rename the commit point of the migration. Because a
+/// crashed attempt leaves those sidecars in the target directory without the
+/// main database - a shape that cannot be told apart from foreign leftover
+/// files by name alone - the migration first records which channel it is
+/// moving from in a marker file inside the target directory. The marker lets
+/// a later startup resume an interrupted migration, while target sidecars
+/// without a matching marker are treated as foreign and stop the migration
+/// before databases of different lineages could be mixed. Nothing is ever
+/// deleted or overwritten except the marker file, which this logic owns.
 async fn reconcile_default_channel_database(
     settings_dir: &Path,
 ) -> crate::Result<()> {
@@ -341,22 +387,67 @@ async fn reconcile_default_channel_database(
         "release"
     };
 
-    let target = settings_dir.join(channel).join(LEGACY_APP_DB_FILE);
+    let source = settings_dir.join(other_channel).join(LEGACY_APP_DB_FILE);
+    let target_dir = settings_dir.join(channel);
+    let target = target_dir.join(LEGACY_APP_DB_FILE);
+    let marker = target_dir.join(CHANNEL_RECONCILE_MARKER_FILE);
+
     if target.try_exists()? {
+        // A migration that completed but crashed before removing its marker
+        // leaves both the marker and an empty source directory behind.
+        if !source.try_exists()?
+            && matches!(
+                marker_matches(&marker, other_channel).await,
+                MarkerState::Matches
+            )
+        {
+            remove_reconcile_marker(&marker).await;
+        }
         return Ok(());
     }
-    let source = settings_dir.join(other_channel).join(LEGACY_APP_DB_FILE);
     if !source.try_exists()? {
         return Ok(());
     }
 
-    let target_dir = settings_dir.join(channel);
     crate::util::io::create_dir_all(&target_dir).await?;
 
-    let mut unresolved_sidecar = false;
+    match marker_matches(&marker, other_channel).await {
+        MarkerState::Missing => {
+            // Without a marker there is no way to claim a target sidecar as
+            // ours; it could belong to a different database of the same name,
+            // so refuse to move the main database next to it.
+            for suffix in ["-wal", "-shm"] {
+                if sidecar_path(&target, suffix).try_exists()? {
+                    tracing::warn!(
+                        source = %source.display(),
+                        destination = %target.display(),
+                        "Channel reconciliation aborted: the target channel \
+                         contains an unowned {suffix} file; the existing \
+                         database was left in place"
+                    );
+                    return Ok(());
+                }
+            }
+            write_reconcile_marker(&marker, other_channel).await?;
+        }
+        MarkerState::Mismatched => {
+            tracing::warn!(
+                marker = %marker.display(),
+                expected = other_channel,
+                "Channel reconciliation aborted: the target channel contains \
+                 a reconciliation marker from another migration; the existing \
+                 database was left in place"
+            );
+            return Ok(());
+        }
+        MarkerState::Matches => {}
+    }
+
+    let mut conflict = false;
     for suffix in ["-wal", "-shm"] {
         let source_sidecar = sidecar_path(&source, suffix);
         if !source_sidecar.try_exists()? {
+            // Already moved by an interrupted attempt, or never existed.
             continue;
         }
         let target_sidecar = sidecar_path(&target, suffix);
@@ -364,20 +455,20 @@ async fn reconcile_default_channel_database(
             tracing::warn!(
                 source = %source_sidecar.display(),
                 destination = %target_sidecar.display(),
-                channel,
-                "Both update channel databases have a {suffix} file; \
-                 leaving the existing database in place"
+                "Channel reconciliation aborted: both channels have a \
+                 {suffix} file; leaving the existing database in place"
             );
-            unresolved_sidecar = true;
+            conflict = true;
             continue;
         }
         tokio::fs::rename(&source_sidecar, &target_sidecar).await?;
     }
-    if unresolved_sidecar {
+    if conflict {
         return Ok(());
     }
 
     tokio::fs::rename(&source, &target).await?;
+    remove_reconcile_marker(&marker).await;
     tracing::info!(
         source = %source.display(),
         destination = %target.display(),
@@ -385,6 +476,44 @@ async fn reconcile_default_channel_database(
         "Moved the existing app database into the default update channel"
     );
     Ok(())
+}
+
+enum MarkerState {
+    Missing,
+    Mismatched,
+    Matches,
+}
+
+async fn marker_matches(marker: &Path, channel: &str) -> MarkerState {
+    match tokio::fs::read_to_string(marker).await {
+        Ok(contents) if contents == channel => MarkerState::Matches,
+        Ok(_) => MarkerState::Mismatched,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            MarkerState::Missing
+        }
+        Err(_) => MarkerState::Mismatched,
+    }
+}
+
+async fn write_reconcile_marker(
+    marker: &Path,
+    channel: &str,
+) -> crate::Result<()> {
+    let temporary_path = marker.with_extension("tmp");
+    tokio::fs::write(&temporary_path, channel).await?;
+    tokio::fs::rename(&temporary_path, marker).await?;
+    Ok(())
+}
+
+async fn remove_reconcile_marker(marker: &Path) {
+    if let Err(error) = tokio::fs::remove_file(marker).await {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                path = %marker.display(),
+                "Failed to remove channel reconciliation marker: {error}"
+            );
+        }
+    }
 }
 
 async fn migrate_legacy_release_database(
@@ -2056,17 +2185,6 @@ mod tests {
         assert!(foreign_key_errors.is_empty());
     }
 
-    fn temporary_settings_dir(test_name: &str) -> PathBuf {
-        let directory = std::env::temp_dir().join(format!(
-            "theseus-db-channel-test-{test_name}-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&directory);
-        std::fs::create_dir_all(&directory)
-            .expect("temporary settings directory should be created");
-        directory
-    }
-
     #[test]
     fn default_channel_resolves_from_version() {
         for (version, expected) in [
@@ -2086,69 +2204,67 @@ mod tests {
 
     #[tokio::test]
     async fn update_channel_falls_back_without_explicit_choice() {
-        let directory = temporary_settings_dir("build-default");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
         assert_eq!(
-            read_explicit_update_channel(&directory).await.unwrap(),
+            read_explicit_update_channel(settings_dir).await.unwrap(),
             None
         );
         assert_eq!(
-            read_update_channel(&directory).await.unwrap(),
+            read_update_channel(settings_dir).await.unwrap(),
             default_update_channel()
         );
 
         std::fs::write(
-            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
             r#"{"immediate_update_fetch":true}"#,
         )
         .unwrap();
         assert_eq!(
-            read_explicit_update_channel(&directory).await.unwrap(),
+            read_explicit_update_channel(settings_dir).await.unwrap(),
             None
         );
         assert_eq!(
-            read_update_channel(&directory).await.unwrap(),
+            read_update_channel(settings_dir).await.unwrap(),
             default_update_channel()
         );
-
-        std::fs::remove_dir_all(&directory).unwrap();
     }
 
     #[tokio::test]
     async fn update_channel_honors_explicit_selection() {
-        let directory = temporary_settings_dir("explicit-selection");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
         std::fs::write(
-            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
             r#"{"active_channel":"release"}"#,
         )
         .unwrap();
         assert_eq!(
-            read_explicit_update_channel(&directory).await.unwrap(),
+            read_explicit_update_channel(settings_dir).await.unwrap(),
             Some("release")
         );
-        assert_eq!(read_update_channel(&directory).await.unwrap(), "release");
+        assert_eq!(read_update_channel(settings_dir).await.unwrap(), "release");
 
         std::fs::write(
-            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
             r#"{"active_channel":"beta"}"#,
         )
         .unwrap();
         assert_eq!(
-            read_explicit_update_channel(&directory).await.unwrap(),
+            read_explicit_update_channel(settings_dir).await.unwrap(),
             Some("beta")
         );
-        assert_eq!(read_update_channel(&directory).await.unwrap(), "beta");
+        assert_eq!(read_update_channel(settings_dir).await.unwrap(), "beta");
 
         std::fs::write(
-            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
             r#"{"active_channel":"dev"}"#,
         )
         .unwrap();
-        assert!(read_explicit_update_channel(&directory).await.is_err());
-        assert!(read_update_channel(&directory).await.is_err());
-
-        std::fs::remove_dir_all(&directory).unwrap();
+        assert!(read_explicit_update_channel(settings_dir).await.is_err());
+        assert!(read_update_channel(settings_dir).await.is_err());
     }
 
     #[tokio::test]
@@ -2159,9 +2275,10 @@ mod tests {
         } else {
             "release"
         };
-        let directory = temporary_settings_dir("reconcile-move");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
-        let source_dir = directory.join(other);
+        let source_dir = settings_dir.join(other);
         std::fs::create_dir_all(&source_dir).unwrap();
         std::fs::write(source_dir.join(LEGACY_APP_DB_FILE), "existing data")
             .unwrap();
@@ -2171,11 +2288,11 @@ mod tests {
         )
         .unwrap();
 
-        reconcile_default_channel_database(&directory)
+        reconcile_default_channel_database(settings_dir)
             .await
             .unwrap();
 
-        let target_dir = directory.join(channel);
+        let target_dir = settings_dir.join(channel);
         assert_eq!(
             std::fs::read_to_string(target_dir.join(LEGACY_APP_DB_FILE))
                 .unwrap(),
@@ -2189,8 +2306,8 @@ mod tests {
             "wal"
         );
         assert!(!source_dir.join(LEGACY_APP_DB_FILE).exists());
-
-        std::fs::remove_dir_all(&directory).unwrap();
+        // The migration marker is removed once the move has completed.
+        assert!(!target_dir.join(CHANNEL_RECONCILE_MARKER_FILE).exists());
     }
 
     #[tokio::test]
@@ -2201,33 +2318,34 @@ mod tests {
         } else {
             "release"
         };
-        let directory = temporary_settings_dir("reconcile-keep");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
-        let source_dir = directory.join(other);
+        let source_dir = settings_dir.join(other);
         std::fs::create_dir_all(&source_dir).unwrap();
         let source_db = source_dir.join(LEGACY_APP_DB_FILE);
         std::fs::write(&source_db, "untouched").unwrap();
 
         // An explicit channel choice disables reconciliation entirely.
         std::fs::write(
-            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            settings_dir.join(UPDATE_CHANNEL_STATE_FILE),
             r#"{"active_channel":"release"}"#,
         )
         .unwrap();
-        reconcile_default_channel_database(&directory)
+        reconcile_default_channel_database(settings_dir)
             .await
             .unwrap();
         assert!(source_db.exists());
-        assert!(!directory.join(channel).join(LEGACY_APP_DB_FILE).exists());
+        assert!(!settings_dir.join(channel).join(LEGACY_APP_DB_FILE).exists());
 
         // An existing database in the default channel is left alone.
-        std::fs::remove_file(directory.join(UPDATE_CHANNEL_STATE_FILE))
+        std::fs::remove_file(settings_dir.join(UPDATE_CHANNEL_STATE_FILE))
             .unwrap();
-        let default_dir = directory.join(channel);
+        let default_dir = settings_dir.join(channel);
         std::fs::create_dir_all(&default_dir).unwrap();
         let default_db = default_dir.join(LEGACY_APP_DB_FILE);
         std::fs::write(&default_db, "default data").unwrap();
-        reconcile_default_channel_database(&directory)
+        reconcile_default_channel_database(settings_dir)
             .await
             .unwrap();
         assert_eq!(
@@ -2235,8 +2353,6 @@ mod tests {
             "default data"
         );
         assert_eq!(std::fs::read_to_string(&source_db).unwrap(), "untouched");
-
-        std::fs::remove_dir_all(&directory).unwrap();
     }
 
     #[tokio::test]
@@ -2247,22 +2363,26 @@ mod tests {
         } else {
             "release"
         };
-        let directory = temporary_settings_dir("reconcile-resume");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
-        // A previous attempt crashed after moving the -wal sidecar.
-        let source_dir = directory.join(other);
+        // A previous attempt crashed after writing its marker and moving the
+        // -wal sidecar; the marker attributes those files to this migration.
+        let source_dir = settings_dir.join(other);
         std::fs::create_dir_all(&source_dir).unwrap();
         let source_db = source_dir.join(LEGACY_APP_DB_FILE);
         std::fs::write(&source_db, "existing data").unwrap();
-        let target_dir = directory.join(channel);
+        let target_dir = settings_dir.join(channel);
         std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join(CHANNEL_RECONCILE_MARKER_FILE), other)
+            .unwrap();
         std::fs::write(
             target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal")),
             "wal",
         )
         .unwrap();
 
-        reconcile_default_channel_database(&directory)
+        reconcile_default_channel_database(settings_dir)
             .await
             .unwrap();
 
@@ -2279,36 +2399,116 @@ mod tests {
             "wal"
         );
         assert!(!source_db.exists());
-
-        std::fs::remove_dir_all(&directory).unwrap();
+        assert!(!target_dir.join(CHANNEL_RECONCILE_MARKER_FILE).exists());
     }
 
     #[tokio::test]
-    async fn reconcile_keeps_source_when_sidecars_conflict() {
+    async fn reconcile_aborts_on_foreign_orphan_sidecar() {
         let channel = default_update_channel();
         let other = if channel == "release" {
             "beta"
         } else {
             "release"
         };
-        let directory = temporary_settings_dir("reconcile-conflict");
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
 
-        let source_dir = directory.join(other);
+        // The target channel holds a WAL file that no migration marker claims;
+        // it may belong to a different database of the same name.
+        let source_dir = settings_dir.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_db = source_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&source_db, "existing data").unwrap();
+        let target_dir = settings_dir.join(channel);
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let target_wal = target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"));
+        std::fs::write(&target_wal, "foreign wal").unwrap();
+
+        reconcile_default_channel_database(settings_dir)
+            .await
+            .unwrap();
+
+        // Nothing is moved, created, or deleted.
+        assert_eq!(
+            std::fs::read_to_string(&source_db).unwrap(),
+            "existing data"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target_wal).unwrap(),
+            "foreign wal"
+        );
+        assert!(!target_dir.join(LEGACY_APP_DB_FILE).exists());
+        assert!(!target_dir.join(CHANNEL_RECONCILE_MARKER_FILE).exists());
+    }
+
+    #[tokio::test]
+    async fn reconcile_aborts_on_mismatched_marker() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
+
+        let source_dir = settings_dir.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_db = source_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&source_db, "existing data").unwrap();
+        let target_dir = settings_dir.join(channel);
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join(CHANNEL_RECONCILE_MARKER_FILE), channel)
+            .unwrap();
+
+        reconcile_default_channel_database(settings_dir)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&source_db).unwrap(),
+            "existing data"
+        );
+        assert!(!target_dir.join(LEGACY_APP_DB_FILE).exists());
+        assert_eq!(
+            std::fs::read_to_string(
+                target_dir.join(CHANNEL_RECONCILE_MARKER_FILE)
+            )
+            .unwrap(),
+            channel
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_aborts_when_target_sidecar_appears_mid_flight() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
+
+        // The marker matches, but a foreign sidecar appeared next to the one
+        // this migration already moved; do not move the main database.
+        let source_dir = settings_dir.join(other);
         std::fs::create_dir_all(&source_dir).unwrap();
         let source_db = source_dir.join(LEGACY_APP_DB_FILE);
         std::fs::write(&source_db, "existing data").unwrap();
         let source_wal = source_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"));
         std::fs::write(&source_wal, "source wal").unwrap();
-        let target_dir = directory.join(channel);
+        let target_dir = settings_dir.join(channel);
         std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join(CHANNEL_RECONCILE_MARKER_FILE), other)
+            .unwrap();
         let target_wal = target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"));
         std::fs::write(&target_wal, "target wal").unwrap();
 
-        reconcile_default_channel_database(&directory)
+        reconcile_default_channel_database(settings_dir)
             .await
             .unwrap();
 
-        // Neither the main database nor either WAL file is touched.
         assert_eq!(
             std::fs::read_to_string(&source_db).unwrap(),
             "existing data"
@@ -2316,8 +2516,38 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&source_wal).unwrap(), "source wal");
         assert_eq!(std::fs::read_to_string(&target_wal).unwrap(), "target wal");
         assert!(!target_dir.join(LEGACY_APP_DB_FILE).exists());
+        assert!(target_dir.join(CHANNEL_RECONCILE_MARKER_FILE).exists());
+    }
 
-        std::fs::remove_dir_all(&directory).unwrap();
+    #[tokio::test]
+    async fn reconcile_cleans_up_marker_after_commit_crash() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = tempfile::tempdir().unwrap();
+        let settings_dir = directory.path();
+
+        // The main database was moved, but the process crashed before the
+        // marker could be removed.
+        let target_dir = settings_dir.join(channel);
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let default_db = target_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&default_db, "default data").unwrap();
+        std::fs::write(target_dir.join(CHANNEL_RECONCILE_MARKER_FILE), other)
+            .unwrap();
+
+        reconcile_default_channel_database(settings_dir)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&default_db).unwrap(),
+            "default data"
+        );
+        assert!(!target_dir.join(CHANNEL_RECONCILE_MARKER_FILE).exists());
     }
 
     fn initial_migration() -> &'static Migration {

--- a/packages/app-lib/src/state/db.rs
+++ b/packages/app-lib/src/state/db.rs
@@ -89,6 +89,7 @@ pub(crate) async fn connect(
     crate::util::io::create_dir_all(&settings_dir).await?;
 
     migrate_legacy_release_database(&settings_dir).await?;
+    reconcile_default_channel_database(&settings_dir).await?;
     let db_path = app_db_path(&settings_dir).await?;
     let db_dir = db_path.parent().ok_or_else(|| {
         crate::ErrorKind::FSError(format!(
@@ -245,11 +246,26 @@ async fn app_db_path(settings_dir: &Path) -> crate::Result<PathBuf> {
 async fn read_update_channel(
     settings_dir: &Path,
 ) -> crate::Result<&'static str> {
+    Ok(read_explicit_update_channel(settings_dir)
+        .await?
+        .unwrap_or_else(default_update_channel))
+}
+
+/// Reads the update channel the user explicitly chose, if any.
+///
+/// Returns `None` when the user has not made a choice yet: either the
+/// `update-channel.json` file is missing, or it carries no `active_channel`
+/// value. This lets fresh installs fall back to the channel of the current
+/// build (see [`default_update_channel`]) instead of always defaulting to the
+/// Release channel.
+async fn read_explicit_update_channel(
+    settings_dir: &Path,
+) -> crate::Result<Option<&'static str>> {
     let path = settings_dir.join(UPDATE_CHANNEL_STATE_FILE);
     let contents = match tokio::fs::read_to_string(&path).await {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok("release");
+            return Ok(None);
         }
         Err(error) => return Err(error.into()),
     };
@@ -263,14 +279,86 @@ async fn read_update_channel(
         });
 
     match channel.as_deref() {
-        Some("beta") => Ok("beta"),
-        Some("release") | None => Ok("release"),
+        Some("release") => Ok(Some("release")),
+        Some("beta") => Ok(Some("beta")),
+        None => Ok(None),
         Some(other) => Err(crate::ErrorKind::FSError(format!(
             "Invalid update channel {other:?} in {}",
             path.display()
         ))
         .into()),
     }
+}
+
+/// Resolves the default update channel for a given app version.
+///
+/// The Release channel is the only stable channel, so any version carrying a
+/// pre-release segment (`-beta`, `-rc`, ...) belongs to a pre-release channel.
+/// The launcher currently ships a single pre-release channel, Beta; additional
+/// channels can be mapped here as they are introduced.
+fn default_update_channel_for(version: &str) -> &'static str {
+    match version.split_once('-') {
+        None => "release",
+        Some(_) => "beta",
+    }
+}
+
+/// Default update channel of the current build, used whenever the user has
+/// not explicitly chosen an update channel.
+pub fn default_update_channel() -> &'static str {
+    default_update_channel_for(env!("CARGO_PKG_VERSION"))
+}
+
+/// When the user has not explicitly chosen an update channel, keeps an
+/// existing app database aligned with the update channel of the current
+/// build.
+///
+/// Fresh pre-release builds previously fell back to the Release channel and
+/// created their database under `<settings>/release/app.db`. If such a
+/// database exists while the build's own default channel has none, move it
+/// over so the database follows the build instead of silently starting over
+/// with an empty database in the default channel's directory.
+async fn reconcile_default_channel_database(
+    settings_dir: &Path,
+) -> crate::Result<()> {
+    if read_explicit_update_channel(settings_dir).await?.is_some() {
+        return Ok(());
+    }
+
+    let channel = default_update_channel();
+    let other_channel = if channel == "release" {
+        "beta"
+    } else {
+        "release"
+    };
+
+    let target = settings_dir.join(channel).join(LEGACY_APP_DB_FILE);
+    if target.try_exists()? {
+        return Ok(());
+    }
+    let source = settings_dir.join(other_channel).join(LEGACY_APP_DB_FILE);
+    if !source.try_exists()? {
+        return Ok(());
+    }
+
+    let target_dir = settings_dir.join(channel);
+    crate::util::io::create_dir_all(&target_dir).await?;
+    tokio::fs::rename(&source, &target).await?;
+    for suffix in ["-wal", "-shm"] {
+        let source_sidecar = sidecar_path(&source, suffix);
+        if source_sidecar.try_exists()? {
+            tokio::fs::rename(source_sidecar, sidecar_path(&target, suffix))
+                .await?;
+        }
+    }
+
+    tracing::info!(
+        source = %source.display(),
+        destination = %target.display(),
+        channel,
+        "Moved the existing app database into the default update channel"
+    );
+    Ok(())
 }
 
 async fn migrate_legacy_release_database(
@@ -1940,6 +2028,189 @@ mod tests {
                 .await
                 .unwrap();
         assert!(foreign_key_errors.is_empty());
+    }
+
+    fn temporary_settings_dir(test_name: &str) -> PathBuf {
+        let directory = std::env::temp_dir().join(format!(
+            "theseus-db-channel-test-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(&directory)
+            .expect("temporary settings directory should be created");
+        directory
+    }
+
+    #[test]
+    fn default_channel_resolves_from_version() {
+        for (version, expected) in [
+            ("1.9.6", "release"),
+            ("1.9.6.0", "release"),
+            ("1.9.6-beta.3", "beta"),
+            ("1.9.6-rc.1", "beta"),
+            ("1.9.6-alpha.2", "beta"),
+        ] {
+            assert_eq!(
+                default_update_channel_for(version),
+                expected,
+                "unexpected default channel for {version}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_channel_falls_back_without_explicit_choice() {
+        let directory = temporary_settings_dir("build-default");
+
+        assert_eq!(
+            read_explicit_update_channel(&directory).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            read_update_channel(&directory).await.unwrap(),
+            default_update_channel()
+        );
+
+        std::fs::write(
+            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            r#"{"immediate_update_fetch":true}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_explicit_update_channel(&directory).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            read_update_channel(&directory).await.unwrap(),
+            default_update_channel()
+        );
+
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_channel_honors_explicit_selection() {
+        let directory = temporary_settings_dir("explicit-selection");
+
+        std::fs::write(
+            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            r#"{"active_channel":"release"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_explicit_update_channel(&directory).await.unwrap(),
+            Some("release")
+        );
+        assert_eq!(read_update_channel(&directory).await.unwrap(), "release");
+
+        std::fs::write(
+            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            r#"{"active_channel":"beta"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_explicit_update_channel(&directory).await.unwrap(),
+            Some("beta")
+        );
+        assert_eq!(read_update_channel(&directory).await.unwrap(), "beta");
+
+        std::fs::write(
+            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            r#"{"active_channel":"dev"}"#,
+        )
+        .unwrap();
+        assert!(read_explicit_update_channel(&directory).await.is_err());
+        assert!(read_update_channel(&directory).await.is_err());
+
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_moves_database_without_explicit_choice() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = temporary_settings_dir("reconcile-move");
+
+        let source_dir = directory.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::write(source_dir.join(LEGACY_APP_DB_FILE), "existing data")
+            .unwrap();
+        std::fs::write(
+            source_dir.join(format!("{LEGACY_APP_DB_FILE}-wal")),
+            "wal",
+        )
+        .unwrap();
+
+        reconcile_default_channel_database(&directory)
+            .await
+            .unwrap();
+
+        let target_dir = directory.join(channel);
+        assert_eq!(
+            std::fs::read_to_string(target_dir.join(LEGACY_APP_DB_FILE))
+                .unwrap(),
+            "existing data"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                target_dir.join(format!("{LEGACY_APP_DB_FILE}-wal"))
+            )
+            .unwrap(),
+            "wal"
+        );
+        assert!(!source_dir.join(LEGACY_APP_DB_FILE).exists());
+
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_never_overwrites_or_deletes() {
+        let channel = default_update_channel();
+        let other = if channel == "release" {
+            "beta"
+        } else {
+            "release"
+        };
+        let directory = temporary_settings_dir("reconcile-keep");
+
+        let source_dir = directory.join(other);
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_db = source_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&source_db, "untouched").unwrap();
+
+        // An explicit channel choice disables reconciliation entirely.
+        std::fs::write(
+            directory.join(UPDATE_CHANNEL_STATE_FILE),
+            r#"{"active_channel":"release"}"#,
+        )
+        .unwrap();
+        reconcile_default_channel_database(&directory)
+            .await
+            .unwrap();
+        assert!(source_db.exists());
+        assert!(!directory.join(channel).join(LEGACY_APP_DB_FILE).exists());
+
+        // An existing database in the default channel is left alone.
+        std::fs::remove_file(directory.join(UPDATE_CHANNEL_STATE_FILE))
+            .unwrap();
+        let default_dir = directory.join(channel);
+        std::fs::create_dir_all(&default_dir).unwrap();
+        let default_db = default_dir.join(LEGACY_APP_DB_FILE);
+        std::fs::write(&default_db, "default data").unwrap();
+        reconcile_default_channel_database(&directory)
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&default_db).unwrap(),
+            "default data"
+        );
+        assert_eq!(std::fs::read_to_string(&source_db).unwrap(), "untouched");
+
+        std::fs::remove_dir_all(&directory).unwrap();
     }
 
     fn initial_migration() -> &'static Migration {


### PR DESCRIPTION
## 概述

修复 #528：当 `update-channel.json` 不存在（用户从未显式设置 `active_channel`）时，代码将默认更新频道解析为 `release`。由于应用数据库路径由频道决定（`<settings_dir>/{release|beta}/app.db`），**Beta 构建首次启动会错误地打开并修改 Release 应用数据库**，存在数据库 schema / migration 错配风险。

## 根因

无显式选择时默认回落 `"release"` 共有三处，其中两处为本修复目标：

| 位置 | 原行为 | 修复后 |
|---|---|---|
| `packages/app-lib/src/state/db.rs` `read_update_channel` | 文件缺失或 `active_channel` 缺失 → `"release"`（决定 app.db 路径） | 回落当前构建的默认频道 |
| `apps/app/src/main.rs` `get_update_channel` | `None` → `"release"`（设置页展示、更新检查） | 同上 |
| `apps/app/src/main.rs` `get_update_preferences` | `is_beta` 仅认显式 `active_channel` | 基于有效频道（含默认）保持一致 |

判定依据：仓库没有区分 Beta/Release 构建的编译期特性，现有事实标准是版本号（发布工具链 `publish-update-server.mjs` 即以 `version.includes('-')` 判定 beta 频道，且 `Cargo.toml` 版本由发布流程同步写入）。

## 改动

- **`packages/app-lib/src/state/db.rs`**
  - 新增 `default_update_channel()`：采用"反向判定"——`release` 是唯一稳定频道，任何带 `-` 预发布段的版本（`-beta`/`-rc`/…）默认进入预发行频道（当前为 `beta`，未来新增频道只需扩展此映射）。
  - 拆分出 `read_explicit_update_channel()`：文件缺失或未携带 `active_channel` 视为"用户未选择"，由调用方回落构建默认频道。
  - 新增 `reconcile_default_channel_database()` 并在 `connect()` 启动路径挂载：当用户未显式选择频道、且当前构建默认频道的数据库不存在而另一频道目录中留有数据库时，将既有数据库（含 `-wal`/`-shm`）搬入当前构建频道，**避免携带此 bug 的旧 Beta 版本用户升级后数据看似丢失**。绝不删除任何数据库。
- **`packages/app-lib/src/lib.rs`**：re-export `default_update_channel` 及 `UpdateChannelState`、频道状态读取/路径 API，GUI 与库共用同一判定与解析规则。
- **`apps/app/src/main.rs`**：`get_update_channel`、`get_update_preferences` 的默认值改用 `theseus::default_update_channel()`。
- 前端无需改动：后端返回 `"beta"` 后，频道展示、更新检查与公告请求自动保持一致。

## 行为对照

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 全新安装 Beta 构建（无频道文件） | active=release，使用 `release/app.db` | active=beta，使用 `beta/app.db` |
| 全新安装 Release 构建（无频道文件） | `release/app.db` | 不变 |
| 旧版 Beta 用户升级（数据遗留在 `release/app.db`、未显式选择） | — | 启动对账：搬移至 `beta/app.db`，数据保留 |
| 用户显式设置过频道 | 以用户选择为准 | 不变（显式选择始终优先，不覆盖不搬移） |

## 验证

- 新增 10 个单元测试（`cargo test -p theseus --lib`，过滤 `channel`/`reconcile`）：版本判定、显式选择优先、文件缺失回落默认频道、对账搬移（含 sidecar）、不覆盖不删除、中断恢复、孤儿 sidecar 中止、marker 冲突与清理——全部通过。
- `cargo check -p theseus_gui --features updater` 通过（与贡献指南一致）。
- 新增代码无 clippy 告警、`cargo fmt --check` 干净。

Closes #528

## Sourcery 摘要

使默认更新频道选择与构建版本保持一致，并安全地协调现有应用数据库，以防止 Beta/Release 数据库混用。

错误修复：
- 在未明确选择更新频道时，使用当前构建版本的默认更新频道，防止 Beta 构建打开 Release 应用数据库。
- 对受影响的用户，将现有数据库和 SQLite 侧边文件迁移到当前默认频道，同时避免覆盖或删除数据。

改进：
- 在应用 GUI 和应用库之间共享更新频道解析逻辑，并根据有效频道设置 Beta 更新偏好。
- 保留用户明确选择的频道，并将缺失或不完整的频道状态视为未明确选择。

测试：
- 增加对基于版本的频道解析、明确选择优先级、回退行为以及安全数据库协调的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使默认更新频道的选择与构建版本保持一致，并安全地协调现有应用数据库，以防止 Beta/Release 数据库混用。

Bug 修复：
- 在未明确选择更新频道时，使用当前构建版本的默认更新频道，防止 Beta 构建打开 Release 应用数据库。
- 对受影响的用户，将现有数据库和 SQLite sidecar 文件迁移到当前构建版本的默认频道，同时不会覆盖或删除数据。

增强功能：
- 在应用 GUI 和应用库之间共享更新频道解析逻辑，同时保留用户明确选择的频道，并将 Beta 偏好应用到实际生效的频道。

测试：
- 增加对基于版本的频道解析、回退行为、明确选择以及安全数据库协调的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使默认更新渠道的选择与构建版本保持一致，并保护现有应用数据，避免 Beta/Release 数据库混用。

错误修复：
- 在未明确选择更新渠道时，使用当前构建版本的默认更新渠道，防止 Beta 构建打开 Release 应用数据库。
- 对受影响用户，将现有数据库和 SQLite 辅助文件安全地协调到当前默认渠道，同时避免覆盖或删除数据。

增强功能：
- 在应用 GUI 和应用库之间共享更新渠道状态处理逻辑，同时保留用户明确选择的渠道，并将偏好设置应用到实际生效的渠道。

测试：
- 增加对基于版本的渠道解析、明确选择优先级、回退行为、中断协调过程，以及防止冲突或意外数据丢失等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使默认更新频道选择与构建版本保持一致，并保护现有应用数据，避免 Beta/Release 数据库混用。

Bug 修复：
- 在未明确选择更新频道时，使用当前构建版本的默认更新频道，防止 Beta 构建打开 Release 应用数据库。
- 将现有应用数据库和 SQLite 辅助文件安全地同步到当前默认频道，同时保留数据并避免覆盖或删除。

增强功能：
- 在应用程序库和 GUI 之间共享更新频道状态解析和默认频道解析逻辑，同时遵循用户的明确选择，并将偏好设置应用于实际使用的频道。

测试：
- 增加对基于版本的频道解析、明确选择优先级、回退行为、中断的同步过程、辅助文件冲突、标记冲突以及安全迁移处理的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使默认更新频道的选择与构建版本保持一致，并保护现有应用数据，避免 Beta/Release 数据库混用。

错误修复：
- 在未明确选择更新频道时，使用当前构建版本的默认更新频道，防止 Beta 构建打开 Release 应用数据库。
- 对受影响用户，将现有数据库和 SQLite 附属文件安全地整合到当前默认频道中，不覆盖或删除数据。

增强功能：
- 在应用 GUI 和应用库之间共享更新频道状态及解析逻辑，同时保留用户的明确选择，并将偏好设置应用于实际使用的频道。

测试：
- 增加针对基于版本的频道选择、明确选择优先级、回退行为、中断的整合操作、冲突处理以及数据保护机制的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align default update-channel selection with the build version and protect existing application data from Beta/Release database mix-ups.

Bug Fixes:
- Use the current build’s default update channel when no channel has been explicitly selected, preventing Beta builds from opening the Release application database.
- Safely reconcile existing databases and SQLite sidecar files into the current default channel for affected users without overwriting or deleting data.

Enhancements:
- Share update-channel state and resolution logic between the application GUI and app library while preserving explicit user selections and applying preferences to the effective channel.

Tests:
- Add coverage for version-based channel selection, explicit-choice precedence, fallback behavior, interrupted reconciliation, conflict handling, and data-preservation safeguards.

</details>

</details>

</details>

</details>

</details>