### PR TITLE
feat: 适配MacOS新版”红绿灯“样式

### DIFF
--- a/.github/workflows/axolotl-release.yml
+++ b/.github/workflows/axolotl-release.yml
@@ -97,7 +97,7 @@ jobs:
             runner: windows-2025
             args: --config tauri-release.conf.json --config tauri-modern.conf.json --config tauri-updater.conf.json
           - name: macOS universal
-            runner: macos-15
+            runner: macos-26
             args: --target universal-apple-darwin --config tauri-release.conf.json --config tauri-updater.conf.json
     runs-on: ${{ matrix.runner }}
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6936,6 +6936,7 @@ dependencies = [
  "libc",
  "native-dialog",
  "notify",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "paste",

--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -378,6 +378,75 @@ watch(
 const stateInitialized = ref(false)
 const privacyConsentModal = ref<InstanceType<typeof PrivacyConsentModal>>()
 const privacyConsentPending = ref(false)
+const titlebarAnchor = ref<HTMLElement>()
+let titlebarAnchorObserver: ResizeObserver | undefined
+let titlebarAnchorFrame: number | undefined
+let titlebarAnchorUpdatePending = false
+let titlebarAnchorUpdateRunning = false
+
+async function updateNativeTrafficLightAnchor() {
+	if (titlebarAnchorUpdateRunning) {
+		titlebarAnchorUpdatePending = true
+		return
+	}
+
+	titlebarAnchorUpdateRunning = true
+	do {
+		titlebarAnchorUpdatePending = false
+		const anchorElement = titlebarAnchor.value
+		if (!anchorElement || os.value !== 'MacOS') break
+
+		const rect = anchorElement.getBoundingClientRect()
+		try {
+			await invoke('update_traffic_lights_anchor', {
+				anchor: {
+					x: rect.x,
+					y: rect.y,
+					width: rect.width,
+					height: rect.height,
+					viewportWidth: document.documentElement.clientWidth,
+					viewportHeight: document.documentElement.clientHeight,
+				},
+			})
+		} catch (error) {
+			console.warn('Failed to update the native traffic-light anchor', error)
+		}
+	} while (titlebarAnchorUpdatePending)
+	titlebarAnchorUpdateRunning = false
+}
+
+function scheduleNativeTrafficLightAnchorUpdate() {
+	if (os.value !== 'MacOS' || titlebarAnchorFrame !== undefined) return
+	titlebarAnchorFrame = requestAnimationFrame(() => {
+		titlebarAnchorFrame = undefined
+		void updateNativeTrafficLightAnchor()
+	})
+}
+
+function stopNativeTrafficLightAnchorTracking() {
+	titlebarAnchorObserver?.disconnect()
+	titlebarAnchorObserver = undefined
+	window.removeEventListener('resize', scheduleNativeTrafficLightAnchorUpdate)
+	window.visualViewport?.removeEventListener('resize', scheduleNativeTrafficLightAnchorUpdate)
+	window.visualViewport?.removeEventListener('scroll', scheduleNativeTrafficLightAnchorUpdate)
+	if (titlebarAnchorFrame !== undefined) {
+		cancelAnimationFrame(titlebarAnchorFrame)
+		titlebarAnchorFrame = undefined
+	}
+}
+
+watch([() => os.value, titlebarAnchor], ([platform, anchorElement]) => {
+	stopNativeTrafficLightAnchorTracking()
+	if (platform !== 'MacOS' || !anchorElement) return
+
+	titlebarAnchorObserver = new ResizeObserver(scheduleNativeTrafficLightAnchorUpdate)
+	titlebarAnchorObserver.observe(anchorElement)
+	titlebarAnchorObserver.observe(document.documentElement)
+	window.addEventListener('resize', scheduleNativeTrafficLightAnchorUpdate)
+	window.visualViewport?.addEventListener('resize', scheduleNativeTrafficLightAnchorUpdate)
+	window.visualViewport?.addEventListener('scroll', scheduleNativeTrafficLightAnchorUpdate)
+	scheduleNativeTrafficLightAnchorUpdate()
+})
 const communityAnnouncementModal = ref()
 const surveyModal = ref()
 const updateAnnouncementModal = ref()
@@ -779,6 +848,7 @@ function startDirectLinkSync() {
 onUnmounted(async () => {
 	if (maximizedStateTimer) clearTimeout(maximizedStateTimer)
 	unlistenWindowResize?.()
+	stopNativeTrafficLightAnchorTracking()
 	window.removeEventListener('keydown', handleGlobalKeydown, true)
 	window.removeEventListener('mousedown', handleShortcutMouse, true)
 	window.removeEventListener('wheel', handleShortcutWheel, { capture: true, passive: false })
@@ -2752,7 +2822,11 @@ provideAppUpdateDownloadProgress(appUpdateDownload)
 				<LogInIcon class="text-brand" />
 			</NavButton>
 		</div>
-		<div data-tauri-drag-region class="app-grid-statusbar bg-bg-raised h-[--top-bar-height] flex">
+		<div
+			ref="titlebarAnchor"
+			data-tauri-drag-region
+			class="app-grid-statusbar bg-bg-raised h-[--top-bar-height] flex"
+		>
 			<div data-tauri-drag-region class="flex min-w-0 flex-1 overflow-hidden p-3">
 				<div data-tauri-drag-region class="flex shrink-0 items-center gap-2">
 					<AxolotlLogo class="h-full w-auto shrink-0 pointer-events-none" />

--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -74,14 +74,21 @@ tauri-plugin-updater = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6.2"
+objc2 = "0.6.2"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+  "NSButton",
   "NSColor",
   "NSColorSpace",
+  "NSControl",
+  "NSResponder",
+  "NSView",
+  "NSWindow",
   "objc2-core-foundation",
 ] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = [
   "NSNotification",
   "NSOperation",
+  "NSRunLoop",
   "NSString",
   "block2",
 ] }

--- a/apps/app/src/macos/mod.rs
+++ b/apps/app/src/macos/mod.rs
@@ -1,1 +1,2 @@
 pub mod deep_link;
+pub mod traffic_lights;

--- a/apps/app/src/macos/traffic_lights.rs
+++ b/apps/app/src/macos/traffic_lights.rs
@@ -436,7 +436,7 @@ pub fn install(window: &WebviewWindow) -> tauri::Result<()> {
 }
 
 #[tauri::command]
-pub fn update_traffic_lights_anchor(
+pub async fn update_traffic_lights_anchor(
     window: WebviewWindow,
     anchor: DomAnchorRect,
 ) -> Result<(), String> {
@@ -444,24 +444,24 @@ pub fn update_traffic_lights_anchor(
         return Err("invalid titlebar anchor geometry".to_string());
     }
 
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     window
         .with_webview(move |platform_webview| {
-            match unsafe {
+            let result = unsafe {
                 upsert_controller(
                     platform_webview.ns_window(),
                     platform_webview.inner(),
                 )
-            } {
-                Ok(controller) => {
-                    controller.anchor.set(Some(anchor));
-                    controller.schedule_reposition();
-                }
-                Err(error) => tracing::warn!(
-                    "Failed to update native traffic-light positioning: {error}"
-                ),
             }
+            .map(|controller| {
+                controller.anchor.set(Some(anchor));
+                controller.schedule_reposition();
+            });
+            let _ = result_tx.send(result);
         })
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+
+    result_rx.await.map_err(|error| error.to_string())?
 }
 
 #[cfg(test)]

--- a/apps/app/src/macos/traffic_lights.rs
+++ b/apps/app/src/macos/traffic_lights.rs
@@ -1,0 +1,508 @@
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    ptr::NonNull,
+    rc::Rc,
+};
+
+use block2::RcBlock;
+use objc2::{
+    MainThreadMarker,
+    rc::Retained,
+    runtime::{AnyObject, ProtocolObject},
+};
+use objc2_app_kit::{
+    NSButton, NSView, NSViewFrameDidChangeNotification, NSWindow,
+    NSWindowButton, NSWindowDidChangeBackingPropertiesNotification,
+    NSWindowDidChangeScreenNotification, NSWindowDidEndLiveResizeNotification,
+    NSWindowDidEnterFullScreenNotification,
+    NSWindowDidExitFullScreenNotification, NSWindowDidMoveNotification,
+    NSWindowDidResizeNotification, NSWindowDidUpdateNotification,
+    NSWindowWillCloseNotification,
+};
+use objc2_foundation::{
+    NSNotification, NSNotificationCenter, NSObjectProtocol, NSOperationQueue,
+    NSPoint, NSRect, NSRunLoop, NSSize,
+};
+use serde::Deserialize;
+use tauri::WebviewWindow;
+
+type ObserverToken = Retained<ProtocolObject<dyn NSObjectProtocol>>;
+
+thread_local! {
+    static CONTROLLERS: RefCell<HashMap<usize, Rc<TrafficLightController>>> =
+        RefCell::new(HashMap::new());
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DomAnchorRect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    viewport_width: f64,
+    viewport_height: f64,
+}
+
+impl DomAnchorRect {
+    fn is_valid(self) -> bool {
+        [
+            self.x,
+            self.y,
+            self.width,
+            self.height,
+            self.viewport_width,
+            self.viewport_height,
+        ]
+        .into_iter()
+        .all(f64::is_finite)
+            && self.width > 0.0
+            && self.height > 0.0
+            && self.viewport_width > 0.0
+            && self.viewport_height > 0.0
+    }
+}
+
+struct ObservedButton {
+    button: Retained<NSButton>,
+    previously_posted_frame_changes: bool,
+    token: ObserverToken,
+}
+
+struct ButtonSnapshot {
+    button: Retained<NSButton>,
+    superview: Retained<NSView>,
+    frame_in_window: NSRect,
+}
+
+struct TrafficLightController {
+    key: usize,
+    window: Retained<NSWindow>,
+    webview: RefCell<Retained<NSView>>,
+    anchor: Cell<Option<DomAnchorRect>>,
+    scheduled: Cell<bool>,
+    repositioning: Cell<bool>,
+    closed: Cell<bool>,
+    window_observers: RefCell<Vec<ObserverToken>>,
+    button_observers: RefCell<Vec<ObservedButton>>,
+}
+
+impl TrafficLightController {
+    fn new(
+        key: usize,
+        window: Retained<NSWindow>,
+        webview: Retained<NSView>,
+    ) -> Rc<Self> {
+        let controller = Rc::new(Self {
+            key,
+            window,
+            webview: RefCell::new(webview),
+            anchor: Cell::new(None),
+            scheduled: Cell::new(false),
+            repositioning: Cell::new(false),
+            closed: Cell::new(false),
+            window_observers: RefCell::new(Vec::new()),
+            button_observers: RefCell::new(Vec::new()),
+        });
+        controller.install_window_observers();
+        controller
+    }
+
+    fn install_window_observers(self: &Rc<Self>) {
+        let notification_names = unsafe {
+            [
+                NSWindowDidResizeNotification,
+                NSWindowDidEndLiveResizeNotification,
+                NSWindowDidMoveNotification,
+                NSWindowDidChangeScreenNotification,
+                NSWindowDidChangeBackingPropertiesNotification,
+                NSWindowDidEnterFullScreenNotification,
+                NSWindowDidExitFullScreenNotification,
+                NSWindowDidUpdateNotification,
+            ]
+        };
+        for name in notification_names {
+            let key = self.key;
+            let block =
+                RcBlock::new(move |_notification: NonNull<NSNotification>| {
+                    with_controller(
+                        key,
+                        TrafficLightController::schedule_reposition,
+                    );
+                });
+            let token = unsafe {
+                NSNotificationCenter::defaultCenter()
+                    .addObserverForName_object_queue_usingBlock(
+                        Some(name),
+                        Some(&self.window),
+                        Some(&NSOperationQueue::mainQueue()),
+                        &block,
+                    )
+            };
+            self.window_observers.borrow_mut().push(token);
+        }
+
+        let key = self.key;
+        let block =
+            RcBlock::new(move |_notification: NonNull<NSNotification>| {
+                CONTROLLERS.with(|controllers| {
+                    if let Some(controller) =
+                        controllers.borrow_mut().remove(&key)
+                    {
+                        controller.cleanup();
+                    }
+                });
+            });
+        let token = unsafe {
+            NSNotificationCenter::defaultCenter()
+                .addObserverForName_object_queue_usingBlock(
+                    Some(NSWindowWillCloseNotification),
+                    Some(&self.window),
+                    Some(&NSOperationQueue::mainQueue()),
+                    &block,
+                )
+        };
+        self.window_observers.borrow_mut().push(token);
+    }
+
+    fn schedule_reposition(self: &Rc<Self>) {
+        assert_main_thread();
+        if self.closed.get() || self.scheduled.replace(true) {
+            return;
+        }
+
+        let key = self.key;
+        let block = RcBlock::new(move || {
+            with_controller(key, |controller| {
+                controller.scheduled.set(false);
+                controller.reposition();
+            });
+        });
+        unsafe {
+            NSRunLoop::mainRunLoop().performBlock(&block);
+        }
+    }
+
+    fn reposition(self: &Rc<Self>) {
+        assert_main_thread();
+        let Some(anchor) = self.anchor.get() else {
+            return;
+        };
+        if self.closed.get() || self.repositioning.replace(true) {
+            return;
+        }
+
+        let Some(buttons) = self.current_buttons() else {
+            self.repositioning.set(false);
+            return;
+        };
+        self.refresh_button_observers(&buttons);
+
+        let webview = self.webview.borrow();
+        let anchor_in_webview =
+            dom_rect_in_view(anchor, webview.bounds(), webview.isFlipped());
+        let anchor_in_window =
+            webview.convertRect_toView(anchor_in_webview, None);
+        let group_min_x = buttons
+            .iter()
+            .map(|button| button.frame_in_window.origin.x)
+            .fold(f64::INFINITY, f64::min);
+        let group_min_y = buttons
+            .iter()
+            .map(|button| button.frame_in_window.origin.y)
+            .fold(f64::INFINITY, f64::min);
+        let group_max_x = buttons
+            .iter()
+            .map(|button| {
+                button.frame_in_window.origin.x
+                    + button.frame_in_window.size.width
+            })
+            .fold(f64::NEG_INFINITY, f64::max);
+        let group_max_y = buttons
+            .iter()
+            .map(|button| {
+                button.frame_in_window.origin.y
+                    + button.frame_in_window.size.height
+            })
+            .fold(f64::NEG_INFINITY, f64::max);
+        let group_frame = NSRect::new(
+            NSPoint::new(group_min_x, group_min_y),
+            NSSize::new(group_max_x - group_min_x, group_max_y - group_min_y),
+        );
+        let target_group_origin = NSPoint::new(
+            group_frame.origin.x,
+            anchor_in_window.origin.y
+                + (anchor_in_window.size.height - group_frame.size.height)
+                    / 2.0,
+        );
+        let translation = NSPoint::new(
+            target_group_origin.x - group_frame.origin.x,
+            target_group_origin.y - group_frame.origin.y,
+        );
+
+        if translation.x != 0.0 || translation.y != 0.0 {
+            for snapshot in buttons {
+                let mut target_in_window = snapshot.frame_in_window;
+                target_in_window.origin.x += translation.x;
+                target_in_window.origin.y += translation.y;
+                let target_in_superview = snapshot
+                    .superview
+                    .convertRect_fromView(target_in_window, None);
+                snapshot.button.setFrameOrigin(target_in_superview.origin);
+            }
+        }
+
+        self.repositioning.set(false);
+    }
+
+    fn current_buttons(&self) -> Option<Vec<ButtonSnapshot>> {
+        let buttons = [
+            self.window
+                .standardWindowButton(NSWindowButton::CloseButton)?,
+            self.window
+                .standardWindowButton(NSWindowButton::MiniaturizeButton)?,
+            self.window
+                .standardWindowButton(NSWindowButton::ZoomButton)?,
+        ];
+
+        buttons
+            .into_iter()
+            .map(|button| {
+                let superview = unsafe { button.superview() }?;
+                let frame_in_window =
+                    superview.convertRect_toView(button.frame(), None);
+                Some(ButtonSnapshot {
+                    button,
+                    superview,
+                    frame_in_window,
+                })
+            })
+            .collect()
+    }
+
+    fn refresh_button_observers(self: &Rc<Self>, buttons: &[ButtonSnapshot]) {
+        let current_ids: Vec<_> = buttons
+            .iter()
+            .map(|snapshot| Retained::as_ptr(&snapshot.button) as usize)
+            .collect();
+        let observed_ids: Vec<_> = self
+            .button_observers
+            .borrow()
+            .iter()
+            .map(|observed| Retained::as_ptr(&observed.button) as usize)
+            .collect();
+        if current_ids == observed_ids {
+            return;
+        }
+
+        self.remove_button_observers();
+        let center = NSNotificationCenter::defaultCenter();
+        let queue = NSOperationQueue::mainQueue();
+        let mut observers = self.button_observers.borrow_mut();
+        for snapshot in buttons {
+            let previously_posted_frame_changes =
+                snapshot.button.postsFrameChangedNotifications();
+            snapshot.button.setPostsFrameChangedNotifications(true);
+            let key = self.key;
+            let block =
+                RcBlock::new(move |_notification: NonNull<NSNotification>| {
+                    with_controller(key, |controller| {
+                        if !controller.repositioning.get() {
+                            controller.schedule_reposition();
+                        }
+                    });
+                });
+            let token = unsafe {
+                center.addObserverForName_object_queue_usingBlock(
+                    Some(NSViewFrameDidChangeNotification),
+                    Some(&snapshot.button),
+                    Some(&queue),
+                    &block,
+                )
+            };
+            observers.push(ObservedButton {
+                button: snapshot.button.clone(),
+                previously_posted_frame_changes,
+                token,
+            });
+        }
+    }
+
+    fn remove_button_observers(&self) {
+        let center = NSNotificationCenter::defaultCenter();
+        for observed in self.button_observers.borrow_mut().drain(..) {
+            let token: &AnyObject =
+                AsRef::<AnyObject>::as_ref(&*observed.token);
+            unsafe {
+                center.removeObserver(token);
+            }
+            observed.button.setPostsFrameChangedNotifications(
+                observed.previously_posted_frame_changes,
+            );
+        }
+    }
+
+    fn cleanup(&self) {
+        assert_main_thread();
+        if self.closed.replace(true) {
+            return;
+        }
+        self.remove_button_observers();
+        let center = NSNotificationCenter::defaultCenter();
+        for token in self.window_observers.borrow_mut().drain(..) {
+            let token: &AnyObject = AsRef::<AnyObject>::as_ref(&*token);
+            unsafe {
+                center.removeObserver(token);
+            }
+        }
+    }
+}
+
+fn with_controller(
+    key: usize,
+    callback: impl FnOnce(&Rc<TrafficLightController>),
+) {
+    CONTROLLERS.with(|controllers| {
+        if let Some(controller) = controllers.borrow().get(&key) {
+            callback(controller);
+        }
+    });
+}
+
+fn dom_rect_in_view(
+    anchor: DomAnchorRect,
+    bounds: NSRect,
+    flipped: bool,
+) -> NSRect {
+    let scale_x = bounds.size.width / anchor.viewport_width;
+    let scale_y = bounds.size.height / anchor.viewport_height;
+    let origin_x = bounds.origin.x + anchor.x * scale_x;
+    let origin_y = if flipped {
+        bounds.origin.y + anchor.y * scale_y
+    } else {
+        bounds.origin.y + bounds.size.height
+            - (anchor.y + anchor.height) * scale_y
+    };
+    NSRect::new(
+        NSPoint::new(origin_x, origin_y),
+        NSSize::new(anchor.width * scale_x, anchor.height * scale_y),
+    )
+}
+
+fn assert_main_thread() {
+    assert!(
+        MainThreadMarker::new().is_some(),
+        "traffic-light AppKit access must run on the main thread"
+    );
+}
+
+unsafe fn upsert_controller(
+    window_ptr: *mut std::ffi::c_void,
+    webview_ptr: *mut std::ffi::c_void,
+) -> Result<Rc<TrafficLightController>, String> {
+    assert_main_thread();
+    let key = window_ptr as usize;
+    let window = unsafe { Retained::retain(window_ptr.cast::<NSWindow>()) }
+        .ok_or_else(|| "NSWindow was released".to_string())?;
+    let webview = unsafe { Retained::retain(webview_ptr.cast::<NSView>()) }
+        .ok_or_else(|| "WKWebView was released".to_string())?;
+
+    Ok(CONTROLLERS.with(|controllers| {
+        let mut controllers = controllers.borrow_mut();
+        if let Some(controller) = controllers.get(&key) {
+            controller.webview.replace(webview);
+            return controller.clone();
+        }
+        let controller = TrafficLightController::new(key, window, webview);
+        controllers.insert(key, controller.clone());
+        controller
+    }))
+}
+
+pub fn install(window: &WebviewWindow) -> tauri::Result<()> {
+    window.with_webview(|platform_webview| {
+        if let Err(error) = unsafe {
+            upsert_controller(
+                platform_webview.ns_window(),
+                platform_webview.inner(),
+            )
+        } {
+            tracing::warn!(
+                "Failed to install native traffic-light positioning: {error}"
+            );
+        }
+    })
+}
+
+#[tauri::command]
+pub fn update_traffic_lights_anchor(
+    window: WebviewWindow,
+    anchor: DomAnchorRect,
+) -> Result<(), String> {
+    if !anchor.is_valid() {
+        return Err("invalid titlebar anchor geometry".to_string());
+    }
+
+    window
+        .with_webview(move |platform_webview| {
+            match unsafe {
+                upsert_controller(
+                    platform_webview.ns_window(),
+                    platform_webview.inner(),
+                )
+            } {
+                Ok(controller) => {
+                    controller.anchor.set(Some(anchor));
+                    controller.schedule_reposition();
+                }
+                Err(error) => tracing::warn!(
+                    "Failed to update native traffic-light positioning: {error}"
+                ),
+            }
+        })
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_dom_rect_for_unflipped_appkit_view() {
+        let rect = dom_rect_in_view(
+            DomAnchorRect {
+                x: 20.0,
+                y: 10.0,
+                width: 100.0,
+                height: 40.0,
+                viewport_width: 400.0,
+                viewport_height: 300.0,
+            },
+            NSRect::new(NSPoint::new(5.0, 7.0), NSSize::new(800.0, 600.0)),
+            false,
+        );
+
+        assert_eq!(rect.origin, NSPoint::new(45.0, 507.0));
+        assert_eq!(rect.size, NSSize::new(200.0, 80.0));
+    }
+
+    #[test]
+    fn converts_dom_rect_for_flipped_appkit_view() {
+        let rect = dom_rect_in_view(
+            DomAnchorRect {
+                x: 20.0,
+                y: 10.0,
+                width: 100.0,
+                height: 40.0,
+                viewport_width: 400.0,
+                viewport_height: 300.0,
+            },
+            NSRect::new(NSPoint::new(5.0, 7.0), NSSize::new(800.0, 600.0)),
+            true,
+        );
+
+        assert_eq!(rect.origin, NSPoint::new(45.0, 27.0));
+        assert_eq!(rect.size, NSSize::new(200.0, 80.0));
+    }
+}

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -751,6 +751,11 @@ fn main() {
         })
         .setup(|app| {
             lightweight_mode::init(&app.handle());
+            #[cfg(target_os = "macos")]
+            if let Some(window) = app.get_webview_window("main") {
+                macos::traffic_lights::install(&window)?;
+            }
+
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(4)).await;
@@ -880,6 +885,8 @@ fn main() {
             lightweight_mode::lightweight_mode_frontend_ready,
             lightweight_mode::lightweight_mode_set_route,
             lightweight_mode::lightweight_mode_enter,
+            #[cfg(target_os = "macos")]
+            macos::traffic_lights::update_traffic_lights_anchor,
         ]);
 
     tracing::info!("Initializing app...");

--- a/apps/app/tauri.macos.conf.json
+++ b/apps/app/tauri.macos.conf.json
@@ -14,11 +14,7 @@
 				"visible": false,
 				"zoomHotkeysEnabled": false,
 				"decorations": true,
-				"transparent": true,
-				"trafficLightPosition": {
-					"x": 15.0,
-					"y": 22.0
-				}
+				"transparent": true
 			}
 		]
 	}


