### PR TITLE
fix: restore blank About page (copyingGuidelines key)

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -230,9 +230,9 @@ const messages = defineMessages({
 		id: 'app.settings.about.project-license',
 		defaultMessage: 'Project license (GPL-3.0)',
 	},
-	copyingLicense: {
-    	id: 'app.settings.about.copying-guidelines',
-    	defaultMessage: 'Copying guidelines',
+	copyingGuidelines: {
+		id: 'app.settings.about.copying-guidelines',
+		defaultMessage: 'Copying guidelines',
 	},
 	thirdPartyLicenses: {
 		id: 'app.settings.about.third-party-licenses',


### PR DESCRIPTION
## 背景

自 1.9.5-beta.5 起「设置 → 关于」整页空白。

## 根因

PR #547（a509bc85f）在 AboutSettings.vue 中：

- defineMessages 属性名为 `copyingLicense`
- 模板却调用 `messages.copyingGuidelines`

`formatMessage(undefined)` 在渲染时抛错，组件挂掉，关于页空白。e060ee3ad 只改了 message id，未改属性名。

## 修复

将属性名改为 `copyingGuidelines`，与模板一致，并理顺该块缩进。

## 验证

- copyingLicense / copyingGuidelines / id 三处已对齐
- 打开设置 → 关于应恢复正常渲染，Copying guidelines 链接指向 COPYING.md

## Sourcery 总结

错误修复：
- 通过将复制指南消息键与其模板引用保持一致，恢复 Settings → About 页面的渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore rendering of the Settings → About page by aligning the copying-guidelines message key with its template reference.

</details>