### PR TITLE
Revert "fix(Settings): incorrect license url"

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -38,8 +38,7 @@ let pressStart = { x: 0, y: 0 }
 let suppressNextMemberClick = false
 const replayOnboarding = inject<(mode: 'main' | 'instance') => Promise<void>>('replayOnboarding')
 
-const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/apps/app/LICENSE`
-const copyingUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/COPYING.md`
+const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/LICENSE`
 const thirdPartyLicensesUrl = `${AxolotlBrandConfig.repositoryUrl}/tree/main/third-party/licenses`
 
 async function copyQqGroupNumber() {
@@ -229,10 +228,6 @@ const messages = defineMessages({
 	projectLicense: {
 		id: 'app.settings.about.project-license',
 		defaultMessage: 'Project license (GPL-3.0)',
-	},
-	copyingLicense: {
-    	id: 'app.settings.about.copying-guidelines',
-    	defaultMessage: 'Copying guidelines',
 	},
 	thirdPartyLicenses: {
 		id: 'app.settings.about.third-party-licenses',
@@ -467,15 +462,6 @@ const projectLinks = [
 				>
 					{{ formatMessage(messages.projectLicense) }}
 					<ExternalIcon class="size-4 text-secondary" />
-				</a>
-				<a
-				    :href="copyingUrl"
-				    target="_blank"
-				    rel="noopener noreferrer"
-				    class="inline-flex items-center gap-2 rounded-lg bg-surface-4 px-3 py-2 text-sm font-semibold text-contrast transition-colors hover:bg-surface-5"
-				>
-				    {{ formatMessage(messages.copyingGuidelines) }}
-				    <ExternalIcon class="size-4 text-secondary" />
 				</a>
 				<a
 					:href="thirdPartyLicensesUrl"

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6890,9 +6890,6 @@
   "app.settings.about.project-license": {
     "message": "Project license (GPL-3.0)"
   },
-  "app.settings.about.copying-guidelines": {
-    "defaultMessage": "Copying guidelines"
-  },
   "app.settings.about.project-website": {
     "message": "Project website"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6896,9 +6896,6 @@
   "app.settings.about.project-license": {
     "message": "项目许可证（GPL-3.0）"
   },
-  "app.settings.about.copying-guidelines": {
-    "defaultMessage": "复制准则"
-  },
   "app.settings.about.project-website": {
     "message": "项目网站"
   },


### PR DESCRIPTION
Reverts Mystic-Stars/Axolotl#547

## Sourcery 总结

恢复“关于”设置中的项目许可证链接。

改进：
- 将“关于”设置中的项目许可证链接恢复为指向仓库根目录中的许可证，并移除单独的复制指南链接。

维护：
- 移除已废弃的复制指南本地化条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the previous project licensing links in the About settings.

Enhancements:
- Restore the About settings project license link to the repository-root license and remove the separate copying-guidelines link.

Chores:
- Remove obsolete copying-guidelines localization entries.

</details>