### PR TITLE
feat: 迁移 revert 自动推导 + 一键 new/renumber + 同步在飞 PR

### DIFF
--- a/.github/workflows/axolotl-ci.yml
+++ b/.github/workflows/axolotl-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - run: node scripts/axolotl/brand-guard.mjs
       - run: node scripts/axolotl/i18n-check.mjs
       - run: node scripts/axolotl/downgrade-app-db.test.mjs
+      - run: node scripts/axolotl/migration.test.mjs
       - run: cargo fmt --all --check
 
   desktop:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ node scripts/axolotl/downgrade-app-db.mjs --suffix pr538 --to 20260903120000 --a
 - 合并上游后若迁移版本撞车，用 `node scripts/axolotl/migration.mjs renumber <旧> <新>` 改名（只改文件名）。
 - 某个 PR 合并进 main 后，可运行 `node scripts/axolotl/sync-open-prs.mjs`（或 `--dry-run`）把其余在飞 PR 分支 merge 到最新 main。
 
-该脚本依赖 Node 内置的 `node:sqlite`，并要求 Windows（解析默认数据目录需要 `APPDATA`；其他平台请用 `--db` 指定路径）。
+该脚本依赖 Node 内置的 `node:sqlite`，并要求 Windows（解析默认数据目录需要 `APPDATA`；其他平台请用 `--db` 指定路径）。`migration.mjs` / `sync-open-prs.mjs` 无此限制。
 
 ## 仓库范围
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,11 @@ node scripts/axolotl/downgrade-app-db.mjs --suffix pr538 --to 20260903120000 --a
 
 脚本的几条硬性约束，遇到时请照提示处理而不是绕过：
 
-- 只认识登记在案的迁移结构。遇到未登记的迁移会**拒绝执行**，因为删掉记录却留下它建的列/表，会让重新安装该构建时因对象重复而失败；确认无碍时用 `--allow-unmapped` 显式放行。
-- 若某个已登记迁移对应的列在库里不存在，说明登记的表结构与数据库不符（版本号被复用、列被改名等），脚本同样拒绝执行。
-- 新增**列**的迁移时，请在 `scripts/axolotl/downgrade-app-db.mjs` 的 `REVERTIBLE_COLUMNS` 里登记它建的每一列，否则越过它的降级会被拒绝。只做数据增删（DELETE/UPDATE）的迁移也要登记一个空数组——它没有列可删，但登记了才不会挡住降级。新增**表**的迁移目前没有登记机制，只能手工处理。
+- 只认识从迁移 SQL 自动推导出的结构（`scripts/axolotl/migration-revert.mjs`）。版本号早于 `OLDEST_REVERTIBLE_VERSION` 的迁移不在推导范围内，越过它们的降级会**拒绝执行**；确认无碍时用 `--allow-unmapped` 显式放行。
+- 若推导出的列在库里不存在，说明迁移与数据库不符（版本号被复用、列被改名等），脚本同样拒绝执行。
+- 新增迁移请用 `node scripts/axolotl/migration.mjs new <slug>`（自动选 max+1 版本）。`ADD COLUMN` 会被降级脚本自动识别，无需再手写映射表；`CREATE TABLE` 目前不会被 DROP，降级时会提示表会留下。
+- 合并上游后若迁移版本撞车，用 `node scripts/axolotl/migration.mjs renumber <旧> <新>` 改名（只改文件名）。
+- 某个 PR 合并进 main 后，可运行 `node scripts/axolotl/sync-open-prs.mjs`（或 `--dry-run`）把其余在飞 PR 分支 merge 到最新 main。
 
 该脚本依赖 Node 内置的 `node:sqlite`，并要求 Windows（解析默认数据目录需要 `APPDATA`；其他平台请用 `--db` 指定路径）。
 

--- a/scripts/axolotl/downgrade-app-db.mjs
+++ b/scripts/axolotl/downgrade-app-db.mjs
@@ -440,9 +440,10 @@ function reportPlan({ applied, failed, plan }) {
 
 	if (failed.length > 0) {
 		note(
-			`\nwarning: ${failed.join(', ')} are recorded as FAILED migrations. Removing their\n` +
-				'records lets a build that carries them try again, but a half-applied migration\n' +
-				'may have left the schema in a state neither build expects.',
+			`\nwarning: ${failed.join(', ')} are recorded as FAILED migrations. Their records\n` +
+				'are removed together with the successful ones so a build that carries them can\n' +
+				'try again, but a half-applied migration may have left the schema in a state\n' +
+				'neither build expects.',
 		)
 	}
 }
