### PR TITLE
feat: re-add About copying guidelines link (restores #553)

### DIFF
--- a/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AboutSettings.vue
@@ -39,6 +39,7 @@ let suppressNextMemberClick = false
 const replayOnboarding = inject<(mode: 'main' | 'instance') => Promise<void>>('replayOnboarding')
 
 const licenseUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/LICENSE`
+const copyingUrl = `${AxolotlBrandConfig.repositoryUrl}/blob/main/COPYING.md`
 const thirdPartyLicensesUrl = `${AxolotlBrandConfig.repositoryUrl}/tree/main/third-party/licenses`
 
 async function copyQqGroupNumber() {
@@ -228,6 +229,10 @@ const messages = defineMessages({
 	projectLicense: {
 		id: 'app.settings.about.project-license',
 		defaultMessage: 'Project license (GPL-3.0)',
+	},
+	copyingGuidelines: {
+		id: 'app.settings.about.copying-guidelines',
+		defaultMessage: 'Copying guidelines',
 	},
 	thirdPartyLicenses: {
 		id: 'app.settings.about.third-party-licenses',
@@ -461,6 +466,15 @@ const projectLinks = [
 					class="inline-flex items-center gap-2 rounded-lg bg-surface-4 px-3 py-2 text-sm font-semibold text-contrast transition-colors hover:bg-surface-5"
 				>
 					{{ formatMessage(messages.projectLicense) }}
+					<ExternalIcon class="size-4 text-secondary" />
+				</a>
+				<a
+					:href="copyingUrl"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex items-center gap-2 rounded-lg bg-surface-4 px-3 py-2 text-sm font-semibold text-contrast transition-colors hover:bg-surface-5"
+				>
+					{{ formatMessage(messages.copyingGuidelines) }}
 					<ExternalIcon class="size-4 text-secondary" />
 				</a>
 				<a

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -6794,6 +6794,9 @@
   "app.settings.about.copy-qq-group": {
     "message": "Copy group number"
   },
+  "app.settings.about.copying-guidelines": {
+    "message": "Copying guidelines"
+  },
   "app.settings.about.description": {
     "message": "Your last launcher."
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -6866,6 +6866,9 @@
   "app.settings.about.copy-qq-group": {
     "message": "复制群号"
   },
+  "app.settings.about.copying-guidelines": {
+    "message": "复制准则"
+  },
   "app.settings.about.description": {
     "message": "你的最后一款启动器。"
   },


### PR DESCRIPTION
## 背景

#547 在关于页加入 COPYING 链接时，消息属性名与模板不一致（`copyingLicense` vs `messages.copyingGuidelines`），导致 `formatMessage(undefined)`、关于页整页空白。

上游用 `0f871c8e5` 整段 revert 恢复了关于页，但 COPYING 链接功能也一并没了。

本 PR 以正确键名**重新引入**该链接（原 #553 被误关，此为恢复提交）。

## 改动

- `AboutSettings.vue`：`copyingUrl` + `copyingGuidelines` 消息键 + 链接按钮（属性名与模板一致）
- `en-US` / `zh-CN`：`app.settings.about.copying-guidelines`

## 验证

- `i18n-check` 通过
- 属性名 / id / 模板引用三处对齐，不会再空白

## Sourcery 总结

恢复从“关于”设置页面访问仓库 COPYING 指南的功能。

新功能：
- 在“关于”设置页面添加“COPYING 指南”链接。],

改进：
- 对齐“关于”页面中新链接的消息键和模板引用，以保持页面正常渲染。

杂项：
- 为“COPYING 指南”标签添加英文和中文翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore access to the repository’s COPYING guidelines from the About settings page.

New Features:
- Add a Copying guidelines link to the About settings page.],

Enhancements:
- Align the About page’s message key and template reference for the new link to preserve page rendering.

Chores:
- Add English and Chinese translations for the Copying guidelines label.

</details>