### PR DESCRIPTION
如图
当前样式：
<img width="239" height="103" alt="image" src="https://github.com/user-attachments/assets/f27f7eeb-f846-4c79-a275-36af544153f6" />
修改后样式
<img width="243" height="108" alt="image" src="https://github.com/user-attachments/assets/c1035c83-e894-4cb0-9ce3-268258e25103" />
PS：傻鸟Apple在新版SDK删了固定xy尺寸，现在必须手动根据边距自己计算实时显示尺寸

## Sourcery 摘要

通过将 macOS 交通灯控件的原生位置与渲染后的标题栏同步，使其适配新的 SDK 布局。

新功能：
- 使 macOS 窗口交通灯控件适配更新后的 SDK 样式，并动态将其与应用程序标题栏对齐。

增强功能：
- 跟踪标题栏几何信息和原生窗口变化，以便在调整大小、移动、缩放和全屏切换期间保持交通灯控件位置同步。
- 为原生交通灯控件位置观察器添加生命周期管理和验证。

构建：
- 更新 macOS 发布工作流运行器和 macOS 原生依赖项，以支持新实现。

测试：
- 添加将浏览器标题栏坐标转换为翻转和未翻转 AppKit 视图坐标的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过将原生位置与渲染后的标题栏同步，使 macOS 红绿灯控件适配更新后的 SDK 布局。

新功能：
- 在更新后的 SDK 布局下，使原生 macOS 红绿灯控件与应用程序标题栏对齐。

增强功能：
- 在标题栏几何结构变化、窗口移动、调整大小、缩放、屏幕变更和全屏切换期间，保持红绿灯位置同步，并管理观察者的生命周期。

构建：
- 更新 macOS 发布工具和原生依赖，以支持新的红绿灯定位实现。

测试：
- 添加将浏览器标题栏坐标转换为翻转和未翻转 AppKit 视图坐标的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the macOS traffic-light controls to the updated SDK layout by synchronizing their native position with the rendered title bar.

New Features:
- Align the native macOS traffic-light controls with the application title bar under the updated SDK layout.

Enhancements:
- Keep traffic-light positioning synchronized during title-bar geometry changes, window movement, resizing, scaling, screen changes, and full-screen transitions with managed observer lifecycles.

Build:
- Update macOS release tooling and native dependencies to support the new traffic-light positioning implementation.

Tests:
- Add coverage for converting browser title-bar coordinates into flipped and unflipped AppKit view coordinates.

</details>

</details>