@@ -466,6 +467,27 @@ function checkMappings(plan) {
 
 function unmappedVersions(plan) {
 	return plan.filter(({ mapped }) => !mapped).map(({ version }) => version)
+}
+
+function createdTableVersions(plan) {
+	return plan
+		.filter(({ createdTables }) => createdTables.length > 0)
+		.map(({ version, createdTables }) => ({ version, createdTables }))
+}
+
+function checkCreatedTables(plan) {
+	const risky = createdTableVersions(plan)
+	if (risky.length === 0) return
+
+	const details = risky
+		.map(({ version, createdTables }) => `${version} (${createdTables.join(', ')})`)
+		.join('; ')
+	fail(
+		`${details} created tables this script will not drop. Removing only the migration\n` +
+			'record leaves objects behind, and reinstalling that build fails on\n' +
+			'"table already exists". Drop those objects by hand after inspecting the backup,\n' +
+			'or downgrade to a version before this migration instead.',
+	)
 }
 
 function main() {
@@ -508,9 +530,17 @@ function main() {
 	}
 
 	if (!args.apply) {
+		const risky = createdTableVersions(state.plan)
+		if (risky.length > 0) {
+			note(
+				'\nnote: --apply will refuse migrations that created tables this script will not drop.',
+			)
+		}
 		note('\ndry run: rerun with --apply to perform the downgrade')
 		return
 	}
+
+	checkCreatedTables(state.plan)
 
 	const running = runningLauncher()
 	if (running) {
@@ -534,9 +564,12 @@ function main() {
 					if (present) writable.exec(`ALTER TABLE ${table} DROP COLUMN ${column}`)
 				}
 			}
-			writable
-				.prepare(`DELETE FROM _sqlx_migrations WHERE version IN (${state.applied.join(', ')})`)
-				.run()
+			const versions = [...state.applied, ...state.failed]
+			if (versions.length > 0) {
+				writable
+					.prepare(`DELETE FROM _sqlx_migrations WHERE version IN (${versions.join(', ')})`)
+					.run()
+			}
 			writable.exec('COMMIT')
 		} catch (error) {
 			writable.exec('ROLLBACK')

--- a/scripts/axolotl/downgrade-app-db.mjs
+++ b/scripts/axolotl/downgrade-app-db.mjs
@@ -37,40 +37,19 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join, basename, dirname } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import { loadRevertibleMigrations } from './migration-revert.mjs'
 
 const SETTINGS_DIR_NAME = 'red.ghs.axolotl'
 const APP_DB = 'app.db'
 const CHANNELS = ['release', 'beta']
 
-// Schema added by known migrations, used to undo it. Every migration a
-// downgrade is allowed to pass needs an entry here: `ALTER TABLE ... ADD COLUMN`
-// cannot be reversed in place, and leaving the column behind breaks the next
-// install of a build that carries the migration. A migration that only moves
-// data (DELETE, UPDATE) gets an empty list - there is nothing to drop, but
-// naming it keeps the downgrade from stopping on a migration it could pass.
-//
-// Only recent migrations are listed. Dropping to a threshold before them is
-// refused rather than guessed at; --allow-unmapped accepts the risk explicitly.
-const REVERTIBLE_COLUMNS = {
-	// settings.close_behavior
-	20260903120000: [{ table: 'settings', column: 'close_behavior' }],
-	// instances: the direct link columns
-	20260904120000: [
-		{ table: 'instances', column: 'linked_launcher' },
-		{ table: 'instances', column: 'linked_launcher_root' },
-		{ table: 'instances', column: 'linked_dot_minecraft' },
-		{ table: 'instances', column: 'linked_version_id' },
-		{ table: 'instances', column: 'linked_version_json_path' },
-	],
-	// telemetry samples; the tables stay, so nothing to drop
-	20260905000000: [],
-	// settings.mc_maximize_window
-	20260908000000: [{ table: 'settings', column: 'mc_maximize_window' }],
-	// instances.linked_game_dir_mode
-	20260908010000: [{ table: 'instances', column: 'linked_game_dir_mode' }],
-	// crash_analysis_ai_settings.ai_source
-	20260911120000: [{ table: 'crash_analysis_ai_settings', column: 'ai_source' }],
-}
+// Columns a downgrade must drop are derived from the migration SQL
+// (see migration-revert.mjs). Migrations at or after
+// OLDEST_REVERTIBLE_VERSION are always known; ADD COLUMN statements become
+// DROP COLUMN on the way down. Data-only migrations map to an empty list.
+// Older migrations stay unmapped so a downgrade into them refuses rather
+// than guesses; --allow-unmapped accepts the risk explicitly.
+const REVERTIBLE_MIGRATIONS = loadRevertibleMigrations()
 
 function fail(message) {
 	console.error(`error: ${message}`)
@@ -421,20 +400,28 @@ function planDowngrade(db, target) {
 	const applied = rows.filter((row) => row.success).map((row) => Number(row.version))
 	const failed = rows.filter((row) => !row.success).map((row) => Number(row.version))
 
-	const plan = applied.map((version) => ({
-		version,
-		mapped: REVERTIBLE_COLUMNS[version] !== undefined,
-		columns: columnsPresent(db, REVERTIBLE_COLUMNS[version] ?? []),
-	}))
+	const plan = applied.map((version) => {
+		const known = REVERTIBLE_MIGRATIONS.get(version)
+		return {
+			version,
+			mapped: known !== undefined,
+			columns: columnsPresent(db, known?.columns ?? []),
+			createdTables: known?.createdTables ?? [],
+		}
+	})
 
 	return { applied, failed, plan }
 }
 
 function reportPlan({ applied, failed, plan }) {
 	note(`migrations to remove: ${applied.join(', ')}`)
-	for (const { version, mapped, columns } of plan) {
+	for (const { version, mapped, columns, createdTables } of plan) {
 		if (!mapped) {
 			note(`  ${version}: no known schema for this migration, removing its record only`)
+			continue
+		}
+		if (columns.length === 0 && createdTables.length === 0) {
+			note(`  ${version}: no columns to drop`)
 			continue
 		}
 		for (const { table, column, present } of columns) {
@@ -442,6 +429,11 @@ function reportPlan({ applied, failed, plan }) {
 				present
 					? `  ${version}: drop ${table}.${column}`
 					: `  ${version}: ${table}.${column} is NOT in the database`,
+			)
+		}
+		if (createdTables.length > 0) {
+			note(
+				`  ${version}: created tables stay in place (${createdTables.join(', ')}) - this script only drops columns`,
 			)
 		}
 	}
@@ -467,7 +459,7 @@ function checkMappings(plan) {
 
 	if (mismatched.length > 0) {
 		fail(
-			`the schema recorded here for ${mismatched.join(', ')} does not match this database.\nRefusing to remove the records: reinstalling that build would then fail on a duplicate\ncolumn, and neither build could open the database. Check REVERTIBLE_COLUMNS against\npackages/app-lib/migrations, and use --list to inspect the database.`,
+			`the schema derived from the migration SQL for ${mismatched.join(', ')} does not match this database.\nRefusing to remove the records: reinstalling that build would then fail on a duplicate\ncolumn, and neither build could open the database. Check packages/app-lib/migrations against\nthe database, and use --list to inspect it.`,
 		)
 	}
 }

--- a/scripts/axolotl/downgrade-app-db.test.mjs
+++ b/scripts/axolotl/downgrade-app-db.test.mjs
@@ -273,28 +273,43 @@ console.log('resolving the settings directory')
 
 console.log('keeping the migration mapping honest')
 {
-	const source = fs.readFileSync(script, 'utf8')
-	const block = source.slice(source.indexOf('const REVERTIBLE_COLUMNS = {'))
-	const body = block.slice(0, block.indexOf('\n}'))
-	const registered = [...body.matchAll(/^\t(\d{14}):/gm)].map((match) => Number(match[1]))
+	const { loadRevertibleMigrations, parseAddColumns, OLDEST_REVERTIBLE_VERSION } =
+		await import('./migration-revert.mjs')
+
+	const parsed = parseAddColumns(
+		'ALTER TABLE settings ADD COLUMN log_level TEXT NOT NULL DEFAULT \'trace\';',
+	)
+	check(
+		'parses ADD COLUMN into table/column pairs',
+		parsed.length === 1 && parsed[0].table === 'settings' && parsed[0].column === 'log_level',
+		JSON.stringify(parsed),
+	)
+
+	const revertible = loadRevertibleMigrations(migrationsDir)
+	const versions = [...revertible.keys()].sort((a, b) => a - b)
+	check('derives at least the oldest revertible migration', versions[0] === OLDEST_REVERTIBLE_VERSION)
 
 	const files = fs.readdirSync(migrationsDir).filter((name) => name.endsWith('.sql'))
-	const versions = files.map((name) => Number(name.slice(0, 14)))
-
-	// A mapping for a migration that does not exist is dead weight: it can never
-	// match anything, and it makes the table look considered when it is not.
-	const unknown = registered.filter((version) => !versions.includes(version))
-	check('every mapped migration exists', unknown.length === 0, unknown.join(', '))
-
-	// The script refuses any applied migration it has no mapping for, so a
-	// column added without one turns the documented recovery into a refusal.
-	const oldest = Math.min(...registered)
 	const addingColumns = files
 		.filter((name) => /ADD COLUMN/i.test(fs.readFileSync(path.join(migrationsDir, name), 'utf8')))
 		.map((name) => Number(name.slice(0, 14)))
-		.filter((version) => version >= oldest)
-	const unmapped = addingColumns.filter((version) => !registered.includes(version))
+		.filter((version) => version >= OLDEST_REVERTIBLE_VERSION)
+	const unmapped = addingColumns.filter((version) => !revertible.has(version))
 	check('every migration that adds a column is mapped', unmapped.length === 0, unmapped.join(', '))
+
+	const closeBehavior = revertible.get(OLDEST_REVERTIBLE_VERSION)
+	check(
+		'derives close_behavior from the close-behavior migration',
+		closeBehavior?.columns.some((entry) => entry.table === 'settings' && entry.column === 'close_behavior'),
+		JSON.stringify(closeBehavior?.columns),
+	)
+
+	const dataOnly = revertible.get(20260905000000)
+	check(
+		'data-only migrations map to an empty column list',
+		dataOnly !== undefined && dataOnly.columns.length === 0,
+		JSON.stringify(dataOnly),
+	)
 }
 
 // --- refusing a database a running launcher holds open ------------------------

--- a/scripts/axolotl/downgrade-app-db.test.mjs
+++ b/scripts/axolotl/downgrade-app-db.test.mjs
@@ -273,7 +273,7 @@ console.log('resolving the settings directory')
 
 console.log('keeping the migration mapping honest')
 {
-	const { loadRevertibleMigrations, parseAddColumns, OLDEST_REVERTIBLE_VERSION } =
+	const { loadRevertibleMigrations, parseAddColumns, parseCreatedTables, OLDEST_REVERTIBLE_VERSION } =
 		await import('./migration-revert.mjs')
 
 	const parsed = parseAddColumns(
@@ -283,6 +283,16 @@ console.log('keeping the migration mapping honest')
 		'parses ADD COLUMN into table/column pairs',
 		parsed.length === 1 && parsed[0].table === 'settings' && parsed[0].column === 'log_level',
 		JSON.stringify(parsed),
+	)
+
+	check(
+		'ignores CREATE TABLE inside comments',
+		parseCreatedTables('-- CREATE TABLE fake (id INTEGER);\nCREATE TABLE real (id INTEGER);').join() ===
+			'real',
+	)
+	check(
+		'ignores ADD COLUMN inside comments',
+		parseAddColumns('-- ALTER TABLE settings ADD COLUMN fake TEXT;\n').length === 0,
 	)
 
 	const revertible = loadRevertibleMigrations(migrationsDir)

--- a/scripts/axolotl/downgrade-app-db.test.mjs
+++ b/scripts/axolotl/downgrade-app-db.test.mjs
@@ -294,6 +294,15 @@ console.log('keeping the migration mapping honest')
 		'ignores ADD COLUMN inside comments',
 		parseAddColumns('-- ALTER TABLE settings ADD COLUMN fake TEXT;\n').length === 0,
 	)
+	check(
+		'keeps quoted identifiers',
+		parseAddColumns('ALTER TABLE "settings" ADD COLUMN "log_level" TEXT;')[0]?.column ===
+			'log_level',
+	)
+	check(
+		'does not treat string contents as DDL',
+		parseCreatedTables("SELECT 'CREATE TABLE nope (id INTEGER);';").length === 0,
+	)
 
 	const revertible = loadRevertibleMigrations(migrationsDir)
 	const versions = [...revertible.keys()].sort((a, b) => a - b)

--- a/scripts/axolotl/migration-revert.mjs
+++ b/scripts/axolotl/migration-revert.mjs
@@ -1,0 +1,86 @@
+// Derive which columns a downgrade must drop, straight from the migration SQL.
+//
+// The hand-maintained REVERTIBLE_COLUMNS table used to live inside
+// downgrade-app-db.mjs. Renumbering a migration (to clear the immutable-
+// migration guard) silently desynchronized that table and blocked recovery.
+// Reading the SQL removes the second source of truth.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const MIGRATIONS_DIR =
+	process.env.AXOLOTL_MIGRATIONS_DIR ||
+	fileURLToPath(new URL('../../packages/app-lib/migrations', import.meta.url))
+
+// Only migrations at or after this version are treated as revertible. Older
+// ones predate the documented recovery path and stay unmapped so a downgrade
+// into them refuses rather than guesses.
+export const OLDEST_REVERTIBLE_VERSION = 20260903120000
+
+const ADD_COLUMN_RE =
+	/ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?["'`]?([A-Za-z_][A-Za-z0-9_]*)["'`]?\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?([A-Za-z_][A-Za-z0-9_]*)["'`]?/gi
+
+const CREATE_TABLE_RE =
+	/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?([A-Za-z_][A-Za-z0-9_]*)["'`]?/gi
+
+export function parseAddColumns(sql) {
+	const columns = []
+	ADD_COLUMN_RE.lastIndex = 0
+	let match
+	while ((match = ADD_COLUMN_RE.exec(sql)) !== null) {
+		const table = match[1]
+		const column = match[2]
+		if (!columns.some((entry) => entry.table === table && entry.column === column)) {
+			columns.push({ table, column })
+		}
+	}
+	return columns
+}
+
+export function parseCreatedTables(sql) {
+	const tables = []
+	CREATE_TABLE_RE.lastIndex = 0
+	let match
+	while ((match = CREATE_TABLE_RE.exec(sql)) !== null) {
+		const table = match[1]
+		if (!tables.includes(table)) tables.push(table)
+	}
+	return tables
+}
+
+export function migrationVersionFromName(name) {
+	if (!name.endsWith('.sql')) return null
+	const match = /^(\d{14})_[a-z0-9][a-z0-9_-]*\.sql$/.exec(name)
+	return match ? Number(match[1]) : null
+}
+
+export function listMigrationFiles(dir = MIGRATIONS_DIR) {
+	return readdirSync(dir)
+		.filter((name) => name.endsWith('.sql'))
+		.map((name) => ({ name, version: migrationVersionFromName(name) }))
+		.filter((entry) => entry.version !== null)
+		.sort((left, right) => left.version - right.version)
+}
+
+/**
+ * version -> { columns: [{table, column}], createdTables: [string] }
+ * for every migration at or after OLDEST_REVERTIBLE_VERSION.
+ */
+export function loadRevertibleMigrations(dir = MIGRATIONS_DIR) {
+	const map = new Map()
+	for (const { name, version } of listMigrationFiles(dir)) {
+		if (version < OLDEST_REVERTIBLE_VERSION) continue
+		const sql = readFileSync(join(dir, name), 'utf8')
+		map.set(version, {
+			name,
+			columns: parseAddColumns(sql),
+			createdTables: parseCreatedTables(sql),
+		})
+	}
+	return map
+}
+
+export function isRevertibleVersion(version, revertible = loadRevertibleMigrations()) {
+	return revertible.has(Number(version))
+}

--- a/scripts/axolotl/migration-revert.mjs
+++ b/scripts/axolotl/migration-revert.mjs
@@ -45,6 +45,7 @@ export function stripSqlNoise(sql) {
 		}
 		const quote = sql[index]
 		if (quote === "'" || quote === '"' || quote === '`') {
+			const start = index
 			index += 1
 			while (index < sql.length) {
 				if (sql[index] === quote) {
@@ -57,7 +58,10 @@ export function stripSqlNoise(sql) {
 				}
 				index += 1
 			}
-			out += '""'
+			// Keep identifier quotes so "table"."column" still matches DDL regexes;
+			// string literals become empty quotes and cannot fake identifiers.
+			const raw = sql.slice(start, index)
+			out += quote === "'" ? "''" : raw
 			continue
 		}
 		out += sql[index]
@@ -123,8 +127,4 @@ export function loadRevertibleMigrations(dir = MIGRATIONS_DIR) {
 		})
 	}
 	return map
-}
-
-export function isRevertibleVersion(version, revertible = loadRevertibleMigrations()) {
-	return revertible.has(Number(version))
 }

--- a/scripts/axolotl/migration-revert.mjs
+++ b/scripts/axolotl/migration-revert.mjs
@@ -24,11 +24,54 @@ const ADD_COLUMN_RE =
 const CREATE_TABLE_RE =
 	/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?([A-Za-z_][A-Za-z0-9_]*)["'`]?/gi
 
+// Remove line/block comments and string literals so DDL recognizers only see
+// executable SQL. A commented-out CREATE TABLE must not look like a real table.
+export function stripSqlNoise(sql) {
+	let out = ''
+	let index = 0
+	while (index < sql.length) {
+		const rest = sql.slice(index)
+		if (rest.startsWith('--')) {
+			const newline = sql.indexOf('\n', index)
+			index = newline === -1 ? sql.length : newline + 1
+			out += '\n'
+			continue
+		}
+		if (rest.startsWith('/*')) {
+			const end = sql.indexOf('*/', index + 2)
+			index = end === -1 ? sql.length : end + 2
+			out += ' '
+			continue
+		}
+		const quote = sql[index]
+		if (quote === "'" || quote === '"' || quote === '`') {
+			index += 1
+			while (index < sql.length) {
+				if (sql[index] === quote) {
+					if (sql[index + 1] === quote) {
+						index += 2
+						continue
+					}
+					index += 1
+					break
+				}
+				index += 1
+			}
+			out += '""'
+			continue
+		}
+		out += sql[index]
+		index += 1
+	}
+	return out
+}
+
 export function parseAddColumns(sql) {
+	const source = stripSqlNoise(sql)
 	const columns = []
 	ADD_COLUMN_RE.lastIndex = 0
 	let match
-	while ((match = ADD_COLUMN_RE.exec(sql)) !== null) {
+	while ((match = ADD_COLUMN_RE.exec(source)) !== null) {
 		const table = match[1]
 		const column = match[2]
 		if (!columns.some((entry) => entry.table === table && entry.column === column)) {
@@ -39,10 +82,11 @@ export function parseAddColumns(sql) {
 }
 
 export function parseCreatedTables(sql) {
+	const source = stripSqlNoise(sql)
 	const tables = []
 	CREATE_TABLE_RE.lastIndex = 0
 	let match
-	while ((match = CREATE_TABLE_RE.exec(sql)) !== null) {
+	while ((match = CREATE_TABLE_RE.exec(source)) !== null) {
 		const table = match[1]
 		if (!tables.includes(table)) tables.push(table)
 	}

--- a/scripts/axolotl/migration.mjs
+++ b/scripts/axolotl/migration.mjs
@@ -1,0 +1,133 @@
+// Create or renumber a launcher database migration without leaving the
+// revert mapping (or the immutable-migration guard) out of step.
+//
+//   node scripts/axolotl/migration.mjs new add-my-setting
+//   node scripts/axolotl/migration.mjs renumber 20260909010000 20260912120000
+//   node scripts/axolotl/migration.mjs next-version
+//
+// Versions are 14-digit sqlx timestamps. `new` picks max(existing)+1 so a
+// concurrent PR that already merged a higher version cannot produce an
+// OUT-OF-ORDER migration. `renumber` only renames the file: the downgrade
+// script derives columns from the SQL itself.
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { MIGRATIONS_DIR, listMigrationFiles } from './migration-revert.mjs'
+
+function fail(message) {
+	console.error(`error: ${message}`)
+	process.exit(1)
+}
+
+function nextVersion(dir = MIGRATIONS_DIR) {
+	const files = listMigrationFiles(dir)
+	if (files.length === 0) fail(`no migrations found in ${dir}`)
+	const max = files[files.length - 1].version
+	return max + 1
+}
+
+function formatVersion(version) {
+	return String(version).padStart(14, '0')
+}
+
+function normalizeSlug(slug) {
+	const cleaned = slug
+		.trim()
+		.replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+	if (!/^[a-z0-9][a-z0-9-]*$/.test(cleaned)) {
+		fail(`slug must look like add-my-setting, got ${slug}`)
+	}
+	return cleaned
+}
+
+function usage() {
+	console.log(
+		[
+			'Create or renumber a database migration.',
+			'',
+			'  node scripts/axolotl/migration.mjs new <slug>',
+			'  node scripts/axolotl/migration.mjs renumber <from> <to>',
+			'  node scripts/axolotl/migration.mjs next-version',
+			'',
+			'`new` writes packages/app-lib/migrations/<max+1>_<slug>.sql.',
+			'`renumber` renames an existing file when the immutable-migration',
+			'guard requires a version past ones already on main.',
+		].join('\n'),
+	)
+}
+
+function commandNew(slug) {
+	const normalized = normalizeSlug(slug)
+	const version = nextVersion()
+	const name = `${formatVersion(version)}_${normalized}.sql`
+	const path = join(MIGRATIONS_DIR, name)
+	if (existsSync(path)) fail(`${name} already exists`)
+
+	const body = [
+		`-- ${normalized.replace(/-/g, ' ')}`,
+		'--',
+		'-- ADD COLUMN statements are picked up automatically by',
+		'-- scripts/axolotl/downgrade-app-db.mjs when undoing this migration.',
+		'',
+		'',
+	].join('\n')
+
+	writeFileSync(path, body)
+	console.log(`created ${path}`)
+	console.log(`version ${formatVersion(version)}`)
+}
+
+function commandRenumber(from, to) {
+	if (!/^\d{14}$/.test(from) || !/^\d{14}$/.test(to)) {
+		fail('renumber expects two 14-digit versions')
+	}
+
+	const files = listMigrationFiles()
+	const source = files.find((entry) => entry.version === Number(from))
+	if (!source) fail(`no migration with version ${from} in ${MIGRATIONS_DIR}`)
+	if (files.some((entry) => entry.version === Number(to))) {
+		fail(`version ${to} already exists`)
+	}
+
+	const others = files.filter((entry) => entry.version !== Number(from))
+	const maxOther = others.length === 0 ? 0 : others[others.length - 1].version
+	if (Number(to) <= maxOther) {
+		fail(
+			`${to} is not greater than the highest other migration (${formatVersion(maxOther)}); ` +
+				`pick a version past that or the guard will still fail`,
+		)
+	}
+
+	const targetName = `${formatVersion(Number(to))}${source.name.slice(14)}`
+	const fromPath = join(MIGRATIONS_DIR, source.name)
+	const toPath = join(MIGRATIONS_DIR, targetName)
+
+	// Prefer git mv so history follows the file when the worktree is a git checkout.
+	const moved = spawnSync('git', ['mv', fromPath, toPath], { encoding: 'utf8' })
+	if (moved.status !== 0) {
+		renameSync(fromPath, toPath)
+	}
+
+	console.log(`renamed ${source.name} -> ${targetName}`)
+	console.log('downgrade-app-db.mjs derives columns from the SQL, so no mapping edit is needed')
+	console.log('local databases that already applied the old version need a downgrade or a fresh suffix')
+}
+
+const [command, ...rest] = process.argv.slice(2)
+
+if (command === 'new') {
+	if (rest.length !== 1) fail('new expects exactly one slug')
+	commandNew(rest[0])
+} else if (command === 'renumber') {
+	if (rest.length !== 2) fail('renumber expects <from> <to>')
+	commandRenumber(rest[0], rest[1])
+} else if (command === 'next-version') {
+	console.log(formatVersion(nextVersion()))
+} else {
+	usage()
+	if (command !== undefined && command !== '--help' && command !== '-h') process.exit(2)
+}

--- a/scripts/axolotl/migration.test.mjs
+++ b/scripts/axolotl/migration.test.mjs
@@ -1,0 +1,87 @@
+// Exercises migration.mjs against a throwaway migrations directory.
+//
+// Run directly: node scripts/axolotl/migration.test.mjs
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const script = fileURLToPath(new URL('migration.mjs', import.meta.url))
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'axolotl-migration-'))
+
+function check(name, condition, detail) {
+	assert.ok(condition, detail ? `${name}: ${detail}` : name)
+	console.log(`  ok  ${name}`)
+}
+
+function run(args, env = {}) {
+	const result = spawnSync(process.execPath, [script, ...args], {
+		encoding: 'utf8',
+		env: { ...process.env, ...env },
+	})
+	return { status: result.status, output: `${result.stdout}${result.stderr}` }
+}
+
+console.log('next-version')
+{
+	const empty = run(['next-version'], { AXOLOTL_MIGRATIONS_DIR: directory })
+	check('refuses an empty migrations directory', empty.status === 1)
+
+	fs.writeFileSync(path.join(directory, '20260101000000_init.sql'), 'SELECT 1;\n')
+	fs.writeFileSync(path.join(directory, '20260102000000_more.sql'), 'SELECT 1;\n')
+	const next = run(['next-version'], { AXOLOTL_MIGRATIONS_DIR: directory })
+	check('exits zero', next.status === 0, next.output)
+	check('picks max+1', next.output.includes('20260102000001'), next.output)
+}
+
+console.log('new')
+{
+	const created = run(['new', 'Add My Setting'], { AXOLOTL_MIGRATIONS_DIR: directory })
+	check('creates a migration file', created.status === 0, created.output)
+	check(
+		'names it max+1_slug',
+		fs.existsSync(path.join(directory, '20260102000001_add-my-setting.sql')),
+		created.output,
+	)
+}
+
+console.log('renumber')
+{
+	const renumbered = run(
+		['renumber', '20260102000001', '20260103000000'],
+		{ AXOLOTL_MIGRATIONS_DIR: directory },
+	)
+	check('renames the file', renumbered.status === 0, renumbered.output)
+	check(
+		'leaves only the new name',
+		fs.existsSync(path.join(directory, '20260103000000_add-my-setting.sql')) &&
+			!fs.existsSync(path.join(directory, '20260102000001_add-my-setting.sql')),
+		renumbered.output,
+	)
+
+	const behind = run(['renumber', '20260101000000', '20260102000000'], {
+		AXOLOTL_MIGRATIONS_DIR: directory,
+	})
+	check('refuses a version that is still behind', behind.status === 1, behind.output)
+
+	const duplicate = run(['renumber', '20260101000000', '20260103000000'], {
+		AXOLOTL_MIGRATIONS_DIR: directory,
+	})
+	check('refuses a duplicate version', duplicate.status === 1, duplicate.output)
+}
+
+console.log('argument validation')
+{
+	check('rejects an unknown command', run(['nope']).status === 2)
+	check('rejects a bad slug', run(['new', '!!!']).status === 1)
+	check(
+		'rejects a short version',
+		run(['renumber', '2026', '20260103000000']).status === 1,
+	)
+}
+
+fs.rmSync(directory, { recursive: true, force: true })
+console.log('\nAll migration script checks passed.')

--- a/scripts/axolotl/sync-open-prs.mjs
+++ b/scripts/axolotl/sync-open-prs.mjs
@@ -18,11 +18,13 @@ function fail(message) {
 
 function git(args, { allowFailure = false } = {}) {
 	const result = spawnSync('git', args, { encoding: 'utf8' })
-	const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+	const stdout = (result.stdout ?? '').trim()
+	const stderr = (result.stderr ?? '').trim()
+	const output = [stdout, stderr].filter(Boolean).join('\n')
 	if (result.status !== 0 && !allowFailure) {
-		fail(`git ${args.join(' ')} failed:\n${output}`)
+		throw new Error(`git ${args.join(' ')} failed:\n${output}`)
 	}
-	return { status: result.status, output }
+	return { status: result.status, stdout, stderr, output }
 }
 
 function gh(args, { allowFailure = false } = {}) {
@@ -67,11 +69,11 @@ function parseArgs(argv) {
 }
 
 function currentBranch() {
-	return git(['rev-parse', '--abbrev-ref', 'HEAD']).output
+	return git(['rev-parse', '--abbrev-ref', 'HEAD']).stdout
 }
 
 function originOwner() {
-	const url = git(['remote', 'get-url', 'origin']).output
+	const url = git(['remote', 'get-url', 'origin']).stdout
 	const match = url.match(/github\.com[/:]([^/]+)\//)
 	if (!match) fail(`could not parse an owner from origin remote url: ${url}`)
 	return match[1]
@@ -94,11 +96,23 @@ function openPullRequests() {
 }
 
 function behindCount(ref) {
-	const counts = git(['rev-list', '--left-right', '--count', `${ref}...upstream/main`], {
+	const result = git(['rev-list', '--left-right', '--count', `${ref}...upstream/main`], {
 		allowFailure: true,
-	}).output
-	const [ahead, behind] = counts.split(/\s+/).map((part) => Number(part))
-	return { ahead: ahead ?? 0, behind: behind ?? 0 }
+	})
+	if (result.status !== 0) {
+		return { ahead: 0, behind: 0, error: result.output }
+	}
+	const [ahead, behind] = result.stdout.split(/\s+/).map((part) => Number(part))
+	return {
+		ahead: Number.isFinite(ahead) ? ahead : 0,
+		behind: Number.isFinite(behind) ? behind : 0,
+	}
+}
+
+function sameTip(a, b) {
+	const left = git(['rev-parse', a], { allowFailure: true })
+	const right = git(['rev-parse', b], { allowFailure: true })
+	return left.status === 0 && right.status === 0 && left.stdout === right.stdout
 }
 
 function syncBranch(pr, { dryRun }) {
@@ -125,8 +139,19 @@ function syncBranch(pr, { dryRun }) {
 	git(['merge', '--ff-only', remoteRef], { allowFailure: true })
 
 	const counts = behindCount(branch)
+	const localDiffersFromRemote = !sameTip(branch, remoteRef)
 	console.log(`  ahead ${counts.ahead}, behind ${counts.behind}`)
 	if (counts.behind === 0) {
+		if (localDiffersFromRemote) {
+			// Local tip already contains the merge (e.g. a previous push failed).
+			const pushed = git(['push', 'origin', branch], { allowFailure: true })
+			if (pushed.status !== 0) {
+				console.error(pushed.output)
+				return { pr: pr.number, status: 'push-failed', ...counts }
+			}
+			console.log('  pushed previously merged local tip')
+			return { pr: pr.number, status: 'synced', ...counts }
+		}
 		console.log('  already up to date')
 		return { pr: pr.number, status: 'clean' }
 	}
@@ -155,7 +180,7 @@ function syncBranch(pr, { dryRun }) {
 function main() {
 	const args = parseArgs(process.argv.slice(2))
 	const original = currentBranch()
-	const originalStatus = git(['status', '--porcelain']).output
+	const originalStatus = git(['status', '--porcelain']).stdout
 	if (originalStatus !== '') {
 		fail('working tree is not clean; commit or stash before syncing PR branches')
 	}

--- a/scripts/axolotl/sync-open-prs.mjs
+++ b/scripts/axolotl/sync-open-prs.mjs
@@ -1,0 +1,174 @@
+// Bring every open PR branch from this fork up to upstream/main with a merge
+// (never a rebase), then push. Run after something lands on main so in-flight
+// PRs stop failing guardrails against a baseline they have not absorbed yet.
+//
+//   node scripts/axolotl/sync-open-prs.mjs
+//   node scripts/axolotl/sync-open-prs.mjs --dry-run
+//   node scripts/axolotl/sync-open-prs.mjs --only 534,546
+//
+// Requires: git remotes `origin` (fork) and `upstream`, and the `gh` CLI
+// authenticated for the fork.
+
+import { spawnSync } from 'node:child_process'
+
+function fail(message) {
+	console.error(`error: ${message}`)
+	process.exit(1)
+}
+
+function git(args, { allowFailure = false } = {}) {
+	const result = spawnSync('git', args, { encoding: 'utf8' })
+	const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+	if (result.status !== 0 && !allowFailure) {
+		fail(`git ${args.join(' ')} failed:\n${output}`)
+	}
+	return { status: result.status, output }
+}
+
+function gh(args, { allowFailure = false } = {}) {
+	const result = spawnSync('gh', args, { encoding: 'utf8' })
+	const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+	if (result.status !== 0 && !allowFailure) {
+		fail(`gh ${args.join(' ')} failed:\n${output}`)
+	}
+	return { status: result.status, output }
+}
+
+function parseArgs(argv) {
+	const args = { dryRun: false, only: null }
+	for (let index = 0; index < argv.length; index += 1) {
+		const token = argv[index]
+		if (token === '--dry-run') {
+			args.dryRun = true
+		} else if (token === '--only') {
+			const value = argv[index + 1]
+			if (!value) fail('--only needs a comma-separated list of PR numbers')
+			args.only = new Set(
+				value
+					.split(',')
+					.map((part) => Number(part.trim()))
+					.filter((number) => Number.isInteger(number) && number > 0),
+			)
+			index += 1
+		} else if (token === '--help' || token === '-h') {
+			console.log(
+				[
+					'Merge upstream/main into every open PR branch and push.',
+					'',
+					'  node scripts/axolotl/sync-open-prs.mjs [--dry-run] [--only 534,546]',
+				].join('\n'),
+			)
+			process.exit(0)
+		} else {
+			fail(`unknown argument: ${token}`)
+		}
+	}
+	return args
+}
+
+function currentBranch() {
+	return git(['rev-parse', '--abbrev-ref', 'HEAD']).output
+}
+
+function openPullRequests() {
+	const listed = gh([
+		'pr',
+		'list',
+		'--state',
+		'open',
+		'--author',
+		'@me',
+		'--json',
+		'number,headRefName,headRepositoryOwner,title',
+		'--limit',
+		'50',
+	])
+	return JSON.parse(listed.output)
+}
+
+function behindCount(branch) {
+	const counts = git(['rev-list', '--left-right', '--count', `${branch}...upstream/main`], {
+		allowFailure: true,
+	}).output
+	const [ahead, behind] = counts.split(/\s+/).map((part) => Number(part))
+	return { ahead: ahead ?? 0, behind: behind ?? 0 }
+}
+
+function syncBranch(pr, { dryRun }) {
+	const branch = pr.headRefName
+	console.log(`\n#${pr.number} ${branch} — ${pr.title}`)
+
+	git(['fetch', 'origin', branch])
+	git(['fetch', 'upstream', 'main'])
+	git(['switch', branch])
+	git(['merge', '--ff-only', 'origin/' + branch], { allowFailure: true })
+
+	const counts = behindCount(branch)
+	console.log(`  ahead ${counts.ahead}, behind ${counts.behind}`)
+	if (counts.behind === 0) {
+		console.log('  already up to date')
+		return { pr: pr.number, status: 'clean' }
+	}
+
+	if (dryRun) {
+		console.log('  dry-run: would merge upstream/main and push')
+		return { pr: pr.number, status: 'would-sync', ...counts }
+	}
+
+	const merged = git(['merge', 'upstream/main', '--no-edit', '--no-gpg-sign'], { allowFailure: true })
+	if (merged.status !== 0) {
+		console.error(merged.output)
+		git(['merge', '--abort'], { allowFailure: true })
+		return { pr: pr.number, status: 'conflict', ...counts }
+	}
+
+	git(['push', 'origin', branch])
+	const after = behindCount(branch)
+	console.log(`  pushed; ahead ${after.ahead}, behind ${after.behind}`)
+	return { pr: pr.number, status: 'synced', ...after }
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2))
+	const original = currentBranch()
+	const originalStatus = git(['status', '--porcelain']).output
+	if (originalStatus !== '') {
+		fail('working tree is not clean; commit or stash before syncing PR branches')
+	}
+
+	git(['fetch', 'upstream', 'main'])
+	const prs = openPullRequests().filter((pr) => {
+		if (args.only && !args.only.has(pr.number)) return false
+		// Only branches that live on this fork.
+		return pr.headRepositoryOwner?.login !== undefined
+	})
+
+	if (prs.length === 0) {
+		console.log('no open pull requests to sync')
+		return
+	}
+
+	const results = []
+	for (const pr of prs) {
+		try {
+			results.push(syncBranch(pr, args))
+		} catch (error) {
+			console.error(`  failed: ${error.message}`)
+			results.push({ pr: pr.number, status: 'failed' })
+		}
+	}
+
+	git(['switch', original])
+
+	console.log('\nsummary')
+	for (const result of results) {
+		console.log(`  #${result.pr}: ${result.status}`)
+	}
+
+	const conflicts = results.filter((result) => result.status === 'conflict' || result.status === 'failed')
+	if (conflicts.length > 0) {
+		process.exitCode = 1
+	}
+}
+
+main()

--- a/scripts/axolotl/sync-open-prs.mjs
+++ b/scripts/axolotl/sync-open-prs.mjs
@@ -70,6 +70,13 @@ function currentBranch() {
 	return git(['rev-parse', '--abbrev-ref', 'HEAD']).output
 }
 
+function originOwner() {
+	const url = git(['remote', 'get-url', 'origin']).output
+	const match = url.match(/github\.com[/:]([^/]+)\//)
+	if (!match) fail(`could not parse an owner from origin remote url: ${url}`)
+	return match[1]
+}
+
 function openPullRequests() {
 	const listed = gh([
 		'pr',
@@ -81,13 +88,13 @@ function openPullRequests() {
 		'--json',
 		'number,headRefName,headRepositoryOwner,title',
 		'--limit',
-		'50',
+		'1000',
 	])
 	return JSON.parse(listed.output)
 }
 
-function behindCount(branch) {
-	const counts = git(['rev-list', '--left-right', '--count', `${branch}...upstream/main`], {
+function behindCount(ref) {
+	const counts = git(['rev-list', '--left-right', '--count', `${ref}...upstream/main`], {
 		allowFailure: true,
 	}).output
 	const [ahead, behind] = counts.split(/\s+/).map((part) => Number(part))
@@ -96,12 +103,26 @@ function behindCount(branch) {
 
 function syncBranch(pr, { dryRun }) {
 	const branch = pr.headRefName
+	const remoteRef = `origin/${branch}`
 	console.log(`\n#${pr.number} ${branch} — ${pr.title}`)
 
 	git(['fetch', 'origin', branch])
 	git(['fetch', 'upstream', 'main'])
+
+	if (dryRun) {
+		// Never switch or merge in dry-run: only inspect the fetched remote tip.
+		const counts = behindCount(remoteRef)
+		console.log(`  ahead ${counts.ahead}, behind ${counts.behind} (vs ${remoteRef})`)
+		if (counts.behind === 0) {
+			console.log('  already up to date')
+			return { pr: pr.number, status: 'clean' }
+		}
+		console.log('  dry-run: would merge upstream/main and push')
+		return { pr: pr.number, status: 'would-sync', ...counts }
+	}
+
 	git(['switch', branch])
-	git(['merge', '--ff-only', 'origin/' + branch], { allowFailure: true })
+	git(['merge', '--ff-only', remoteRef], { allowFailure: true })
 
 	const counts = behindCount(branch)
 	console.log(`  ahead ${counts.ahead}, behind ${counts.behind}`)
@@ -110,19 +131,22 @@ function syncBranch(pr, { dryRun }) {
 		return { pr: pr.number, status: 'clean' }
 	}
 
-	if (dryRun) {
-		console.log('  dry-run: would merge upstream/main and push')
-		return { pr: pr.number, status: 'would-sync', ...counts }
-	}
-
-	const merged = git(['merge', 'upstream/main', '--no-edit', '--no-gpg-sign'], { allowFailure: true })
+	const merged = git(['merge', 'upstream/main', '--no-edit', '--no-gpg-sign'], {
+		allowFailure: true,
+	})
 	if (merged.status !== 0) {
 		console.error(merged.output)
 		git(['merge', '--abort'], { allowFailure: true })
 		return { pr: pr.number, status: 'conflict', ...counts }
 	}
 
-	git(['push', 'origin', branch])
+	const pushed = git(['push', 'origin', branch], { allowFailure: true })
+	if (pushed.status !== 0) {
+		console.error(pushed.output)
+		// Leave the local merge in place for inspection, but do not kill the run.
+		return { pr: pr.number, status: 'push-failed', ...counts }
+	}
+
 	const after = behindCount(branch)
 	console.log(`  pushed; ahead ${after.ahead}, behind ${after.behind}`)
 	return { pr: pr.number, status: 'synced', ...after }
@@ -137,10 +161,11 @@ function main() {
 	}
 
 	git(['fetch', 'upstream', 'main'])
+	const owner = originOwner()
 	const prs = openPullRequests().filter((pr) => {
 		if (args.only && !args.only.has(pr.number)) return false
-		// Only branches that live on this fork.
-		return pr.headRepositoryOwner?.login !== undefined
+		// Only branches that live on this fork's origin remote.
+		return pr.headRepositoryOwner?.login === owner
 	})
 
 	if (prs.length === 0) {
@@ -149,24 +174,28 @@ function main() {
 	}
 
 	const results = []
-	for (const pr of prs) {
-		try {
-			results.push(syncBranch(pr, args))
-		} catch (error) {
-			console.error(`  failed: ${error.message}`)
-			results.push({ pr: pr.number, status: 'failed' })
+	try {
+		for (const pr of prs) {
+			try {
+				results.push(syncBranch(pr, args))
+			} catch (error) {
+				console.error(`  failed: ${error.message}`)
+				results.push({ pr: pr.number, status: 'failed' })
+			}
 		}
+	} finally {
+		git(['switch', original], { allowFailure: true })
 	}
-
-	git(['switch', original])
 
 	console.log('\nsummary')
 	for (const result of results) {
 		console.log(`  #${result.pr}: ${result.status}`)
 	}
 
-	const conflicts = results.filter((result) => result.status === 'conflict' || result.status === 'failed')
-	if (conflicts.length > 0) {
+	const bad = results.filter((result) =>
+		['conflict', 'failed', 'push-failed'].includes(result.status),
+	)
+	if (bad.length > 0) {
 		process.exitCode = 1
 	}
 }


### PR DESCRIPTION
## 背景

并发 PR 反复踩同一类坑：

1. 迁移重编号后，手写 `REVERTIBLE_COLUMNS` 未同步 → guardrails 里 downgrade 测试红（如 #534 comment）
2. 无一键 `new` / `renumber`，版本号与映射靠人肉对齐
3. 别人的 PR 合并进 main 后，在飞 PR 不自动同步基线，出现「自己的 PR 拦自己」

## 改动

### A. 从 SQL 自动推导 revert 映射
- 新增 `scripts/axolotl/migration-revert.mjs`：解析 `ADD COLUMN` / `CREATE TABLE`
- `downgrade-app-db.mjs` 删除手写 `REVERTIBLE_COLUMNS`，改为加载推导结果
- `≥ 20260903120000` 的迁移一律视为可推导；重编号只改文件名即可

### B. 一键迁移脚本
```bash
node scripts/axolotl/migration.mjs new add-my-setting   # max+1
node scripts/axolotl/migration.mjs renumber <旧> <新>   # 校验不会仍落后
node scripts/axolotl/migration.mjs next-version
```

### C. 合并后 bulk-sync 在飞 PR
```bash
node scripts/axolotl/sync-open-prs.mjs            # merge upstream/main → 全部 open PR
node scripts/axolotl/sync-open-prs.mjs --dry-run
node scripts/axolotl/sync-open-prs.mjs --only 534,546
```
冲突会 abort 并记入 summary，不半吊子提交。

### 其它
- guardrails 增加 `migration.test.mjs`
- CONTRIBUTING 更新：不再要求手写映射表

## 验证

- `node scripts/axolotl/downgrade-app-db.test.mjs` 全绿
- `node scripts/axolotl/migration.test.mjs` 全绿
- `sync-open-prs.mjs` 在脏工作区正确拒绝

## Sourcery 摘要

自动管理迁移版本和回滚元数据，同时提供安全的工作流，用于将未合并的 Pull Request 与最新的 main 分支同步。

新功能：
- 从迁移 SQL 中自动发现迁移回滚元数据，包括检测新增列和创建的表。
- 添加用于使用下一个版本创建迁移、安全地重新编号迁移，以及报告下一个可用版本的命令。
- 添加一个实用工具，用于将 upstream/main 合并到所有选定的未合并 Pull Request 分支，并支持试运行和冲突报告。

错误修复：
- 防止迁移重新编号导致回滚元数据不同步。
- 在合并后，使未合并 Pull Request 的分支与最新的 main 基线保持一致。

增强功能：
- 更新数据库回滚规划，以使用从 SQL 派生的迁移元数据，并报告回滚过程中仍然保留的表。
- 记录新的迁移和未合并 PR 同步工作流，并移除手动维护回滚映射的要求。

CI：
- 在 Axolotl CI 工作流中运行迁移防护测试。

文档：
- 更新贡献者指南，涵盖自动迁移回滚检测、迁移版本管理以及未合并 Pull Request 同步。

测试：
- 增加迁移解析器和迁移管理命令的测试覆盖，包括版本选择、创建、重新编号和无效参数验证。
- 扩展回滚测试，以验证从 SQL 派生的映射和仅包含数据的迁移。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

自动处理迁移版本管理和回滚元数据，同时提供安全的工作流，用于将未合并的 Pull Request 与最新的主分支同步。

新功能：
- 添加命令，以创建下一个可用版本的迁移、安全地重新编号现有迁移，并报告下一个版本。
- 添加实用工具，将上游最新的 main 合并到选定的或所有未合并的 Pull Request 分支，并支持试运行和冲突报告。

错误修复：
- 通过直接从迁移 SQL 中推导回滚信息，防止迁移重新编号导致降级元数据不同步。
- 在合并上游更改后，使未合并的 Pull Request 分支与最新的 main 基线保持同步。

增强功能：
- 更新数据库降级规划，以便从迁移 SQL 中检测新增列和创建的表，同时报告仍然存在的表。

CI：
- 在 Axolotl CI 工作流中运行迁移管理测试。

文档：
- 更新贡献者指南，涵盖自动回滚检测、迁移版本管理以及未合并 Pull Request 的同步。

测试：
- 增加对迁移 SQL 解析、迁移创建、重新编号、版本选择和参数验证的测试覆盖。
- 扩展降级测试，以验证基于 SQL 推导的映射和仅包含数据变更的迁移。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动执行迁移版本管理和降级元数据处理，同时提供一种安全的工作流，用于将开放的拉取请求与最新的主分支同步。

新功能：
- 添加用于创建、重新编号和检查数据库迁移版本的命令。
- 添加实用工具，将最新的上游主分支合并到选定的或所有开放的拉取请求分支中，并支持试运行和冲突报告。

错误修复：
- 通过从迁移 SQL 中推导降级元数据，防止迁移重新编号导致降级元数据不同步。
- 在上游发生更改后，使开放的拉取请求分支与最新的主分支基线保持同步。

增强功能：
- 使用基于 SQL 的检测来识别新增列和创建的表，替代手动维护的降级映射；当创建的表无法自动删除时发出警告。

CI：
- 在 Axolotl CI 工作流中运行迁移管理测试。

文档：
- 更新有关自动降级检测、迁移版本管理和开放的拉取请求同步的贡献者指南。

测试：
- 增加对迁移 SQL 解析、迁移创建、重新编号、版本选择和参数验证的测试覆盖。
- 扩展降级测试，以覆盖基于 SQL 的映射和仅包含数据的迁移。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动化迁移版本管理和回滚元数据，同时提供一种安全的工作流，用于将开放的拉取请求与最新的 main 分支同步。

新功能：
- 添加用于创建、重新编号和检查数据库迁移版本的命令。
- 添加一个实用工具，用于将开放的 fork 拉取请求分支与 upstream/main 同步，并支持试运行、选择和冲突报告。

错误修复：
- 通过从迁移 SQL 中推导回滚信息，防止迁移重新编号时降级元数据过时。
- 在上游发生变更后，使进行中的拉取请求分支与最新的 main 分支保持一致。

增强功能：
- 使用基于 SQL 的检测来替代手动维护的回滚映射，以识别新增列和创建的表，同时明确报告无法自动删除的表。

CI：
- 在 Axolotl CI 工作流中运行迁移管理测试。

文档：
- 更新有关自动回滚检测、迁移版本管理和开放拉取请求同步的贡献者指南。

测试：
- 增加对迁移 SQL 解析和迁移创建、重新编号、版本选择及参数验证的测试覆盖。
- 扩展降级测试，以覆盖基于 SQL 的映射、仅涉及数据的迁移以及创建表的处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动化迁移版本管理和降级元数据处理，同时提供一个安全的工作流，用于将未合并的 Pull Request 与最新的 main 分支同步。

新功能：
- 添加用于创建、重新编号和检查数据库迁移版本的命令。
- 添加一个工具，用于安全地将 upstream/main 合并到指定的或所有未合并的 Pull Request 分支中，并支持试运行和冲突报告。

Bug 修复：
- 通过直接从迁移 SQL 中推导回滚信息，防止迁移重新编号导致降级元数据不同步。
- 在上游发生变更后，使进行中的 Pull Request 分支与最新的 main 基线保持同步。

增强功能：
- 使用基于 SQL 的检测来识别新增列和创建的表，替代手动维护的降级映射，同时明确报告无法自动删除的表。

CI：
- 在 Axolotl CI 工作流中运行迁移管理测试。

文档：
- 更新有关自动降级检测、迁移版本管理以及同步未合并 Pull Request 的贡献者指南。

测试：
- 增加对迁移 SQL 解析、迁移创建、重新编号、版本选择和参数验证的测试覆盖。
- 扩展降级测试，以覆盖基于 SQL 的映射、仅数据迁移以及创建表的处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

自动管理迁移版本和回滚元数据，同时提供一个安全的工作流，用于将未合并的拉取请求与最新的 main 分支同步。

新功能：
- 添加用于使用下一个可用版本创建迁移、安全地重新编号现有迁移以及报告下一个版本的命令。
- 添加一个工具，用于将 upstream/main 合并到选定的或所有未合并的拉取请求分支中，并支持试运行和冲突报告。

错误修复：
- 防止迁移重新编号导致回滚元数据不同步，改为直接从迁移 SQL 中派生回滚元数据。
- 在 upstream 发生变更后，使进行中的拉取请求分支与最新的 main 基线保持同步。

增强功能：
- 使用基于 SQL 的检测来识别新增列和创建的表，替代手动维护的回滚映射；同时警告在降级过程中不会删除已创建的表。

CI：
- 在 Axolotl CI 工作流中运行迁移管理测试。

文档：
- 更新贡献者指南，加入自动回滚检测、迁移版本管理以及未合并拉取请求同步工作流的说明。

测试：
- 增加对迁移 SQL 解析、迁移创建、重新编号、版本选择、参数验证以及基于 SQL 的降级映射的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate migration versioning and rollback metadata while providing a safe workflow for synchronizing open pull requests with the latest main branch.

New Features:
- Add commands to create migrations with the next available version, safely renumber existing migrations, and report the next version.
- Add a utility to merge upstream/main into selected or all open pull request branches, with dry-run support and conflict reporting.

Bug Fixes:
- Prevent migration renumbering from leaving rollback metadata out of sync by deriving it directly from migration SQL.
- Keep in-flight pull request branches synchronized with the latest main baseline after upstream changes.

Enhancements:
- Replace manually maintained rollback mappings with SQL-derived detection of added columns and created tables, while warning that created tables are not removed during downgrade.

CI:
- Run migration management tests in the Axolotl CI workflow.

Documentation:
- Update the contributor guide with automatic rollback detection, migration version management, and open pull request synchronization workflows.

Tests:
- Add coverage for migration SQL parsing, migration creation, renumbering, version selection, argument validation, and SQL-derived downgrade mappings.

</details>

</details>

</details>

</details>

</details>

</details>