### PR TITLE
fix(Settings): incorrect license url

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -38,7 +38,7 @@ let pressStart = { x: 0, y: 0 }
 let suppressNextMemberClick = false
 const replayOnboarding = inject<(mode: 'main' | 'instance') => Promise<void>>('replayOnboarding')
 
-const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/LICENSE`
+const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/apps/app/LICENSE`
 const thirdPartyLicensesUrl = `${AxolotlBrandConfig.repositoryUrl}/tree/main/third-party/licenses`
 
 async function copyQqGroupNumber() {

--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -231,7 +231,7 @@ const messages = defineMessages({
 		defaultMessage: 'Project license (GPL-3.0)',
 	},
 	copyingLicense: {
-    	id: 'app.settings.about.copying-license',
+    	id: 'app.settings.about.copying-guidelines',
     	defaultMessage: 'Copying guidelines',
 	},
 	thirdPartyLicenses: {

--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -39,6 +39,7 @@ let suppressNextMemberClick = false
 const replayOnboarding = inject<(mode: 'main' | 'instance') => Promise<void>>('replayOnboarding')
 
 const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/apps/app/LICENSE`
+const copyingUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/COPYING.md`
 const thirdPartyLicensesUrl = `${AxolotlBrandConfig.repositoryUrl}/tree/main/third-party/licenses`
 
 async function copyQqGroupNumber() {
@@ -228,6 +229,10 @@ const messages = defineMessages({
 	projectLicense: {
 		id: 'app.settings.about.project-license',
 		defaultMessage: 'Project license (GPL-3.0)',
+	},
+	copyingLicense: {
+    	id: 'app.settings.about.copying-license',
+    	defaultMessage: 'Copying guidelines',
 	},
 	thirdPartyLicenses: {
 		id: 'app.settings.about.third-party-licenses',
@@ -462,6 +467,15 @@ const projectLinks = [
 				>
 					{{ formatMessage(messages.projectLicense) }}
 					<ExternalIcon class="size-4 text-secondary" />
+				</a>
+				<a
+				    :href="copyingUrl"
+				    target="_blank"
+				    rel="noopener noreferrer"
+				    class="inline-flex items-center gap-2 rounded-lg bg-surface-4 px-3 py-2 text-sm font-semibold text-contrast transition-colors hover:bg-surface-5"
+				>
+				    {{ formatMessage(messages.copyingGuidelines) }}
+				    <ExternalIcon class="size-4 text-secondary" />
 				</a>
 				<a
 					:href="thirdPartyLicensesUrl"

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6875,6 +6875,9 @@
   "app.settings.about.project-license": {
     "message": "Project license (GPL-3.0)"
   },
+  "app.settings.about.copying-guidelines": {
+    "defaultMessage": "Copying guidelines"
+  },
   "app.settings.about.project-website": {
     "message": "Project website"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6881,6 +6881,9 @@
   "app.settings.about.project-license": {
     "message": "项目许可证（GPL-3.0）"
   },
+  "app.settings.about.copying-guidelines": {
+    "defaultMessage": "复制准则"
+  },
   "app.settings.about.project-website": {
     "message": "项目网站"
   },


### PR DESCRIPTION
设置页面的许可证按钮跳转的链接错误了，当前点击按钮跳转显示没有文件，正确的地址应为：**/blob/main/apps/app/LICENSE**

## Sourcery 总结

错误修复：
- 修正“设置”页面中的许可证链接，使其指向应用程序许可证文件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正“设置”页面中的项目链接，以便用户访问应用程序许可证和复制指南。

新功能：
- 在“设置”页面添加指向仓库复制指南的链接。

错误修复：
- 修正项目许可证链接，使其指向应用程序的许可证文件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新“设置”项目链接，以提供准确的应用许可和复制指南资源。

新功能：
- 在“设置”页面添加指向代码仓库复制指南的链接。

错误修复：
- 修正“设置”页面的许可证链接，使其指向应用许可证文件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

更新“设置”页面中的项目链接，以提供准确的许可证和复制指南资源。

新功能：
- 在“设置”页面添加指向仓库复制指南的链接。

错误修复：
- 修正项目许可证链接，使其指向应用程序许可证文件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

更新 Settings 项目链接，以提供准确的许可证和复制指南资源。

新功能：
- 在 Settings 中添加指向仓库复制指南的链接。

错误修复：
- 修正 Settings 中的许可证链接，使其指向应用程序的许可证文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Settings project links to provide accurate license and copying-guideline resources.

New Features:
- Add a Settings link to the repository’s copying guidelines.

Bug Fixes:
- Correct the Settings license link to point to the application’s license file.

</details>

</details>

</details>

</details>

</details>