### PR TITLE
fix: 强调色「跟随系统」选中态与自定义按钮重叠

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -560,8 +560,9 @@ watch(
 				</p>
 			</template>
 			<div class="flex flex-col gap-4 p-4 @container">
+				<!-- flex-wrap + per-chip basis: long i18n labels reflow instead of colliding -->
 				<div
-					class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,7.5rem),1fr))] gap-1 @2xl:gap-2"
+					class="flex flex-wrap gap-2"
 					role="radiogroup"
 					:aria-label="formatMessage(messages.accentColorTitle)"
 				>
@@ -571,7 +572,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="settings.accent_color === accentColor.value"
-						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[5.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							settings.accent_color === accentColor.value
 								? 'border-brand bg-brand-highlight text-brand'
@@ -588,12 +589,12 @@ watch(
 							class="size-4 shrink-0 rounded-full ring-2 ring-white/20"
 							:style="{ backgroundColor: accentColor.color }"
 						/>
-						<span class="hidden min-w-0 flex-1 truncate text-center @xl:block">{{
+						<span class="hidden min-w-0 truncate @xl:block">{{
 							formatMessage(accentColor.label)
 						}}</span>
 						<CheckIcon
 							v-if="settings.accent_color === accentColor.value"
-							class="hidden size-4 shrink-0 @xl:block"
+							class="absolute end-1.5 top-1.5 hidden size-3.5 shrink-0 @xl:block"
 						/>
 					</button>
 					<button
@@ -608,7 +609,7 @@ watch(
 									: messages.accentColorSystem,
 							)
 						"
-						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[8.25rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all enabled:active:scale-[0.97]"
 						:class="
 							themeStore.systemAccentSupported !== true
 								? 'cursor-not-allowed border-surface-4 bg-surface-2 text-secondary opacity-60'
@@ -629,7 +630,7 @@ watch(
 								backgroundColor: themeStore.systemAccentColor ?? 'var(--color-pink)',
 							}"
 						/>
-						<span class="hidden min-w-0 flex-1 flex-col text-start leading-tight @xl:flex">
+						<span class="hidden min-w-0 flex-col text-start leading-tight @xl:flex">
 							<span class="truncate">{{ formatMessage(messages.accentColorSystem) }}</span>
 							<span
 								v-if="themeStore.systemAccentSupported === false"
@@ -638,13 +639,16 @@ watch(
 								{{ formatMessage(messages.accentColorSystemUnsupported) }}
 							</span>
 						</span>
-						<CheckIcon v-if="isSystemAccent" class="hidden size-4 shrink-0 @xl:block" />
+						<CheckIcon
+							v-if="isSystemAccent"
+							class="absolute end-1.5 top-1.5 hidden size-3.5 shrink-0 @xl:block"
+						/>
 					</button>
 					<button
 						type="button"
 						role="radio"
 						:aria-checked="isCustomAccent"
-						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[6.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							isCustomAccent
 								? 'border-brand bg-brand-highlight text-brand'
@@ -660,10 +664,13 @@ watch(
 									: 'conic-gradient(#ef4444, #f59e0b, #22c55e, #06b6d4, #6366f1, #ec4899, #ef4444)',
 							}"
 						/>
-						<span class="hidden min-w-0 flex-1 truncate text-center @xl:block">{{
+						<span class="hidden min-w-0 truncate @xl:block">{{
 							formatMessage(messages.accentColorCustom)
 						}}</span>
-						<CheckIcon v-if="isCustomAccent" class="hidden size-4 shrink-0 @xl:block" />
+						<CheckIcon
+							v-if="isCustomAccent"
+							class="absolute end-1.5 top-1.5 hidden size-3.5 shrink-0 @xl:block"
+						/>
 					</button>
 				</div>
 

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -571,7 +571,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="settings.accent_color === accentColor.value"
-						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							settings.accent_color === accentColor.value
 								? 'border-brand bg-brand-highlight text-brand'
@@ -588,7 +588,7 @@ watch(
 							class="size-4 shrink-0 rounded-full ring-2 ring-white/20"
 							:style="{ backgroundColor: accentColor.color }"
 						/>
-						<span class="hidden min-w-0 flex-1 truncate text-center @xl:inline">{{
+						<span class="hidden min-w-0 flex-1 truncate text-center @xl:block">{{
 							formatMessage(accentColor.label)
 						}}</span>
 						<CheckIcon
@@ -608,7 +608,7 @@ watch(
 									: messages.accentColorSystem,
 							)
 						"
-						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
+						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
 						:class="
 							themeStore.systemAccentSupported !== true
 								? 'cursor-not-allowed border-surface-4 bg-surface-2 text-secondary opacity-60'
@@ -644,7 +644,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="isCustomAccent"
-						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="flex min-w-0 items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							isCustomAccent
 								? 'border-brand bg-brand-highlight text-brand'
@@ -660,7 +660,7 @@ watch(
 									: 'conic-gradient(#ef4444, #f59e0b, #22c55e, #06b6d4, #6366f1, #ec4899, #ef4444)',
 							}"
 						/>
-						<span class="hidden min-w-0 flex-1 truncate text-center @xl:inline">{{
+						<span class="hidden min-w-0 flex-1 truncate text-center @xl:block">{{
 							formatMessage(messages.accentColorCustom)
 						}}</span>
 						<CheckIcon v-if="isCustomAccent" class="hidden size-4 shrink-0 @xl:block" />

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -561,7 +561,7 @@ watch(
 			</template>
 			<div class="flex flex-col gap-4 p-4 @container">
 				<div
-					class="grid grid-cols-4 gap-1 @2xl:gap-2 @4xl:grid-cols-7"
+					class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,7.5rem),1fr))] gap-1 @2xl:gap-2"
 					role="radiogroup"
 					:aria-label="formatMessage(messages.accentColorTitle)"
 				>
@@ -571,7 +571,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="settings.accent_color === accentColor.value"
-						class="flex min-w-0 items-center justify-center gap-2 rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							settings.accent_color === accentColor.value
 								? 'border-brand bg-brand-highlight text-brand'
@@ -588,10 +588,12 @@ watch(
 							class="size-4 shrink-0 rounded-full ring-2 ring-white/20"
 							:style="{ backgroundColor: accentColor.color }"
 						/>
-						<span class="hidden truncate @xl:inline">{{ formatMessage(accentColor.label) }}</span>
+						<span class="hidden min-w-0 flex-1 truncate text-center @xl:inline">{{
+							formatMessage(accentColor.label)
+						}}</span>
 						<CheckIcon
 							v-if="settings.accent_color === accentColor.value"
-							class="ml-auto hidden size-4 shrink-0 @4xl:block"
+							class="hidden size-4 shrink-0 @xl:block"
 						/>
 					</button>
 					<button
@@ -606,7 +608,7 @@ watch(
 									: messages.accentColorSystem,
 							)
 						"
-						class="flex min-w-0 items-center justify-center gap-2 rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
+						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all enabled:active:scale-[0.97]"
 						:class="
 							themeStore.systemAccentSupported !== true
 								? 'cursor-not-allowed border-surface-4 bg-surface-2 text-secondary opacity-60'
@@ -627,7 +629,7 @@ watch(
 								backgroundColor: themeStore.systemAccentColor ?? 'var(--color-pink)',
 							}"
 						/>
-						<span class="hidden min-w-0 flex-col truncate text-start leading-tight @xl:flex">
+						<span class="hidden min-w-0 flex-1 flex-col text-start leading-tight @xl:flex">
 							<span class="truncate">{{ formatMessage(messages.accentColorSystem) }}</span>
 							<span
 								v-if="themeStore.systemAccentSupported === false"
@@ -636,13 +638,13 @@ watch(
 								{{ formatMessage(messages.accentColorSystemUnsupported) }}
 							</span>
 						</span>
-						<CheckIcon v-if="isSystemAccent" class="ml-auto hidden size-4 shrink-0 @4xl:block" />
+						<CheckIcon v-if="isSystemAccent" class="hidden size-4 shrink-0 @xl:block" />
 					</button>
 					<button
 						type="button"
 						role="radio"
 						:aria-checked="isCustomAccent"
-						class="flex min-w-0 items-center justify-center gap-2 rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
+						class="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border border-solid px-1 py-2.5 @2xl:px-2 @4xl:px-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							isCustomAccent
 								? 'border-brand bg-brand-highlight text-brand'
@@ -658,10 +660,10 @@ watch(
 									: 'conic-gradient(#ef4444, #f59e0b, #22c55e, #06b6d4, #6366f1, #ec4899, #ef4444)',
 							}"
 						/>
-						<span class="hidden truncate @xl:inline">{{
+						<span class="hidden min-w-0 flex-1 truncate text-center @xl:inline">{{
 							formatMessage(messages.accentColorCustom)
 						}}</span>
-						<CheckIcon v-if="isCustomAccent" class="ml-auto hidden size-4 shrink-0 @4xl:block" />
+						<CheckIcon v-if="isCustomAccent" class="hidden size-4 shrink-0 @xl:block" />
 					</button>
 				</div>
 

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -572,7 +572,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="settings.accent_color === accentColor.value"
-						class="relative flex min-w-0 flex-1 basis-[5.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[5.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:ps-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							settings.accent_color === accentColor.value
 								? 'border-brand bg-brand-highlight text-brand'
@@ -609,7 +609,7 @@ watch(
 									: messages.accentColorSystem,
 							)
 						"
-						class="relative flex min-w-0 flex-1 basis-[8.25rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all enabled:active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[8.25rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:ps-3 font-semibold transition-all enabled:active:scale-[0.97]"
 						:class="
 							themeStore.systemAccentSupported !== true
 								? 'cursor-not-allowed border-surface-4 bg-surface-2 text-secondary opacity-60'
@@ -648,7 +648,7 @@ watch(
 						type="button"
 						role="radio"
 						:aria-checked="isCustomAccent"
-						class="relative flex min-w-0 flex-1 basis-[6.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:px-3 @4xl:pe-5 font-semibold transition-all active:scale-[0.97]"
+						class="relative flex min-w-0 flex-1 basis-[6.75rem] items-center justify-center gap-2 overflow-hidden rounded-lg border border-solid px-2 py-2.5 @xl:pe-5 @4xl:ps-3 font-semibold transition-all active:scale-[0.97]"
 						:class="
 							isCustomAccent
 								? 'border-brand bg-brand-highlight text-brand'


### PR DESCRIPTION
## 问题

Closes #550

截图可见：七个 chip 同排时，「跟随系统」+ 勾选图标比两字颜色名更宽，与右侧「自定义」几乎贴边/重叠。自定义本身是普通 radio chip（彩虹色点），不是独立特殊组件；选中后才在下方展开 hue/hex 面板。

第一轮用 auto-fit grid + overflow-hidden 未真正缓解——等宽 `1fr` 轨道仍按可用空间均分，勾选仍在横向占宽，窄轨时依旧顶到邻居。

## 修复（本轮）

1. **父级改为 flex-wrap**：chip 按内容 basis 伸缩，过窄自动换行，不再被 4/7 等分列锁死。
2. **「跟随系统」basis 更大**（`8.25rem` vs 颜色 `5.75rem` / 自定义 `6.75rem`），长文案有独立呼吸空间。
3. **勾选图标脱离布局流**：`absolute end-1.5 top-1.5` 角标，选中**不改变**按钮宽度；`@xl` 起为文案预留 `pe-5`。
4. 保留 `overflow-hidden` + 文案 `truncate`，兼容 zh「跟随系统」/ en `Follow system`。
5. 不改 i18n 文案与 store。

## 验证

- eslint / prettier 通过
- 已根据 issue 截图逐项对照布局成因

## 涉及文件

- `apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue`

## Summary by Sourcery

改善强调色选择器的响应式布局，避免「跟随系统」选中态与自定义选项发生重叠。

Bug Fixes:
- 修复强调色选项在窄布局下因选中图标和长标签导致与自定义按钮重叠的问题。

Enhancements:
- 改进强调色选项的响应式布局，使按钮按内容宽度伸缩并在空间不足时自动换行，同时优化长标签截断和选中状态展示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改善强调色选择器的响应式布局，避免「跟随系统」选中态与自定义选项发生重叠。

Bug Fixes:
- 修复强调色选项在窄布局下因选中图标和长标签导致与自定义按钮重叠的问题。

Enhancements:
- 改进强调色选项的响应式布局，使按钮按内容宽度伸缩并在空间不足时自动换行，同时优化长标签截断和选中状态展示。

</details>